### PR TITLE
update the TrackingDetail class to make the 'tracking_location' prope…

### DIFF
--- a/EasyPost/TrackingDetail.cs
+++ b/EasyPost/TrackingDetail.cs
@@ -9,6 +9,6 @@ namespace EasyPost {
         public DateTime datetime { get; set; }
         public string message { get; set; }
         public string status { get; set; }
-        public List<TrackingLocation> tracking_location { get; set; }
+        public TrackingLocation tracking_location { get; set; }
     }
 }


### PR DESCRIPTION
Guys, I noticed in the C# library, the TrackingDetail class defines the "tracking_location" property as a List<TrackingLocation>.  According to your API documentation and sample json [here](https://www.easypost.com/docs/api#tracking), this property should actually just be a single instance of TrackingLocation.  I tried to deserialize your sample tracker event json while testing my webhook implementation, and it failed with your existing class structure.  If I made the change included in this pull request, I was able to successfully deserialize that json into the data structure.  Thanks!