### PR TITLE
Refactor client connection instantiation to support multiple API keys

### DIFF
--- a/EasyPost.Net40/EasyPost.Net40.csproj
+++ b/EasyPost.Net40/EasyPost.Net40.csproj
@@ -69,6 +69,9 @@
     <Compile Include="..\EasyPost\ClientConfiguration.cs">
       <Link>ClientConfiguration.cs</Link>
     </Compile>
+    <Compile Include="..\EasyPost\ClientFactory.cs">
+      <Link>ClientFactory.cs</Link>
+    </Compile>
     <Compile Include="..\EasyPost\Container.cs">
       <Link>Container.cs</Link>
     </Compile>

--- a/EasyPost.Net40/EasyPost.Net40.csproj
+++ b/EasyPost.Net40/EasyPost.Net40.csproj
@@ -66,6 +66,9 @@
     <Compile Include="..\EasyPost\Client.cs">
       <Link>Client.cs</Link>
     </Compile>
+    <Compile Include="..\EasyPost\ClientConfiguration.cs">
+      <Link>ClientConfiguration.cs</Link>
+    </Compile>
     <Compile Include="..\EasyPost\Container.cs">
       <Link>Container.cs</Link>
     </Compile>

--- a/EasyPost/Client.cs
+++ b/EasyPost/Client.cs
@@ -29,7 +29,7 @@ namespace EasyPost {
         public Client(ClientConfiguration clientConfiguration) {
             System.Net.ServicePointManager.SecurityProtocol = Security.GetProtocol();
 
-            if (clientConfiguration == null) throw new ArgumentNullException(nameof(clientConfiguration));
+            if (clientConfiguration == null) throw new ArgumentNullException("clientConfiguration");
             configuration = clientConfiguration;
 
             client = new RestClient(clientConfiguration.ApiBase);

--- a/EasyPost/Client.cs
+++ b/EasyPost/Client.cs
@@ -12,18 +12,27 @@ using System.Reflection;
 
 namespace EasyPost {
     public class Client {
+
+        internal const string ApiBaseUrl = "https://api.easypost.com/v2";
+
         public static string apiKey { get; set; }
         public static string apiBase { get; set; }
 
         public string version;
 
         internal RestClient client;
+        internal ClientConfiguration configuration;
 
-        public Client(string apiBaseUrl = "https://api.easypost.com/v2") {
+        public Client(string apiBaseUrl = ApiBaseUrl)
+            : this(new ClientConfiguration(apiKey, apiBase ?? apiBaseUrl)) { }
+
+        public Client(ClientConfiguration clientConfiguration) {
             System.Net.ServicePointManager.SecurityProtocol = Security.GetProtocol();
 
-            apiBaseUrl = apiBase ?? apiBaseUrl;
-            client = new RestClient(apiBaseUrl);
+            if (clientConfiguration == null) throw new ArgumentNullException(nameof(clientConfiguration));
+            configuration = clientConfiguration;
+
+            client = new RestClient(clientConfiguration.ApiBase);
 
             Assembly assembly = Assembly.GetExecutingAssembly();
             FileVersionInfo info = FileVersionInfo.GetVersionInfo(assembly.Location);
@@ -54,7 +63,7 @@ namespace EasyPost {
             RestRequest restRequest = (RestRequest)request;
 
             restRequest.AddHeader("user_agent", string.Concat("EasyPost/v2 CSharp/", version));
-            restRequest.AddHeader("authorization", "Bearer " + apiKey);
+            restRequest.AddHeader("authorization", "Bearer " + this.configuration.ApiKey);
             restRequest.AddHeader("content_type", "application/x-www-form-urlencoded");
 
             return restRequest;

--- a/EasyPost/ClientConfiguration.cs
+++ b/EasyPost/ClientConfiguration.cs
@@ -1,0 +1,34 @@
+namespace EasyPost
+{
+    /// <summary>
+    /// Provides configuration options for the REST client
+    /// </summary>
+    public class ClientConfiguration {
+
+        /// <summary>
+        /// Create a ClientConfiguration instance
+        /// </summary>
+        /// <param name="apiKey">The API key to use for the client connection</param>
+        public ClientConfiguration(string apiKey) : this(apiKey, Client.ApiBaseUrl) { }
+
+        /// <summary>
+        /// Create an ClientConfiguration instance
+        /// </summary>
+        /// <param name="apiKey">The API key to use for the client connection</param>
+        /// <param name="apiBase">The base API url to use for the client connection</param>
+        public ClientConfiguration(string apiKey, string apiBase) {
+            ApiKey = apiKey;
+            ApiBase = apiBase;
+        }
+
+        /// <summary>
+        /// The API key to use on per-request basis
+        /// </summary>
+        public string ApiKey { get; set; }
+
+        /// <summary>
+        /// The API base URI to use on a per-request basis
+        /// </summary>
+        public string ApiBase { get; set; }
+    }
+}

--- a/EasyPost/ClientFactory.cs
+++ b/EasyPost/ClientFactory.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace EasyPost
+{
+    /// <summary>
+    /// Provides construction of REST client objects
+    /// </summary>
+    public interface IClientFactory {
+        Client Build();
+    }
+
+    /// <summary>
+    /// Provides well-known factory location to support loose management of dependencies as relates to the instantiation of REST clients
+    /// </summary>
+    public static class ClientFactory {
+        private static Func<IClientFactory> current;
+        
+        static ClientFactory() {
+            current = () => new DefaultClientFactory();
+        }
+
+        public static IClientFactory Current {
+            get { return current(); } 
+        }
+
+        public static void SetCurrent(IClientFactory factory) {
+            if (factory == null) throw new ArgumentNullException("factory");
+            SetCurrent(() => factory);
+        }
+
+        public static void SetCurrent(Func<IClientFactory> getCurrentFactory) {
+            if (getCurrentFactory == null) throw new ArgumentNullException("getCurrentFactory");
+            current = getCurrentFactory;
+        }
+    }
+
+    /// <summary>
+    /// Default implementation of a REST client factory using the empty/default constructor
+    /// </summary>
+    public class DefaultClientFactory : IClientFactory {
+        public Client Build() {
+            return new Client();
+        }
+    }
+}

--- a/EasyPost/EasyPost.csproj
+++ b/EasyPost/EasyPost.csproj
@@ -56,6 +56,7 @@
     <Compile Include="CarrierAccount.cs" />
     <Compile Include="CarrierType.cs" />
     <Compile Include="ClientConfiguration.cs" />
+    <Compile Include="ClientFactory.cs" />
     <Compile Include="TrackerList.cs" />
     <Compile Include="ScanFormList.cs" />
     <Compile Include="Exception.cs" />

--- a/EasyPost/EasyPost.csproj
+++ b/EasyPost/EasyPost.csproj
@@ -55,6 +55,7 @@
     <Compile Include="BatchShipment.cs" />
     <Compile Include="CarrierAccount.cs" />
     <Compile Include="CarrierType.cs" />
+    <Compile Include="ClientConfiguration.cs" />
     <Compile Include="TrackerList.cs" />
     <Compile Include="ScanFormList.cs" />
     <Compile Include="Exception.cs" />

--- a/EasyPost/Request.cs
+++ b/EasyPost/Request.cs
@@ -26,12 +26,12 @@ namespace EasyPost {
         }
 
         public T Execute<T>() where T : new() {
-            Client client = new Client();
+            Client client = ClientFactory.Current.Build();
             return client.Execute<T>(this);
         }
 
         public IRestResponse Execute() {
-            Client client = new Client();
+            Client client = ClientFactory.Current.Build();
             return client.Execute(this);
         }
 

--- a/EasyPostTest/ClientConfigurationTest.cs
+++ b/EasyPostTest/ClientConfigurationTest.cs
@@ -1,0 +1,25 @@
+﻿using EasyPost;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EasyPostTest
+{
+    [TestClass]
+    public class ClientConfigurationTest {
+
+        [TestMethod]
+        public void TestApiKeyConstructor() {
+            ClientConfiguration config = new ClientConfiguration("someApiKey");
+
+            Assert.AreEqual("someApiKey",config.ApiKey);
+            Assert.AreEqual(Client.ApiBaseUrl, config.ApiBase);
+        }
+
+        [TestMethod]
+        public void TestApiKeyPlusBaseUrlConstructor() {
+            ClientConfiguration config = new ClientConfiguration("someApiKey", "http://foobar.com");
+
+            Assert.AreEqual("someApiKey", config.ApiKey);
+            Assert.AreEqual("http://foobar.com", config.ApiBase);
+        }
+    }
+}

--- a/EasyPostTest/ClientFactoryTest.cs
+++ b/EasyPostTest/ClientFactoryTest.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using EasyPost;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EasyPostTest
+{
+    [TestClass]
+    public class ClientFactoryTest {
+
+        private class FakeClientFactoryForKeyPlusUrl : IClientFactory {
+            public Client Build(){
+                return new Client(new ClientConfiguration("someapikey","http://foobar.com"));
+            }
+        }
+
+        private class FakeClientFactoryForKey : IClientFactory {
+            public Client Build() {
+                return new Client(new ClientConfiguration("someapikey"));
+            }
+        }
+
+        [TestMethod]
+        public void TestDefaultFactoryClientConstruction() {
+            ClientFactory.SetCurrent(new DefaultClientFactory());
+
+            Client.apiKey = "asdf";
+            Client client = ClientFactory.Current.Build();
+
+            Assert.AreEqual(new Uri("https://api.easypost.com/v2"), client.client.BaseUrl);
+        }
+
+        [TestMethod]
+        public void TestClientFactoryInstanceConstructionWithKeyAndUrl() {
+            ClientFactory.SetCurrent(new FakeClientFactoryForKeyPlusUrl());
+
+            Client client = ClientFactory.Current.Build();
+            Assert.AreEqual(new Uri("http://foobar.com"), client.client.BaseUrl);
+        }
+
+        [TestMethod]
+        public void TestClientFactoryInstanceConstructionWithKey() {
+            ClientFactory.SetCurrent(new FakeClientFactoryForKey());
+
+            Client client = ClientFactory.Current.Build();
+            Assert.AreEqual(new Uri("https://api.easypost.com/v2"), client.client.BaseUrl);
+        }
+
+        [TestMethod]
+        public void TestClientFactoryInstanceDelegatedConstruction() {
+            ClientFactory.SetCurrent(() => null);
+            Assert.AreEqual(null, ClientFactory.Current);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof (ArgumentNullException))]
+        public void TestClientFactorySetCurrentInstanceFailWithNullReferenceException() {
+            ClientFactory.SetCurrent((IClientFactory)null);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void TestClientFactorySetCurrentDelegateFailWithNullReferenceException() {
+            ClientFactory.SetCurrent((Func<IClientFactory>)null);
+        }
+
+    }
+}

--- a/EasyPostTest/ClientTest.cs
+++ b/EasyPostTest/ClientTest.cs
@@ -14,6 +14,14 @@ public class JsonTest {
 namespace EasyPostTest {
     [TestClass]
     public class ClientTest {
+
+        [TestInitialize]
+        public void BeforeEachTest() {
+            // clean out the API key + base before each test; let the constructor defaults do their thing
+            Client.apiKey = null;
+            Client.apiBase = null;
+        }
+
         [TestMethod]
         public void TestApiKey() {
             Client.apiKey = "apiKey";

--- a/EasyPostTest/ClientTest.cs
+++ b/EasyPostTest/ClientTest.cs
@@ -48,6 +48,12 @@ namespace EasyPostTest {
         }
 
         [TestMethod]
+        public void TestRestClientWithOptions() {
+            Client client = new Client(new ClientConfiguration("someapikey", "http://apiBase.com"));
+            Assert.AreEqual(new Uri("http://apiBase.com"), client.client.BaseUrl);
+        }
+
+        [TestMethod]
         public void TestExecute() {
             Client client = new Client("http://echo.jsontest.com");
             Request request = new Request("key/value", Method.GET);
@@ -72,6 +78,17 @@ namespace EasyPostTest {
             List<String> parameters = client.PrepareRequest(request).Parameters.Select(parameter => parameter.ToString()).ToList();
             CollectionAssert.Contains(parameters, "user_agent=EasyPost/v2 CSharp/" + client.version);
             CollectionAssert.Contains(parameters, "authorization=Bearer " + Client.apiKey);
+            CollectionAssert.Contains(parameters, "content_type=application/x-www-form-urlencoded");
+        }
+
+        [TestMethod]
+        public void TestPrepareRequestWithOptions() {
+            Client client = new Client(new ClientConfiguration("someapikey", "http://foobar.com"));
+            Request request = new Request("resource");
+
+            List<String> parameters = client.PrepareRequest(request).Parameters.Select(parameter => parameter.ToString()).ToList();
+            CollectionAssert.Contains(parameters, "user_agent=EasyPost/v2 CSharp/" + client.version);
+            CollectionAssert.Contains(parameters, "authorization=Bearer someapikey");
             CollectionAssert.Contains(parameters, "content_type=application/x-www-form-urlencoded");
         }
     }

--- a/EasyPostTest/EasyPostTest.csproj
+++ b/EasyPostTest/EasyPostTest.csproj
@@ -66,6 +66,7 @@
   <ItemGroup>
     <Compile Include="AddressTest.cs" />
     <Compile Include="BatchTest.cs" />
+    <Compile Include="ClientFactoryTest.cs" />
     <Compile Include="ScanFormTest.cs" />
     <Compile Include="ClientTest.cs" />
     <Compile Include="PickupTest.cs" />

--- a/EasyPostTest/EasyPostTest.csproj
+++ b/EasyPostTest/EasyPostTest.csproj
@@ -81,6 +81,7 @@
     <Compile Include="TrackerTest.cs" />
     <Compile Include="CarrierAccountTest.cs" />
     <Compile Include="CarrierTypeTest.cs" />
+    <Compile Include="ClientConfigurationTest.cs" />
     <Compile Include="UserTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -14,10 +14,29 @@ See NuGet docs for instructions on installing via the [dialog](http://docs.nuget
 
 See the [docs](https://www.easypost.com/docs/api#addresses) for more information.
 
-During the initialization of your application add the following to configure EasyPost.
+If you are operating with a single EasyPost API key, during the initialization of your application add the following to configure EasyPost.
 
 ```cs
 EasyPost.Client.apiKey = "apiKey";
+```
+
+If you have multiple API keys, to control the API key on a per-connection basis, create a new class implementing ```EasyPost.IClientFactory```  and configure the ClientFactory during application initialization.
+
+```cs
+using EasyPost;
+public class MyClientFactory : IClientFactory {
+  // a set of API keys could be enumerated here, either by account, department, or by application tenant  
+  public Client Build() {
+    return new Client(new ClientConfiguration("someApiKey"));
+  }
+}
+
+// initialize the factory with your instance
+EasyPost.ClientFactory.SetCurrent(new MyClientFactory());
+
+// alternatively, initialize the factory with a delegate to obtain an instance.  
+// This is useful for IoC/DI implementations in a concurrent environment.
+EasyPost.ClientFactory.SetCurrent(() => new MyClientFactory());
 ```
 
 ### Address Verification


### PR DESCRIPTION
Here is the complete set of changes to help the EasyPost lib support multiple API keys per application.

As discussed, the current limitation of the static fields ```EasyPost.Client.apiKey``` creates contention across multiple calls to ```EasyPost.Client``` (as in web requests/threads/series of method calls), which can be seen by running the ClientTest fixture in its entirety prior to commit 5198aef8be53bd102b7e5093d571fe7acb4eea60

By refactoring the ApiKey + ApiBaseUrl to a separate ```ClientConfiguration``` class and by providing the appropriate constructor overloads we can create separation; further, adding a well-known location for the ```EasyPost.Request``` class to delegate the construction of the ```EasyPost.Client``` class, it opens up paths for managing multiple API Keys for cases where the operating environment may be multi-tenanted.