### PR TITLE
adds async/await support

### DIFF
--- a/EasyPost/Batch.cs
+++ b/EasyPost/Batch.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace EasyPost {
     public class Batch : IResource {
@@ -32,6 +33,13 @@ namespace EasyPost {
             return request.Execute<Batch>();
         }
 
+        public static async Task<Batch> RetrieveTaskAsync(string id) {
+            Request request = new Request("batches/{id}");
+            request.AddUrlSegment("id", id);
+
+            return await request.ExecuteTaskAsync<Batch>();
+        }
+
         /// <summary>
         /// Create a Batch.
         /// </summary>
@@ -51,6 +59,15 @@ namespace EasyPost {
             return request.Execute<Batch>();
         }
 
+        public static async Task<Batch> CreateTaskAsync(Dictionary<string, object> parameters = null) {
+            parameters = parameters ?? new Dictionary<string, object>();
+
+            Request request = new Request("batches", Method.POST);
+            request.AddBody(parameters, "batch");
+
+            return await request.ExecuteTaskAsync<Batch>();
+        }
+
         /// <summary>
         /// Add shipments to the batch.
         /// </summary>
@@ -65,12 +82,26 @@ namespace EasyPost {
             this.Merge(request.Execute<Batch>());
         }
 
+        public async Task AddShipmentsTaskAsync(IEnumerable<string> shipmentIds) {
+            Request request = new Request("batches/{id}/add_shipments", Method.POST);
+            request.AddUrlSegment("id", id);
+
+            List<Dictionary<string, object>> body = shipmentIds.Select(shipmentId => new Dictionary<string, object>() { { "id", shipmentId } }).ToList();
+            request.AddBody(body, "shipments");
+
+            this.Merge(await request.ExecuteTaskAsync<Batch>());
+        }
+
         /// <summary>
         /// Add shipments to the batch.
         /// </summary>
         /// <param name="shipments">List of Shipment objects to be added.</param>
         public void AddShipments(IEnumerable<Shipment> shipments) {
             AddShipments(shipments.Select(shipment => shipment.id).ToList());
+        }
+
+        public async Task AddShipmentsTaskAsync(IEnumerable<Shipment> shipments) {
+            await AddShipmentsTaskAsync(shipments.Select(shipment => shipment.id).ToList());
         }
 
         /// <summary>
@@ -87,12 +118,26 @@ namespace EasyPost {
             this.Merge(request.Execute<Batch>());
         }
 
+        public async Task RemoveShipmentsTaskAsync(IEnumerable<string> shipmentIds) {
+            Request request = new Request("batches/{id}/remove_shipments", Method.POST);
+            request.AddUrlSegment("id", id);
+
+            List<Dictionary<string, object>> body = shipmentIds.Select(shipmentId => new Dictionary<string, object>() { { "id", shipmentId } }).ToList();
+            request.AddBody(body, "shipments");
+
+            this.Merge(await request.ExecuteTaskAsync<Batch>());
+        }
+
         /// <summary>
         /// Remove shipments from the batch.
         /// </summary>
         /// <param name="shipments">List of Shipment objects to be removed.</param>
         public void RemoveShipments(IEnumerable<Shipment> shipments) {
             RemoveShipments(shipments.Select(shipment => shipment.id).ToList());
+        }
+
+        public async Task RemoveShipmentsTaskAsync(IEnumerable<Shipment> shipments) {
+            await RemoveShipmentsTaskAsync(shipments.Select(shipment => shipment.id).ToList());
         }
 
         /// <summary>
@@ -103,6 +148,13 @@ namespace EasyPost {
             request.AddUrlSegment("id", id);
 
             this.Merge(request.Execute<Batch>());
+        }
+
+        public async Task BuyTaskAsync() {
+            Request request = new Request("batches/{id}/buy", Method.POST);
+            request.AddUrlSegment("id", id);
+
+            this.Merge(await request.ExecuteTaskAsync<Batch>());
         }
 
         /// <summary>
@@ -125,6 +177,21 @@ namespace EasyPost {
             this.Merge(request.Execute<Batch>());
         }
 
+        public async Task GenerateLabelTaskAsync(string fileFormat, string orderBy = null) {
+            Request request = new Request("batches/{id}/label", Method.POST);
+            request.AddUrlSegment("id", id);
+
+            List<Tuple<string, string>> body = new List<Tuple<string, string>>() {
+                new Tuple<string, string>("file_format", fileFormat)
+            };
+
+            if (orderBy != null)
+                body.Add(new Tuple<string, string>("order_by", orderBy));
+
+            request.AddBody(body);
+            this.Merge(await request.ExecuteTaskAsync<Batch>());
+        }
+
         /// <summary>
         /// Asychronously generate a scan from for the batch.
         /// </summary>
@@ -133,6 +200,13 @@ namespace EasyPost {
             request.AddUrlSegment("id", id);
 
             this.Merge(request.Execute<Batch>());
+        }
+
+        public async Task GenerateScanFormTaskAsync() {
+            Request request = new Request("batches/{id}/scan_form", Method.POST);
+            request.AddUrlSegment("id", id);
+
+            this.Merge(await request.ExecuteTaskAsync<Batch>());
         }
     }
 }

--- a/EasyPost/CarrierAccount.cs
+++ b/EasyPost/CarrierAccount.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace EasyPost {
     public class CarrierAccount : IResource {
@@ -19,6 +20,11 @@ namespace EasyPost {
             return request.Execute<List<CarrierAccount>>();
         }
 
+        public static async Task<List<CarrierAccount>> ListTaskAsync() {
+            Request request = new Request("carrier_accounts");
+            return await request.ExecuteTaskAsync<List<CarrierAccount>>();
+        }
+
         /// <summary>
         /// Retrieve a CarrierAccount from its id.
         /// </summary>
@@ -29,6 +35,13 @@ namespace EasyPost {
             request.AddUrlSegment("id", id);
 
             return request.Execute<CarrierAccount>();
+        }
+
+        public static async Task<CarrierAccount> RetrieveTaskAsync(string id) {
+            Request request = new Request("carrier_accounts/{id}");
+            request.AddUrlSegment("id", id);
+
+            return await request.ExecuteTaskAsync<CarrierAccount>();
         }
 
         /// <summary>
@@ -51,6 +64,13 @@ namespace EasyPost {
             return request.Execute<CarrierAccount>();
         }
 
+        public static async Task<CarrierAccount> CreateTaskAsync(Dictionary<string, object> parameters) {
+            Request request = new Request("carrier_accounts", Method.POST);
+            request.AddBody(parameters, "carrier_account");
+
+            return await request.ExecuteTaskAsync<CarrierAccount>();
+        }
+
         /// <summary>
         /// Remove this CarrierAccount from your account.
         /// </summary>
@@ -59,6 +79,13 @@ namespace EasyPost {
             request.AddUrlSegment("id", id);
 
             request.Execute();
+        }
+
+        public async Task DestroyTaskAsync() {
+            Request request = new Request("carrier_accounts/{id}", Method.DELETE);
+            request.AddUrlSegment("id", id);
+
+            await request.ExecuteTaskAsync();
         }
 
         /// <summary>
@@ -71,6 +98,14 @@ namespace EasyPost {
             request.AddBody(parameters, "carrier_account");
 
             this.Merge(request.Execute<CarrierAccount>());
+        }
+
+        public async Task UpdateTaskAsync(Dictionary<string, object> parameters) {
+            Request request = new Request("carrier_accounts/{id}", Method.PUT);
+            request.AddUrlSegment("id", id);
+            request.AddBody(parameters, "carrier_account");
+
+            this.Merge(await request.ExecuteTaskAsync<CarrierAccount>());
         }
     }
 }

--- a/EasyPost/CarrierType.cs
+++ b/EasyPost/CarrierType.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace EasyPost {
     public class CarrierType : IResource {
@@ -10,6 +11,11 @@ namespace EasyPost {
         public static List<CarrierType> All() {
             Request request = new Request("carrier_types");
             return request.Execute<List<CarrierType>>();
+        }
+
+        public static async Task<List<CarrierType>> AllTaskAsync() {
+            Request request = new Request("carrier_types");
+            return await request.ExecuteTaskAsync<List<CarrierType>>();
         }
     }
 }

--- a/EasyPost/Container.cs
+++ b/EasyPost/Container.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace EasyPost {
     public class Container : IResource {
@@ -28,6 +29,13 @@ namespace EasyPost {
             return request.Execute<Container>();
         }
 
+        public static async Task<Container> RetrieveTaskAsync(string id) {
+            Request request = new Request("containers/{id}");
+            request.AddUrlSegment("id", id);
+
+            return await request.ExecuteTaskAsync<Container>();
+        }
+
         /// <summary>
         /// Create a Container.
         /// </summary>
@@ -48,6 +56,13 @@ namespace EasyPost {
             request.AddBody(parameters, "container");
 
             return request.Execute<Container>();
+        }
+
+        public static async Task<Container> CreateTaskAsync(Dictionary<string, object> parameters) {
+            Request request = new Request("containers", Method.POST);
+            request.AddBody(parameters, "container");
+
+            return await request.ExecuteTaskAsync<Container>();
         }
     }
 }

--- a/EasyPost/CustomsInfo.cs
+++ b/EasyPost/CustomsInfo.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace EasyPost {
     public class CustomsInfo : IResource {
@@ -31,6 +32,13 @@ namespace EasyPost {
             return request.Execute<CustomsInfo>();
         }
 
+        public static async Task<CustomsInfo> RetrieveTaskAsync(string id) {
+            Request request = new Request("customs_infos/{id}");
+            request.AddUrlSegment("id", id);
+
+            return await request.ExecuteTaskAsync<CustomsInfo>();
+        }
+
         /// <summary>
         /// Create a CustomsInfo.
         /// </summary>
@@ -51,6 +59,13 @@ namespace EasyPost {
             request.AddBody(parameters, "customs_info");
 
             return request.Execute<CustomsInfo>();
+        }
+
+        public static async Task<CustomsInfo> CreateTaskAsync(Dictionary<string, object> parameters) {
+            Request request = new Request("customs_infos", Method.POST);
+            request.AddBody(parameters, "customs_info");
+
+            return await request.ExecuteTaskAsync<CustomsInfo>();
         }
     }
 }

--- a/EasyPost/CustomsItem.cs
+++ b/EasyPost/CustomsItem.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace EasyPost {
     public class CustomsItem : IResource {
@@ -29,6 +30,13 @@ namespace EasyPost {
             return request.Execute<CustomsItem>();
         }
 
+        public static async Task<CustomsItem> RetrieveTaskAsync(string id) {
+            Request request = new Request("customs_items/{id}");
+            request.AddUrlSegment("id", id);
+
+            return await request.ExecuteTaskAsync<CustomsItem>();
+        }
+
         /// <summary>
         /// Create a CustomsItem.
         /// </summary>
@@ -48,6 +56,13 @@ namespace EasyPost {
             request.AddBody(parameters, "customs_item");
 
             return request.Execute<CustomsItem>();
+        }
+
+        public static async Task<CustomsItem> CreateTaskAsync(Dictionary<string, object> parameters) {
+            Request request = new Request("customs_items", Method.POST);
+            request.AddBody(parameters, "customs_item");
+
+            return await request.ExecuteTaskAsync<CustomsItem>();
         }
     }
 }

--- a/EasyPost/Item.cs
+++ b/EasyPost/Item.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace EasyPost {
     public class Item : IResource {
@@ -34,6 +35,13 @@ namespace EasyPost {
             return request.Execute<Item>();
         }
 
+        public static async Task<Item> RetrieveTaskAsync(string id) {
+            Request request = new Request("items/{id}");
+            request.AddUrlSegment("id", id);
+
+            return await request.ExecuteTaskAsync<Item>();
+        }
+
         /// <summary>
         /// Create an Item.
         /// </summary>
@@ -60,6 +68,12 @@ namespace EasyPost {
 
             return request.Execute<Item>();
         }
+        public static async Task<Item> CreateTaskAsync(Dictionary<string, object> parameters) {
+            Request request = new Request("items", Method.POST);
+            request.AddBody(parameters, "item");
+
+            return await request.ExecuteTaskAsync<Item>();
+        }
 
         /// <summary>
         /// Retrieve a Item from a custom reference.
@@ -73,6 +87,14 @@ namespace EasyPost {
             request.AddUrlSegment("value", value);
 
             return request.Execute<Item>();
+        }
+
+        public static async Task<Item> RetrieveReferenceTaskAsync(string name, string value) {
+            Request request = new Request("items/retrieve_reference/?{name}={value}");
+            request.AddUrlSegment("name", name);
+            request.AddUrlSegment("value", value);
+
+            return await request.ExecuteTaskAsync<Item>();
         }
     }
 }

--- a/EasyPost/Order.cs
+++ b/EasyPost/Order.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace EasyPost {
     public class Order : IResource {
@@ -35,6 +36,13 @@ namespace EasyPost {
             return request.Execute<Order>();
         }
 
+        public static async Task<Order> RetrieveTaskAsync(string id) {
+            Request request = new Request("orders/{id}");
+            request.AddUrlSegment("id", id);
+
+            return await request.ExecuteTaskAsync<Order>();
+        }
+
         /// <summary>
         /// Create a Order.
         /// </summary>
@@ -60,6 +68,12 @@ namespace EasyPost {
 
             return request.Execute<Order>();
         }
+        public static async Task<Order> CreateTaskAsync(Dictionary<string, object> parameters) {
+            Request request = new Request("orders", Method.POST);
+            request.AddBody(parameters, "order");
+
+            return await request.ExecuteTaskAsync<Order>();
+        }
 
         /// <summary>
         /// Create this Order.
@@ -70,12 +84,24 @@ namespace EasyPost {
                 throw new ResourceAlreadyCreated();
             this.Merge(sendCreate(this.AsDictionary()));
         }
+        public async Task CreateTaskAsync() {
+            if (id != null)
+                throw new ResourceAlreadyCreated();
+            this.Merge(await sendCreateTaskAsync(this.AsDictionary()));
+        }
 
         private static Order sendCreate(Dictionary<string, object> parameters) {
             Request request = new Request("orders", Method.POST);
             request.AddBody(parameters, "order");
 
             return request.Execute<Order>();
+        }
+
+        private static async Task<Order> sendCreateTaskAsync(Dictionary<string, object> parameters) {
+            Request request = new Request("orders", Method.POST);
+            request.AddBody(parameters, "order");
+
+            return await request.ExecuteTaskAsync<Order>();
         }
 
         /// <summary>
@@ -91,12 +117,24 @@ namespace EasyPost {
             this.Merge(request.Execute<Order>());
         }
 
+        public async Task BuyTaskAsync(string carrier, string service) {
+            Request request = new Request("orders/{id}/buy", Method.POST);
+            request.AddUrlSegment("id", id);
+            request.AddBody(new List<Tuple<string, string>>() { new Tuple<string, string>("carrier", carrier), new Tuple<string, string>("service", service) });
+
+            this.Merge(await request.ExecuteTaskAsync<Order>());
+        }
+
         /// <summary>
         /// Purchase a label for this shipment with the given rate.
         /// </summary>
         /// <param name="rate">EasyPost.Rate object to puchase the shipment with.</param>
         public void Buy(Rate rate) {
             Buy(rate.carrier, rate.service);
+        }
+
+        public async Task BuyTaskAsync(Rate rate) {
+            await BuyTaskAsync(rate.carrier, rate.service);
         }
     }
 }

--- a/EasyPost/Parcel.cs
+++ b/EasyPost/Parcel.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace EasyPost {
     public class Parcel : IResource {
@@ -27,6 +28,13 @@ namespace EasyPost {
             return request.Execute<Parcel>();
         }
 
+        public static async Task<Parcel> RetrieveTaskAsync(string id) {
+            Request request = new Request("parcels/{id}");
+            request.AddUrlSegment("id", id);
+
+            return await request.ExecuteTaskAsync<Parcel>();
+        }
+
         /// <summary>
         /// Create a Parcel.
         /// </summary>
@@ -45,6 +53,13 @@ namespace EasyPost {
             request.AddBody(parameters, "parcel");
 
             return request.Execute<Parcel>();
+        }
+
+        public static async Task<Parcel> CreateTaskAsync(Dictionary<string, object> parameters) {
+            Request request = new Request("parcels", Method.POST);
+            request.AddBody(parameters, "parcel");
+
+            return await request.ExecuteTaskAsync<Parcel>();
         }
     }
 }

--- a/EasyPost/Pickup.cs
+++ b/EasyPost/Pickup.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace EasyPost {
     public class Pickup : IResource {
@@ -33,6 +34,14 @@ namespace EasyPost {
 
             return request.Execute<Pickup>();
         }
+
+        public static async Task<Pickup> RetrieveTaskAsync(string id) {
+            Request request = new Request("pickups/{id}");
+            request.AddUrlSegment("id", id);
+
+            return await request.ExecuteTaskAsync<Pickup>();
+        }
+
         /// <summary>
         /// Create a Pickup.
         /// </summary>
@@ -53,6 +62,9 @@ namespace EasyPost {
         public static Pickup Create(Dictionary<string, object> parameters = null) {
             return sendCreate(parameters ?? new Dictionary<string, object>());
         }
+        public static async Task<Pickup> CreateTaskAsync(Dictionary<string, object> parameters = null) {
+            return await sendCreateTaskAsync(parameters ?? new Dictionary<string, object>());
+        }
 
         /// <summary>
         /// Create this Pickup.
@@ -63,12 +75,24 @@ namespace EasyPost {
                 throw new ResourceAlreadyCreated();
             this.Merge(sendCreate(this.AsDictionary()));
         }
+        public async Task CreateTaskAsync() {
+            if (id != null)
+                throw new ResourceAlreadyCreated();
+            this.Merge(await sendCreateTaskAsync(this.AsDictionary()));
+        }
 
         private static Pickup sendCreate(Dictionary<string, object> parameters) {
             Request request = new Request("pickups", Method.POST);
             request.AddBody(parameters, "pickup");
 
             return request.Execute<Pickup>();
+        }
+
+        private static async Task<Pickup> sendCreateTaskAsync(Dictionary<string, object> parameters) {
+            Request request = new Request("pickups", Method.POST);
+            request.AddBody(parameters, "pickup");
+
+            return await request.ExecuteTaskAsync<Pickup>();
         }
 
         /// <summary>
@@ -86,6 +110,16 @@ namespace EasyPost {
 
             this.Merge(request.Execute<Pickup>());
         }
+        public async Task BuyTaskAsync(string carrier, string service) {
+            Request request = new Request("pickups/{id}/buy", Method.POST);
+            request.AddUrlSegment("id", id);
+            request.AddBody(new List<Tuple<string, string>>() {
+                new Tuple<string, string>("carrier", carrier),
+                new Tuple<string, string>("service", service)
+            });
+
+            this.Merge(await request.ExecuteTaskAsync<Pickup>());
+        }
 
         /// <summary>
         /// Cancel this pickup.
@@ -95,6 +129,13 @@ namespace EasyPost {
             request.AddUrlSegment("id", id);
 
             this.Merge(request.Execute<Pickup>());
+        }
+
+        public async Task CancelTaskAsync() {
+            Request request = new Request("pickups/{id}/cancel", Method.POST);
+            request.AddUrlSegment("id", id);
+
+            this.Merge(await request.ExecuteTaskAsync<Pickup>());
         }
     }
 }

--- a/EasyPost/Rate.cs
+++ b/EasyPost/Rate.cs
@@ -1,6 +1,7 @@
 ﻿using RestSharp;
 
 using System;
+using System.Threading.Tasks;
 
 namespace EasyPost {
     public class Rate : IResource {
@@ -33,6 +34,13 @@ namespace EasyPost {
             request.AddUrlSegment("id", id);
 
             return request.Execute<Rate>();
+        }
+
+        public static async Task<Rate> RetrieveTaskAsync(string id) {
+            Request request = new Request("rates/{id}");
+            request.AddUrlSegment("id", id);
+
+            return await request.ExecuteTaskAsync<Rate>();
         }
     }
 }

--- a/EasyPost/Request.cs
+++ b/EasyPost/Request.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace EasyPost {
     public class Request {
@@ -28,9 +29,18 @@ namespace EasyPost {
             return client.Execute<T>(this);
         }
 
+        public async Task<T> ExecuteTaskAsync<T>() where T : new() {
+            Client client = ClientManager.Build();
+            return await client.ExecuteTaskAsync<T>(this);
+        }
+
         public IRestResponse Execute() {
             Client client = ClientManager.Build();
             return client.Execute(this);
+        }
+        public async Task<IRestResponse> ExecuteTaskAsync() {
+            Client client = ClientManager.Build();
+            return await client.ExecuteTaskAsync(this);
         }
 
         public void AddUrlSegment(string name, string value) {

--- a/EasyPost/ScanForm.cs
+++ b/EasyPost/ScanForm.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace EasyPost {
     public class ScanForm : IResource {
@@ -32,6 +33,15 @@ namespace EasyPost {
             request.AddQueryString(parameters ?? new Dictionary<string, object>());
 
             ScanFormList scanFormList = request.Execute<ScanFormList>();
+            scanFormList.filters = parameters;
+            return scanFormList;
+        }
+
+        public static async Task<ScanFormList> ListTaskAsync(Dictionary<string, object> parameters = null) {
+            Request request = new Request("scan_forms");
+            request.AddQueryString(parameters ?? new Dictionary<string, object>());
+
+            ScanFormList scanFormList = await request.ExecuteTaskAsync<ScanFormList>();
             scanFormList.filters = parameters;
             return scanFormList;
         }

--- a/EasyPost/ScanFormList.cs
+++ b/EasyPost/ScanFormList.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace EasyPost {
     public class ScanFormList : IResource {
@@ -18,6 +19,13 @@ namespace EasyPost {
             filters["before_id"] = scanForms.Last().id;
 
             return ScanForm.List(filters);
+        }
+
+        public async Task<ScanFormList> NextTaskAsync() {
+            filters = filters ?? new Dictionary<string, object>();
+            filters["before_id"] = scanForms.Last().id;
+
+            return await ScanForm.ListTaskAsync(filters);
         }
     }
 }

--- a/EasyPost/ShipmentList.cs
+++ b/EasyPost/ShipmentList.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace EasyPost {
     public class ShipmentList : IResource {
@@ -17,6 +18,13 @@ namespace EasyPost {
             filters["before_id"] = shipments.Last().id;
 
             return Shipment.List(filters);
+        }
+
+        public async Task<ShipmentList> NextTaskAsync() {
+            filters = filters ?? new Dictionary<string, object>();
+            filters["before_id"] = shipments.Last().id;
+
+            return await Shipment.ListTaskAsync(filters);
         }
     }
 }

--- a/EasyPost/Tracker.cs
+++ b/EasyPost/Tracker.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace EasyPost {
     public class Tracker : IResource {
@@ -41,6 +42,15 @@ namespace EasyPost {
             return trackerList;
         }
 
+        public static async Task<TrackerList> ListTaskAsync(Dictionary<string, object> parameters = null) {
+            Request request = new Request("trackers");
+            request.AddQueryString(parameters ?? new Dictionary<string, object>());
+
+            TrackerList trackerList = await request.ExecuteTaskAsync<TrackerList>();
+            trackerList.filters = parameters;
+            return trackerList;
+        }
+
         public static Tracker Create(string carrier, string trackingCode) {
             Request request = new Request("trackers", RestSharp.Method.POST);
             Dictionary<string, object> parameters = new Dictionary<string, object>() {
@@ -50,6 +60,17 @@ namespace EasyPost {
             request.AddBody(parameters, "tracker");
 
             return request.Execute<Tracker>();
+        }
+
+        public static async Task<Tracker> CreateTaskAsync(string carrier, string trackingCode) {
+            Request request = new Request("trackers", RestSharp.Method.POST);
+            Dictionary<string, object> parameters = new Dictionary<string, object>() {
+                { "tracking_code", trackingCode }, { "carrier", carrier }
+            };
+
+            request.AddBody(parameters, "tracker");
+
+            return await request.ExecuteTaskAsync<Tracker>();
         }
 
         /// <summary>
@@ -62,6 +83,13 @@ namespace EasyPost {
             request.AddUrlSegment("id", id);
 
             return request.Execute<Tracker>();
+        }
+
+        public static async Task<Tracker> RetrieveTaskAsync(string id) {
+            Request request = new Request("trackers/{id}");
+            request.AddUrlSegment("id", id);
+
+            return await request.ExecuteTaskAsync<Tracker>();
         }
     }
 }

--- a/EasyPost/TrackerList.cs
+++ b/EasyPost/TrackerList.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace EasyPost {
     public class TrackerList {
@@ -17,6 +18,13 @@ namespace EasyPost {
             filters["before_id"] = trackers.Last().id;
 
             return Tracker.List(filters);
+        }
+
+        public async Task<TrackerList> NextTaskAsync() {
+            filters = filters ?? new Dictionary<string, object>();
+            filters["before_id"] = trackers.Last().id;
+
+            return await Tracker.ListTaskAsync(filters);
         }
     }
 }

--- a/EasyPost/User.cs
+++ b/EasyPost/User.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace EasyPost {
     public class User : IResource {
@@ -39,6 +40,21 @@ namespace EasyPost {
             return request.Execute<User>();
         }
 
+        public static async Task<User> RetrieveTaskAsync(string id = null) {
+            Request request;
+
+            if (id == null)
+            {
+                request = new Request("users");
+            }
+            else {
+                request = new Request("users/{id}");
+                request.AddUrlSegment("id", id);
+            }
+
+            return await request.ExecuteTaskAsync<User>();
+        }
+
         /// <summary>
         /// Create a child user for the account associated with the api_key specified.
         /// </summary>
@@ -53,6 +69,13 @@ namespace EasyPost {
             request.AddBody(parameters, "user");
 
             return request.Execute<User>();
+        }
+
+        public static async Task<User> CreateTaskAsync(Dictionary<string, object> parameters) {
+            Request request = new Request("users", Method.POST);
+            request.AddBody(parameters, "user");
+
+            return await request.ExecuteTaskAsync<User>();
         }
 
         /// <summary>
@@ -74,6 +97,14 @@ namespace EasyPost {
             request.AddBody(parameters, "user");
 
             this.Merge(request.Execute<User>());
+        }
+
+        public async Task UpdateTaskAsync(Dictionary<string, object> parameters) {
+            Request request = new Request("users/{id}", Method.PUT);
+            request.AddUrlSegment("id", id);
+            request.AddBody(parameters, "user");
+
+            this.Merge(await request.ExecuteTaskAsync<User>());
         }
     }
 }


### PR DESCRIPTION
These changes supply additional 'TaskAsync' counterpart methods for methods like Address.CreateAndVerify. So instead of using Address.CreateAndVerify, which functions only synchronously, you can use Address.CreateAndVerifyTaskAsync, which will return an asynchronous awaitable task. Used correctly, you can see 100 to 1,000 fold improvements in performance.
