### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Shipment shipment = new Shipment() {
     to_address = toAddress,
     parcel = parcel,
     customs_info = info,
-    optoins = options
+    options = options
 };
 
 shipment.Buy(shipment.LowestRate(


### PR DESCRIPTION
Correct spelling to the Shipment options property. Should read 'options' instead of 'optoins'.