### PR TITLE
get rates when the list is null or is an empty list

### DIFF
--- a/EasyPost/Shipment.cs
+++ b/EasyPost/Shipment.cs
@@ -224,7 +224,7 @@ namespace EasyPost {
         /// <returns>EasyPost.Rate instance or null if no rate was found.</returns>
         public Rate LowestRate(IEnumerable<string> includeCarriers = null, IEnumerable<string> includeServices = null,
                                IEnumerable<string> excludeCarriers = null, IEnumerable<string> excludeServices = null) {
-            if (rates == null)
+            if (rates == null || !rates.Any())
                 GetRates();
 
             List<Rate> result = new List<Rate>(rates);


### PR DESCRIPTION
In a situation where you retrieve a shipment and then try to get the lowest rate, the list is empty and it doesn't get the rates which results in an exception. 

Ex:
```
                var shipmentDetail = Shipment.Retrieve("SOME_SHIPMENT_ID");
              
                shipmentDetail.Buy(shipmentDetail.LowestRate(
                                    includeServices: new List<string>() { "First" },
                                    excludeCarriers: new List<string>() { "FedEx" }
                                    ));
```