### PR TITLE
 Add support for TLSv1.2 for versions before Net45

### DIFF
--- a/EasyPost/Client.cs
+++ b/EasyPost/Client.cs
@@ -15,7 +15,7 @@ namespace EasyPost {
         internal ClientConfiguration configuration;
 
         internal Client(ClientConfiguration clientConfiguration) {
-            System.Net.ServicePointManager.SecurityProtocol = Security.GetProtocol();
+            System.Net.ServicePointManager.SecurityProtocol |= Security.GetProtocol();
 
             if (clientConfiguration == null) throw new ArgumentNullException("clientConfiguration");
             configuration = clientConfiguration;

--- a/EasyPost/Security.cs
+++ b/EasyPost/Security.cs
@@ -6,7 +6,7 @@ namespace EasyPost {
 #if NET45
             return SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
 #else
-            return SecurityProtocolType.Tls;
+            return (SecurityProtocolType)0x00000C00;
 #endif
         }
     }


### PR DESCRIPTION
The current solution is forcing everyone not using Net45 to use TLSv1. That will be shut off Dec 1st.

This will add support for TLSv1.2 for versions before Net45 as per this [stackoverflow answer](https://stackoverflow.com/a/39725273/6504973). The other small change is good practise and ensures that other supported protocols aren't replaced, but that TLSv1.2 is in addition. This is in case something else still relies on TLSv1 or v1.1.