### PR TITLE
remove duplicate shipment option

### DIFF
--- a/EasyPost/Options.cs
+++ b/EasyPost/Options.cs
@@ -67,7 +67,6 @@ namespace EasyPost {
         public bool? print_rate { get; set; }
         public bool? registered_mail { get; set; }
         public double? registered_mail_amount { get; set; }
-        public bool? restricted_delivery { get; set; }
         public bool? return_receipt { get; set; }
         public string return_service { get; set; }
         public bool? saturday_delivery { get; set; }


### PR DESCRIPTION
Adding restricted_delivery was a mistake after discovering that the shipment option has already been implemented via undocumented delivery_confirmation values. Easypost's api docs were updated to reflect the full list of valid USPS delivery_confirmation shipment options.