### PR TITLE
Added CHANGELOG and add releasing info to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+### 2.5.1.3 (2020-01-07)
+
+* Add restricted delivery shipment option
+* Correct certified mail type
+
+### 2.5.1.2 (2019-09-26)
+
+* Add certified mail, registered mail, and return receipt shipment options
+
+### 2.5.1.1 (2019-07-05)
+
+* Added suppress etd option
+
+### 2.5.1.0 (2018-10-05)
+
+* Added overlabel shipment options

--- a/README.md
+++ b/README.md
@@ -202,6 +202,14 @@ batch.GenerateLabel("zpl"); // populates batch.label_url asynchronously
 
 Consume the subsequent `batch.updated` webhook to process further.
 
+### Releasing
+
+1. Update the [CHANGELOG](CHANGELOG.md)
+1. Bump version in `EasyPost.nuspec`
+1. Rebuild the library
+1. Create a git tag
+1. Publish new Nuget package
+
 ### Reporting Issues
 
 If you have an issue with the client feel free to open an issue on [GitHub](https://github.com/EasyPost/easypost-csharp/issues). If you have a general shipping question or a questions about EasyPost's service please contact support@easypost.com for additional assitance.


### PR DESCRIPTION
Oddly enough, C# is the only CL to be missing a CHANGELOG. Added that with the last few changes as well as added missing Releasing info to the REAMDE.