### PR TITLE
Add public access to Client delegate constructor

### DIFF
--- a/EasyPost/Client.cs
+++ b/EasyPost/Client.cs
@@ -13,7 +13,7 @@ namespace EasyPost {
         internal RestClient client;
         internal ClientConfiguration configuration;
 
-        internal Client(ClientConfiguration clientConfiguration) {
+        public Client(ClientConfiguration clientConfiguration) {
             System.Net.ServicePointManager.SecurityProtocol |= Security.GetProtocol();
             configuration = clientConfiguration ?? throw new ArgumentNullException("clientConfiguration");
 


### PR DESCRIPTION
This constructor is listed in the docs as though it should be publicly accessible. 