### PR TITLE
docs: removes CreateAndBuy example from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,37 +171,6 @@ foreach (Form form in shipment.forms) {
 }
 ```
 
-### Asynchronous Batch Processing
-
-The `Batch` object allows you to perform operations on multiple `Shipment`s at once. This includes scheduling a `Pickup`, creating a `ScanForm` and consolidating labels. Operations performed on a `Batch` are asynchronous and take advantage of our [webhoook](https://www.easypost.com/docs/api/csharp#events) infrastructure.
-
-```cs
-using EasyPost;
-
-Shipment shipment = new Shipment() {
-    from_address = fromAddress,
-    to_address = toAddress,
-    parcel = parcel,
-    optoins = options
-};
-
-Batch batch = Batch.CreateAndBuy(new Dictionary<string, object>() {
-    { "reference", "MyReference" },
-    { "shipments", new List<Dictionary<string, object>>() { shipment } }
-});
-```
-
-This will produce two webhooks. One `batch.created` and one `batch.updated`. Process each `Batch` [state](https://www.easypost.com/docs/api/csharp#batch-object) according to your business logic.
-
-```cs
-using EasyPost;
-
-Batch batch = Batch.Retrieve("batch_...");
-batch.GenerateLabel("zpl"); // populates batch.label_url asynchronously
-```
-
-Consume the subsequent `batch.updated` webhook to process further.
-
 ### Releasing
 
 1. Update the [CHANGELOG](CHANGELOG.md).


### PR DESCRIPTION
Over the years, we've had many users write in confused by the `CreateAndBuy` example in our README. The code doesn't exist (maybe it did at one point?) I've provided an example of how to buy a batch (AKA "CreateAndBuy") without the need for us to actually add logic as this functionality is already supported via this library (see #134 for details).

This PR removes the bad `CreateAndBuy` example from the README.

Closes #134 