### PR TITLE
fix: adds missing VerificationDetails compile targets

### DIFF
--- a/EasyPost.Net35/EasyPost.Net35.csproj
+++ b/EasyPost.Net35/EasyPost.Net35.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build"
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -174,6 +175,9 @@
     </Compile>
     <Compile Include="..\EasyPost\Verification.cs">
       <Link>Verification.cs</Link>
+    </Compile>
+    <Compile Include="..\EasyPost\VerificationDetails.cs">
+      <Link>VerificationDetails.cs</Link>
     </Compile>
     <Compile Include="..\EasyPost\Verifications.cs">
       <Link>Verifications.cs</Link>

--- a/EasyPost.Net40/EasyPost.Net40.csproj
+++ b/EasyPost.Net40/EasyPost.Net40.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build"
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -175,6 +176,9 @@
     </Compile>
     <Compile Include="..\EasyPost\Verification.cs">
       <Link>Verification.cs</Link>
+    </Compile>
+    <Compile Include="..\EasyPost\VerificationDetails.cs">
+      <Link>VerificationDetails.cs</Link>
     </Compile>
     <Compile Include="..\EasyPost\Verifications.cs">
       <Link>Verifications.cs</Link>

--- a/EasyPost.NetCore20/EasyPost.NetCore20.csproj
+++ b/EasyPost.NetCore20/EasyPost.NetCore20.csproj
@@ -146,6 +146,9 @@
     <Compile Include="..\EasyPost\Verification.cs">
       <Link>Verification.cs</Link>
     </Compile>
+    <Compile Include="..\EasyPost\VerificationDetails.cs">
+      <Link>VerificationDetails.cs</Link>
+    </Compile>
     <Compile Include="..\EasyPost\Verifications.cs">
       <Link>Verifications.cs</Link>
     </Compile>

--- a/EasyPost/EasyPost.csproj
+++ b/EasyPost/EasyPost.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build"
+  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -102,6 +103,7 @@
     <Compile Include="TrackingLocation.cs" />
     <Compile Include="User.cs" />
     <Compile Include="Verification.cs" />
+    <Compile Include="VerificationDetails.cs" />
     <Compile Include="Verifications.cs" />
     <Compile Include="Webhook.cs" />
     <Compile Include="WebhookList.cs" />


### PR DESCRIPTION
We recently merged in a fix that adds the missing `VerificationDetails` object. This is in a new file. The PR was missing the compile targets to include it in the project. This simply adds the compile targets for the new file so when the project gets built, it's included.