### PR TITLE
docs: adds missing items to next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Adds missing `commercial_invoice_letterhead` option (closes #142)
 * Adds missing `license_number` option
 * Adds missing `VerificationDetails` object (closes #140, #141, #162)
+* Bumps `RestSharp` from `106.4.2` to `106.12.0`
+* Changes the Client delegate constructor from `internal` to `public`
 * Updates various information in the README related to thread-safety, examples, releasing, etc
 * Adds all missing dates and versions to the CHANGELOG
 


### PR DESCRIPTION
Adds the following to the CHANGELOG from recent PR merges:

```
* Bumps `RestSharp` from `106.4.2` to `106.12.0`
* Changes the Client delegate constructor from `internal` to `public`
```