### PR TITLE
fix: adds missing receiver_liquor_license option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Adds missing `commercial_invoice_letterhead` option (closes #142)
 * Adds missing `license_number` option
+* Adds missing `receiver_liquor_license` option
 * Adds missing `VerificationDetails` object (closes #140, #141, #162)
 * Bumps `RestSharp` from `106.4.2` to `106.12.0`
 * Changes the Client delegate constructor from `internal` to `public`

--- a/EasyPost/Options.cs
+++ b/EasyPost/Options.cs
@@ -69,6 +69,7 @@ namespace EasyPost
         public bool? print_custom_2_barcode { get; set; }
         public bool? print_custom_3_barcode { get; set; }
         public bool? print_rate { get; set; }
+        public string receiver_liquor_license { get; set; }
         public bool? registered_mail { get; set; }
         public double? registered_mail_amount { get; set; }
         public bool? return_receipt { get; set; }


### PR DESCRIPTION
fix: adds missing receiver_liquor_license option (required for FedEx alcohol shipments)