### PR TITLE
chore: remove unused orderBy param from Batch object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## NEXT RELEASE
 
 * Adds support for one-call-buys on shipments and orders via adding the `service` key to both objects
+* Removes the unused `orderBy` parameter from the `Batch` object
 
 ## 2.7.0 (2021-11-24)
 

--- a/EasyPost.Tests/BatchTest.cs
+++ b/EasyPost.Tests/BatchTest.cs
@@ -114,18 +114,5 @@ namespace EasyPost.Tests {
 
             batch.GenerateScanForm();
         }
-
-        [TestMethod]
-        public void TestGenerateLabelWithOrderBy() {
-            Batch batch = CreateBatch();
-
-            while (batch.state == "creating") { batch = Batch.Retrieve(batch.id); }
-            batch.Buy();
-
-            while (batch.state == "created") { batch = Batch.Retrieve(batch.id); }
-            batch.GenerateLabel("pdf", orderBy: "reference DESC");
-
-            Assert.AreEqual(batch.state, "label_generating");
-        }
     }
 }

--- a/EasyPost/Batch.cs
+++ b/EasyPost/Batch.cs
@@ -111,15 +111,11 @@ namespace EasyPost {
         /// Asynchronously generate a label containing all of the Shimpent labels belonging to the batch.
         /// </summary>
         /// <param name="fileFormat">Format to generate the label in. Valid formats: "pdf", "zpl" and "epl2".</param>
-        /// <param name="orderBy">Optional parameter to order the generated label. Ex: "reference DESC"</param>
-        public void GenerateLabel(string fileFormat, string orderBy = null) {
+        public void GenerateLabel(string fileFormat) {
             Request request = new Request("v2/batches/{id}/label", Method.POST);
             request.AddUrlSegment("id", id);
 
             Dictionary<string, object> parameters = new Dictionary<string, object>() { { "file_format", fileFormat } };
-
-            if (orderBy != null)
-                parameters["order_by"] = orderBy;
 
             request.AddQueryString(parameters);
             Merge(request.Execute<Batch>());


### PR DESCRIPTION
Removes the usused `orderBy` param from the Batch object.