### PR TITLE
Include .NET version in User Agent

### DIFF
--- a/EasyPost/Client.cs
+++ b/EasyPost/Client.cs
@@ -82,7 +82,7 @@ namespace EasyPost
                  * but we can't get the exact version.
                  * See: https://docs.microsoft.com/en-us/dotnet/api/system.environment.version?view=net-6.0#remarks
                  */
-                dotNetVersion = "4.6+ or Core 2.2-";
+                dotNetVersion = "4.6+";
             }
 
             _dotNetVersion = dotNetVersion;

--- a/EasyPost/Client.cs
+++ b/EasyPost/Client.cs
@@ -1,68 +1,91 @@
 ﻿using Newtonsoft.Json;
 using RestSharp;
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 
-namespace EasyPost {
-    public class Client {
-        public string version;
+namespace EasyPost
+{
+    public class Client
+    {
+        private readonly string _libraryVersion;
+        private readonly string _dotNetVersion;
+        private readonly RestClient _restClient;
+        private readonly ClientConfiguration _configuration;
+        private string UserAgent => $"EasyPost/v2 CSharpClient/{_libraryVersion} .NET/{_dotNetVersion}";
 
-        internal RestClient client;
-        internal ClientConfiguration configuration;
+        private RestRequest PrepareRequest(Request request)
+        {
+            var restRequest = (RestRequest)request;
 
-        public Client(ClientConfiguration clientConfiguration) {
-            System.Net.ServicePointManager.SecurityProtocol |= Security.GetProtocol();
-            configuration = clientConfiguration ?? throw new ArgumentNullException("clientConfiguration");
-
-            client = new RestClient(clientConfiguration.ApiBase);
-
-            Assembly assembly = Assembly.GetExecutingAssembly();
-            FileVersionInfo info = FileVersionInfo.GetVersionInfo(assembly.Location);
-            version = info.FileVersion;
-        }
-
-        internal IRestResponse Execute(Request request) {
-            return client.Execute(PrepareRequest(request));
-        }
-
-        internal T Execute<T>(Request request) where T : new() {
-            RestResponse<T> response = (RestResponse<T>)client.Execute<T>(PrepareRequest(request));
-            int StatusCode = Convert.ToInt32(response.StatusCode);
-
-            if (StatusCode > 399) {
-                Dictionary<string, Dictionary<string, object>> Body;
-                List<Error> Errors;
-
-                try {
-                    Body = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, object>>>(response.Content);
-                    Errors = JsonConvert.DeserializeObject<List<Error>>(JsonConvert.SerializeObject(Body["error"]["errors"]));
-                }
-                catch {
-                    throw new HttpException(StatusCode, "RESPONSE.PARSE_ERROR", response.Content, new List<Error>());
-                }
-
-                throw new HttpException(
-                    StatusCode,
-                    (string)Body["error"]["code"],
-                    (string)Body["error"]["message"],
-                    Errors
-                );
-            }
-
-            return response.Data;
-        }
-
-        internal RestRequest PrepareRequest(Request request) {
-            RestRequest restRequest = (RestRequest)request;
-
-            restRequest.AddHeader("user_agent", string.Concat("EasyPost/v2 CSharp/", version));
-            restRequest.AddHeader("authorization", "Bearer " + this.configuration.ApiKey);
+            restRequest.AddHeader("user_agent", UserAgent);
+            restRequest.AddHeader("authorization", "Bearer " + _configuration.ApiKey);
             restRequest.AddHeader("content_type", "application/json");
 
             return restRequest;
+        }
+
+        internal IRestResponse Execute(Request request)
+        {
+            return _restClient.Execute(PrepareRequest(request));
+        }
+
+        internal T Execute<T>(Request request) where T : new()
+        {
+            var response = (RestResponse<T>)_restClient.Execute<T>(PrepareRequest(request));
+            var statusCode = Convert.ToInt32(response.StatusCode);
+
+            if (statusCode < 400)
+            {
+                return response.Data;
+            }
+
+            Dictionary<string, Dictionary<string, object>> body;
+            List<Error> errors;
+
+            try
+            {
+                body = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, object>>>(response.Content);
+                errors = JsonConvert.DeserializeObject<List<Error>>(
+                    JsonConvert.SerializeObject(body["error"]["errors"]));
+            }
+            catch
+            {
+                throw new HttpException(statusCode, "RESPONSE.PARSE_ERROR", response.Content, new List<Error>());
+            }
+
+            throw new HttpException(
+                statusCode,
+                (string)body["error"]["code"],
+                (string)body["error"]["message"],
+                errors
+            );
+        }
+
+        public Client(ClientConfiguration clientConfiguration)
+        {
+            System.Net.ServicePointManager.SecurityProtocol |= Security.GetProtocol();
+            _configuration = clientConfiguration ?? throw new ArgumentNullException("clientConfiguration");
+
+            _restClient = new RestClient(clientConfiguration.ApiBase);
+
+            var assembly = Assembly.GetExecutingAssembly();
+            var info = FileVersionInfo.GetVersionInfo(assembly.Location);
+            _libraryVersion = info.FileVersion;
+
+            var dotNetVersion = Environment.Version.ToString();
+            if (dotNetVersion == "4.0.30319.42000")
+            {
+                /*
+                 * We're on a v4.6+ version (or pre-.NET Core 3.0, which we don't support),
+                 * but we can't get the exact version.
+                 * See: https://docs.microsoft.com/en-us/dotnet/api/system.environment.version?view=net-6.0#remarks
+                 */
+                dotNetVersion = "4.6+";
+            }
+
+            _dotNetVersion = dotNetVersion;
         }
     }
 }

--- a/EasyPost/Client.cs
+++ b/EasyPost/Client.cs
@@ -78,11 +78,11 @@ namespace EasyPost
             if (dotNetVersion == "4.0.30319.42000")
             {
                 /*
-                 * We're on a v4.5+ version (or pre-.NET Core 3.0, which we don't support),
+                 * We're on a v4.6+ version (or pre-.NET Core 3.0, which we don't support),
                  * but we can't get the exact version.
                  * See: https://docs.microsoft.com/en-us/dotnet/api/system.environment.version?view=net-6.0#remarks
                  */
-                dotNetVersion = "4.5+ or Core 2.2-";
+                dotNetVersion = "4.6+";
             }
 
             _dotNetVersion = dotNetVersion;

--- a/EasyPost/Client.cs
+++ b/EasyPost/Client.cs
@@ -82,7 +82,7 @@ namespace EasyPost
                  * but we can't get the exact version.
                  * See: https://docs.microsoft.com/en-us/dotnet/api/system.environment.version?view=net-6.0#remarks
                  */
-                dotNetVersion = "4.6+";
+                dotNetVersion = "4.6 or higher";
             }
 
             _dotNetVersion = dotNetVersion;

--- a/EasyPost/Client.cs
+++ b/EasyPost/Client.cs
@@ -78,11 +78,11 @@ namespace EasyPost
             if (dotNetVersion == "4.0.30319.42000")
             {
                 /*
-                 * We're on a v4.6+ version (or pre-.NET Core 3.0, which we don't support),
+                 * We're on a v4.5+ version (or pre-.NET Core 3.0, which we don't support),
                  * but we can't get the exact version.
                  * See: https://docs.microsoft.com/en-us/dotnet/api/system.environment.version?view=net-6.0#remarks
                  */
-                dotNetVersion = "4.6+";
+                dotNetVersion = "4.5+ or Core 2.2-";
             }
 
             _dotNetVersion = dotNetVersion;

--- a/EasyPost/Client.cs
+++ b/EasyPost/Client.cs
@@ -78,11 +78,11 @@ namespace EasyPost
             if (dotNetVersion == "4.0.30319.42000")
             {
                 /*
-                 * We're on a v4.5+ version (or pre-.NET Core 3.0, which we don't support),
+                 * We're on a v4.6+ version (or pre-.NET Core 3.0, which we don't support),
                  * but we can't get the exact version.
                  * See: https://docs.microsoft.com/en-us/dotnet/api/system.environment.version?view=net-6.0#remarks
                  */
-                dotNetVersion = "4.5+ or Core 2.2-";
+                dotNetVersion = "4.6+ or Core 2.2-";
             }
 
             _dotNetVersion = dotNetVersion;


### PR DESCRIPTION
This will include the current .NET framework that the user is running our library in in the User Agent made with every API call.

This isn't a perfect implementation, due to how Microsoft has changed how to get this information depending on the .NET framework, and it's difficult to implement a solution that can account (and work) regardless of the version the user is running (i.e. some classes needed to do the registry check for a version in newer .NET versions simply don't exist in older .NET versions, preventing the project from compiling). We can implement a more accurate solution in the future using interfaces, but for now, this will work as a first pass.
  - If the .NET framework is v4.5 or higher (or lower than .NET Core 3.0 - we are dropping .NET Core 2.0 support anyway), it will only report to us as "v4.5+" rather than a specific version. This is mostly fine, since our library only compiles on up to .NET 4.0, although the user themselves could run our library in a project that is .NET v4.5 or higher.
  - Ref: https://docs.microsoft.com/en-us/dotnet/api/system.environment.version?view=net-6.0#remarks
  
Also included some basic linting on the Client class during the process of adding .NET version.