### PR TITLE
Add support for retrieving all batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## NEXT RELEASE
 
 * Adds support for one-call-buys on shipments and orders via adding the `service` key to both objects
+* Adds support for retrieving all batches
 * Adds support for retrieving all addresses
 * Adds support for retrieving all events
 * Removes the unused `orderBy` parameter from the `Batch` object

--- a/EasyPost.Net35/EasyPost.Net35.csproj
+++ b/EasyPost.Net35/EasyPost.Net35.csproj
@@ -80,6 +80,9 @@
     <Compile Include="..\EasyPost\Batch.cs">
       <Link>Batch.cs</Link>
     </Compile>
+    <Compile Include="..\EasyPost\BatchCollection.cs">
+      <Link>BatchCollection.cs</Link>
+    </Compile>
     <Compile Include="..\EasyPost\BatchShipment.cs">
       <Link>BatchShipment.cs</Link>
     </Compile>

--- a/EasyPost.Net40/EasyPost.Net40.csproj
+++ b/EasyPost.Net40/EasyPost.Net40.csproj
@@ -81,6 +81,9 @@
     <Compile Include="..\EasyPost\Batch.cs">
       <Link>Batch.cs</Link>
     </Compile>
+    <Compile Include="..\EasyPost\BatchCollection.cs">
+      <Link>BatchCollection.cs</Link>
+    </Compile>
     <Compile Include="..\EasyPost\BatchShipment.cs">
       <Link>BatchShipment.cs</Link>
     </Compile>

--- a/EasyPost.NetCore20/EasyPost.NetCore20.csproj
+++ b/EasyPost.NetCore20/EasyPost.NetCore20.csproj
@@ -55,6 +55,9 @@
     <Compile Include="..\EasyPost\Batch.cs">
       <Link>Batch.cs</Link>
     </Compile>
+    <Compile Include="..\EasyPost\BatchCollection.cs">
+      <Link>BatchCollection.cs</Link>
+    </Compile>
     <Compile Include="..\EasyPost\BatchShipment.cs">
       <Link>BatchShipment.cs</Link>
     </Compile>

--- a/EasyPost.NetCore31/EasyPost.NetCore31.csproj
+++ b/EasyPost.NetCore31/EasyPost.NetCore31.csproj
@@ -55,6 +55,9 @@
     <Compile Include="..\EasyPost\Batch.cs">
       <Link>Batch.cs</Link>
     </Compile>
+    <Compile Include="..\EasyPost\BatchCollection.cs">
+      <Link>BatchCollection.cs</Link>
+    </Compile>
     <Compile Include="..\EasyPost\BatchShipment.cs">
       <Link>BatchShipment.cs</Link>
     </Compile>

--- a/EasyPost.Tests/BatchTest.cs
+++ b/EasyPost.Tests/BatchTest.cs
@@ -221,10 +221,10 @@ namespace EasyPost.Tests
         {
             BatchCollection batchCollection = Batch.All();
             Assert.IsNotNull(batchCollection);
-            if (batchCollection.batches.Count > 0)
+            foreach (var batch in batchCollection.batches)
             {
-                Assert.IsNotNull(batchCollection.batches[0].id);
-                Assert.AreEqual(batchCollection.batches[0].id.Substring(0, 6), "batch_");
+                Assert.IsNotNull(batch.id);
+                Assert.AreEqual(batch.id.Substring(0, 6), "batch_");
             }
         }
     }

--- a/EasyPost.Tests/BatchTest.cs
+++ b/EasyPost.Tests/BatchTest.cs
@@ -215,5 +215,17 @@ namespace EasyPost.Tests
             Batch retrieved = Batch.Retrieve(batch.id);
             Assert.AreEqual(batch.id, retrieved.id);
         }
+
+        [TestMethod]
+        public void TestRetrieveAll()
+        {
+            BatchCollection batchCollection = Batch.All();
+            Assert.IsNotNull(batchCollection);
+            if (batchCollection.batches.Count > 0)
+            {
+                Assert.IsNotNull(batchCollection.batches[0].id);
+                Assert.AreEqual(batchCollection.batches[0].id.Substring(0, 6), "batch_");
+            }
+        }
     }
 }

--- a/EasyPost/Batch.cs
+++ b/EasyPost/Batch.cs
@@ -165,5 +165,20 @@ namespace EasyPost
 
             return request.Execute<Batch>();
         }
+
+        /// <summary>
+        ///     List all Batch objects.
+        /// </summary>
+        /// <param name="parameters">Optional dictionary containing parameters for request.</param>
+        /// <returns>EasyPost.BatchCollection instance.</returns>
+        public static BatchCollection All(Dictionary<string, object> parameters = null)
+        {
+            parameters = parameters ?? new Dictionary<string, object>();
+
+            Request request = new Request("batches");
+            request.AddQueryString(parameters);
+
+            return request.Execute<BatchCollection>();
+        }
     }
 }

--- a/EasyPost/Batch.cs
+++ b/EasyPost/Batch.cs
@@ -169,7 +169,17 @@ namespace EasyPost
         /// <summary>
         ///     List all Batch objects.
         /// </summary>
-        /// <param name="parameters">Optional dictionary containing parameters for request.</param>
+        /// <param name="parameters">
+        ///     Optional dictionary containing parameters to filter the list with. Valid pairs:
+        ///     * {"before_id", string} String representing a Batch ID. Starts with "batch_". Only retrieve batches created
+        ///     before this id. Takes precedence over after_id.
+        ///     * {"after_id", string} String representing a Batch ID. Starts with "batch_". Only retrieve batches created after
+        ///     this id.
+        ///     * {"start_datetime", string} ISO 8601 datetime string. Only retrieve batches created after this datetime.
+        ///     * {"end_datetime", string} ISO 8601 datetime string. Only retrieve batches created before this datetime.
+        ///     * {"page_size", int} Max size of list. Default to 20.
+        ///     All invalid keys will be ignored.
+        /// </param>
         /// <returns>EasyPost.BatchCollection instance.</returns>
         public static BatchCollection All(Dictionary<string, object> parameters = null)
         {

--- a/EasyPost/BatchCollection.cs
+++ b/EasyPost/BatchCollection.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace EasyPost
+{
+    public class BatchCollection
+    {
+        public List<Batch> batches { get; set; }
+        public bool has_more { get; set; }
+    }
+}

--- a/EasyPost/EasyPost.csproj
+++ b/EasyPost/EasyPost.csproj
@@ -80,6 +80,7 @@
     <Compile Include="AddressCollection.cs" />
     <Compile Include="ApiKey.cs" />
     <Compile Include="Batch.cs" />
+    <Compile Include="BatchCollection.cs" />
     <Compile Include="BatchShipment.cs" />
     <Compile Include="CarrierAccount.cs" />
     <Compile Include="CarrierDetail.cs" />


### PR DESCRIPTION
Finally, the C# library supports the ability to get all batches with `Batch.All()`

This PR includes:
- The new `Batch.All()` function to retrieve all batches. Can optionally ass in a `Dictionary<string, object>` as parameter. Function returns an `BatchCollection` object.
- Docstring for this function.
- Added new `BatchCollection` class, which features:
  - `public List<Batch> batches`
  - `public bool has_more`
  This is similar to how our other client libraries handle multiple batches.
- A new `BatchTest.TestRetrieveAll()` test for this feature

Classes, functions and tests have been imported/linked to all projects/versions, and all tests pass.

Closes #95 