### PR TITLE
Improve support for retrieving all carrier accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## NEXT RELEASE
 
 * Adds support for one-call-buys on shipments and orders via adding the `service` key to both objects
+* Updated `CarrierAccount.List()` to `CarrierAccount.All()` (with optional dictionary parameter) to remain consistent with other `.All()` methods
 * Removes the unused `orderBy` parameter from the `Batch` object
 * Update the `DefaultApiBase` to include `v2` and remove `v2` from every request url string
 * Add a 30 second connection timeout and a 60 second request timeout for all HTTP requests

--- a/EasyPost.Tests/CarrierAccountTest.cs
+++ b/EasyPost.Tests/CarrierAccountTest.cs
@@ -46,17 +46,22 @@ namespace EasyPost.Tests
         }
 
         [TestMethod]
-        public void TestList()
-        {
-            List<CarrierAccount> accounts = CarrierAccount.List();
-            Assert.AreEqual(accounts[0].id, "ca_7642d249fdcf47bcb5da9ea34c96dfcf");
-        }
-
-        [TestMethod]
         public void TestRetrieve()
         {
             CarrierAccount account = CarrierAccount.Retrieve("ca_7642d249fdcf47bcb5da9ea34c96dfcf");
             Assert.AreEqual("ca_7642d249fdcf47bcb5da9ea34c96dfcf", account.id);
+        }
+
+        [TestMethod]
+        public void TestRetrieveAll()
+        {
+            List<CarrierAccount> accounts = CarrierAccount.All();
+            Assert.IsNotNull(accounts);
+            if (accounts.Count > 0)
+            {
+                Assert.IsNotNull(accounts[0].id);
+                Assert.AreEqual(accounts[0].id.Substring(0, 3), "ca_");
+            }
         }
     }
 }

--- a/EasyPost/CarrierAccount.cs
+++ b/EasyPost/CarrierAccount.cs
@@ -76,9 +76,13 @@ namespace EasyPost
         ///     List all available carrier accounts.
         /// </summary>
         /// <returns>A list of EasyPost.CarrierAccount instances.</returns>
-        public static List<CarrierAccount> List()
+        public static List<CarrierAccount> All(Dictionary<string, object> parameters = null)
         {
+            parameters = parameters ?? new Dictionary<string, object>();
+
             Request request = new Request("carrier_accounts");
+            request.AddQueryString(parameters);
+
             return request.Execute<List<CarrierAccount>>();
         }
 

--- a/EasyPost/CarrierAccount.cs
+++ b/EasyPost/CarrierAccount.cs
@@ -75,6 +75,7 @@ namespace EasyPost
         /// <summary>
         ///     List all available carrier accounts.
         /// </summary>
+        /// <param name="parameters">Optional dictionary containing parameters for request.</param>
         /// <returns>A list of EasyPost.CarrierAccount instances.</returns>
         public static List<CarrierAccount> All(Dictionary<string, object> parameters = null)
         {


### PR DESCRIPTION
Unlike the other PRs for adding `.All()` methods, we actually already had this functionality as `CarrierAccount.List()`.
With this PR, we've enhanced it and renamed it to be consistent with our other C# methods (and other client libraries).

This PR includes:
- The renamed `CarrierAccount.All()` function to retrieve all carrier accounts. Can optionally ass in a `Dictionary<string, object>` as parameter. Function returns a list of `CarrierAccount` objects.
- Docstring for this function.
- A renamed and improved `CarrierAccount.TestRetrieveAll()` test for this feature

All tests pass.