### PR TITLE
Add support for retrieving all events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## NEXT RELEASE
 
 * Adds support for one-call-buys on shipments and orders via adding the `service` key to both objects
+* Adds support for retrieving all events
 * Removes the unused `orderBy` parameter from the `Batch` object
 * Update the `DefaultApiBase` to include `v2` and remove `v2` from every request url string
 * Add a 30 second connection timeout and a 60 second request timeout for all HTTP requests

--- a/EasyPost.Net35/EasyPost.Net35.csproj
+++ b/EasyPost.Net35/EasyPost.Net35.csproj
@@ -107,6 +107,9 @@
     <Compile Include="..\EasyPost\Event.cs">
       <Link>Event.cs</Link>
     </Compile>
+    <Compile Include="..\EasyPost\EventCollection.cs">
+      <Link>EventCollection.cs</Link>
+    </Compile>
     <Compile Include="..\EasyPost\Exception.cs">
       <Link>Exception.cs</Link>
     </Compile>

--- a/EasyPost.Net40/EasyPost.Net40.csproj
+++ b/EasyPost.Net40/EasyPost.Net40.csproj
@@ -108,6 +108,9 @@
     <Compile Include="..\EasyPost\Event.cs">
       <Link>Event.cs</Link>
     </Compile>
+    <Compile Include="..\EasyPost\EventCollection.cs">
+      <Link>EventCollection.cs</Link>
+    </Compile>
     <Compile Include="..\EasyPost\Exception.cs">
       <Link>Exception.cs</Link>
     </Compile>

--- a/EasyPost.NetCore20/EasyPost.NetCore20.csproj
+++ b/EasyPost.NetCore20/EasyPost.NetCore20.csproj
@@ -82,6 +82,9 @@
     <Compile Include="..\EasyPost\Event.cs">
       <Link>Event.cs</Link>
     </Compile>
+    <Compile Include="..\EasyPost\EventCollection.cs">
+      <Link>EventCollection.cs</Link>
+    </Compile>
     <Compile Include="..\EasyPost\Exception.cs">
       <Link>Exception.cs</Link>
     </Compile>

--- a/EasyPost.NetCore31/EasyPost.NetCore31.csproj
+++ b/EasyPost.NetCore31/EasyPost.NetCore31.csproj
@@ -82,6 +82,9 @@
     <Compile Include="..\EasyPost\Event.cs">
       <Link>Event.cs</Link>
     </Compile>
+    <Compile Include="..\EasyPost\EventCollection.cs">
+      <Link>EventCollection.cs</Link>
+    </Compile>
     <Compile Include="..\EasyPost\Exception.cs">
       <Link>Exception.cs</Link>
     </Compile>

--- a/EasyPost.Tests/EventTest.cs
+++ b/EasyPost.Tests/EventTest.cs
@@ -18,5 +18,17 @@ namespace EasyPost.Tests
             // Events are archived after some time. Lets at least make sure we get a 404.
             Event e = Event.Retrieve("evt_d0000c1a9c6c4614949af6931ea9fac8");
         }
+
+        [TestMethod]
+        public void TestRetrieveAll()
+        {
+            EventCollection eventCollection = Event.All();
+            Assert.IsNotNull(eventCollection);
+            if (eventCollection.events.Count > 0)
+            {
+                Assert.IsNotNull(eventCollection.events[0].id);
+                Assert.AreEqual(eventCollection.events[0].id.Substring(0, 4), "evt_");
+            }
+        }
     }
 }

--- a/EasyPost.Tests/EventTest.cs
+++ b/EasyPost.Tests/EventTest.cs
@@ -24,10 +24,10 @@ namespace EasyPost.Tests
         {
             EventCollection eventCollection = Event.All();
             Assert.IsNotNull(eventCollection);
-            if (eventCollection.events.Count > 0)
+            foreach (var tEvent in eventCollection.events)
             {
-                Assert.IsNotNull(eventCollection.events[0].id);
-                Assert.AreEqual(eventCollection.events[0].id.Substring(0, 4), "evt_");
+                Assert.IsNotNull(tEvent.id);
+                Assert.AreEqual(tEvent.id.Substring(0, 4), "evt_");
             }
         }
     }

--- a/EasyPost/EasyPost.csproj
+++ b/EasyPost/EasyPost.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -11,7 +11,7 @@
     <AssemblyName>EasyPost</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile/>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -66,74 +66,75 @@
     <Reference Include="RestSharp, Version=106.13.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.106.13.0\lib\net452\RestSharp.dll</HintPath>
     </Reference>
-    <Reference Include="System"/>
-    <Reference Include="System.Core"/>
-    <Reference Include="System.Web"/>
-    <Reference Include="System.Xml.Linq"/>
-    <Reference Include="System.Data.DataSetExtensions"/>
-    <Reference Include="Microsoft.CSharp"/>
-    <Reference Include="System.Data"/>
-    <Reference Include="System.Xml"/>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Address.cs"/>
-    <Compile Include="ApiKey.cs"/>
-    <Compile Include="Batch.cs"/>
-    <Compile Include="BatchShipment.cs"/>
-    <Compile Include="CarrierAccount.cs"/>
-    <Compile Include="CarrierDetail.cs"/>
-    <Compile Include="CarrierType.cs"/>
-    <Compile Include="Error.cs"/>
-    <Compile Include="Event.cs"/>
-    <Compile Include="Message.cs"/>
-    <Compile Include="Options.cs"/>
-    <Compile Include="ClientConfiguration.cs"/>
-    <Compile Include="ClientManager.cs"/>
-    <Compile Include="Report.cs"/>
-    <Compile Include="ReportList.cs"/>
-    <Compile Include="Resource.cs"/>
-    <Compile Include="Smartrate.cs"/>
-    <Compile Include="TimeInTransit.cs"/>
-    <Compile Include="TrackerList.cs"/>
-    <Compile Include="ScanFormList.cs"/>
-    <Compile Include="Exception.cs"/>
-    <Compile Include="Fee.cs"/>
-    <Compile Include="Form.cs"/>
-    <Compile Include="Order.cs"/>
-    <Compile Include="CustomsInfo.cs"/>
-    <Compile Include="CustomsItem.cs"/>
-    <Compile Include="Client.cs"/>
-    <Compile Include="IResource.cs"/>
-    <Compile Include="Parcel.cs"/>
-    <Compile Include="Pickup.cs"/>
-    <Compile Include="PostageLabel.cs"/>
-    <Compile Include="Properties\AssemblyInfo.cs"/>
-    <Compile Include="Rating.cs"/>
-    <Compile Include="Request.cs"/>
-    <Compile Include="ScanForm.cs"/>
-    <Compile Include="Security.cs"/>
-    <Compile Include="Shipment.cs"/>
-    <Compile Include="ShipmentList.cs"/>
-    <Compile Include="TaxIdentifier.cs"/>
-    <Compile Include="Tracker.cs"/>
-    <Compile Include="TrackingDetail.cs"/>
-    <Compile Include="TrackingLocation.cs"/>
-    <Compile Include="User.cs"/>
-    <Compile Include="Verification.cs"/>
-    <Compile Include="VerificationDetails.cs"/>
-    <Compile Include="Verifications.cs"/>
-    <Compile Include="VersionInfo.cs"/>
-    <Compile Include="Webhook.cs"/>
-    <Compile Include="WebhookList.cs"/>
+    <Compile Include="Address.cs" />
+    <Compile Include="ApiKey.cs" />
+    <Compile Include="Batch.cs" />
+    <Compile Include="BatchShipment.cs" />
+    <Compile Include="CarrierAccount.cs" />
+    <Compile Include="CarrierDetail.cs" />
+    <Compile Include="CarrierType.cs" />
+    <Compile Include="Error.cs" />
+    <Compile Include="Event.cs" />
+    <Compile Include="EventCollection.cs" />
+    <Compile Include="Message.cs" />
+    <Compile Include="Options.cs" />
+    <Compile Include="ClientConfiguration.cs" />
+    <Compile Include="ClientManager.cs" />
+    <Compile Include="Report.cs" />
+    <Compile Include="ReportList.cs" />
+    <Compile Include="Resource.cs" />
+    <Compile Include="Smartrate.cs" />
+    <Compile Include="TimeInTransit.cs" />
+    <Compile Include="TrackerList.cs" />
+    <Compile Include="ScanFormList.cs" />
+    <Compile Include="Exception.cs" />
+    <Compile Include="Fee.cs" />
+    <Compile Include="Form.cs" />
+    <Compile Include="Order.cs" />
+    <Compile Include="CustomsInfo.cs" />
+    <Compile Include="CustomsItem.cs" />
+    <Compile Include="Client.cs" />
+    <Compile Include="IResource.cs" />
+    <Compile Include="Parcel.cs" />
+    <Compile Include="Pickup.cs" />
+    <Compile Include="PostageLabel.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Rating.cs" />
+    <Compile Include="Request.cs" />
+    <Compile Include="ScanForm.cs" />
+    <Compile Include="Security.cs" />
+    <Compile Include="Shipment.cs" />
+    <Compile Include="ShipmentList.cs" />
+    <Compile Include="TaxIdentifier.cs" />
+    <Compile Include="Tracker.cs" />
+    <Compile Include="TrackingDetail.cs" />
+    <Compile Include="TrackingLocation.cs" />
+    <Compile Include="User.cs" />
+    <Compile Include="Verification.cs" />
+    <Compile Include="VerificationDetails.cs" />
+    <Compile Include="Verifications.cs" />
+    <Compile Include="VersionInfo.cs" />
+    <Compile Include="Webhook.cs" />
+    <Compile Include="WebhookList.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Rate.cs"/>
+    <Compile Include="Rate.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="EasyPost.pfx"/>
-    <None Include="packages.config"/>
+    <None Include="EasyPost.pfx" />
+    <None Include="packages.config" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"/>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>
     </PostBuildEvent>

--- a/EasyPost/Event.cs
+++ b/EasyPost/Event.cs
@@ -48,7 +48,17 @@ namespace EasyPost
         /// <summary>
         ///     List all Event objects.
         /// </summary>
-        /// <param name="parameters">Optional dictionary containing parameters for request.</param>
+        /// <param name="parameters">
+        ///     Optional dictionary containing parameters to filter the list with. Valid pairs:
+        ///     * {"before_id", string} String representing an Event ID. Starts with "evt_". Only retrieve events created
+        ///     before this id. Takes precedence over after_id.
+        ///     * {"after_id", string} String representing an Event ID. Starts with "evt_". Only retrieve events created after
+        ///     this id.
+        ///     * {"start_datetime", string} ISO 8601 datetime string. Only retrieve events created after this datetime.
+        ///     * {"end_datetime", string} ISO 8601 datetime string. Only retrieve events created before this datetime.
+        ///     * {"page_size", int} Max size of list. Default to 20.
+        ///     All invalid keys will be ignored.
+        /// </param>
         /// <returns>EasyPost.EventCollection instance.</returns>
         public static EventCollection All(Dictionary<string, object> parameters = null)
         {

--- a/EasyPost/Event.cs
+++ b/EasyPost/Event.cs
@@ -44,5 +44,20 @@ namespace EasyPost
 
             return request.Execute<Event>();
         }
+
+        /// <summary>
+        ///     List all Event objects.
+        /// </summary>
+        /// <param name="parameters">Optional dictionary containing parameters for request.</param>
+        /// <returns>EasyPost.EventCollection instance.</returns>
+        public static EventCollection All(Dictionary<string, object> parameters = null)
+        {
+            parameters = parameters ?? new Dictionary<string, object>();
+
+            Request request = new Request("events");
+            request.AddQueryString(parameters);
+
+            return request.Execute<EventCollection>();
+        }
     }
 }

--- a/EasyPost/EventCollection.cs
+++ b/EasyPost/EventCollection.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace EasyPost
+{
+    public class EventCollection
+    {
+        public List<Event> events { get; set; }
+        public bool has_more { get; set; }
+    }
+}


### PR DESCRIPTION
Finally, the C# library supports the ability to get all events with `Event.All()`

This PR includes:
- The new `Event.All()` function to retrieve all events. Can optionally pass in a `Dictionary<string, object>` as parameter. Function returns an `EventCollection` object.
- Docstring for this function.
- Added new `EventCollection` class, which features:
  - `public List<Event> events`
  - `public bool has_more`
  This is similar to how our other client libraries handle multiple events.
- A new `EventTest.TestRetrieveAll()` test for this feature

Classes, functions and tests have been imported/linked to all projects/versions, and all tests pass.