### PR TITLE
Add support for re-rating a shipment

### DIFF
--- a/EasyPost.Tests/ShipmentTest.cs
+++ b/EasyPost.Tests/ShipmentTest.cs
@@ -268,7 +268,7 @@ namespace EasyPost.Tests
 
         [ExpectedException(typeof(ResourceNotCreated))]
         [TestMethod]
-        public void TestRerateShipmentWithoutFirstCreating()
+        public void TestRerateShipmentWithoutCreate()
         {
             Shipment shipment = CreateShipmentResource();
             shipment.RefreshRates();

--- a/EasyPost.Tests/ShipmentTest.cs
+++ b/EasyPost.Tests/ShipmentTest.cs
@@ -255,6 +255,26 @@ namespace EasyPost.Tests
         }
 
         [TestMethod]
+        public void TestRerateShipment()
+        {
+            Shipment shipment = CreateShipmentResource();
+            shipment.Create();
+            shipment.rates = new List<Rate>();
+            Assert.AreEqual(shipment.rates.Count, 0);
+            shipment.RefreshRates();
+            Assert.IsNotNull(shipment.rates);
+            Assert.AreNotEqual(shipment.rates.Count, 0);
+        }
+
+        [ExpectedException(typeof(ResourceNotCreated))]
+        [TestMethod]
+        public void TestRerateShipmentWithoutFirstCreating()
+        {
+            Shipment shipment = CreateShipmentResource();
+            shipment.RefreshRates();
+        }
+
+        [TestMethod]
         public void TestGetSmartrates()
         {
             Shipment shipment = Shipment.Create(parameters);

--- a/EasyPost.Tests/ShipmentTest.cs
+++ b/EasyPost.Tests/ShipmentTest.cs
@@ -261,17 +261,19 @@ namespace EasyPost.Tests
             shipment.Create();
             shipment.rates = new List<Rate>();
             Assert.AreEqual(shipment.rates.Count, 0);
-            shipment.RefreshRates();
+            shipment.RegenerateRates();
             Assert.IsNotNull(shipment.rates);
             Assert.AreNotEqual(shipment.rates.Count, 0);
         }
 
-        [ExpectedException(typeof(ResourceNotCreated))]
         [TestMethod]
         public void TestRerateShipmentWithoutCreate()
         {
             Shipment shipment = CreateShipmentResource();
-            shipment.RefreshRates();
+            Assert.IsNull(shipment.id);
+            shipment.RegenerateRates();
+            Assert.IsNotNull(shipment.id);
+            Assert.IsNotNull(shipment.rates);
         }
 
         [TestMethod]

--- a/EasyPost/Exception.cs
+++ b/EasyPost/Exception.cs
@@ -52,12 +52,4 @@ namespace EasyPost
     public class ClientNotConfigured : Exception
     {
     }
-
-    [Serializable]
-    public class ResourceNotCreated : Exception
-    {
-        public ResourceNotCreated(string message) : base(message)
-        {
-        }
-    }
 }

--- a/EasyPost/Exception.cs
+++ b/EasyPost/Exception.cs
@@ -52,4 +52,12 @@ namespace EasyPost
     public class ClientNotConfigured : Exception
     {
     }
+
+    [Serializable]
+    public class ResourceNotCreated : Exception
+    {
+        public ResourceNotCreated(string message) : base(message)
+        {
+        }
+    }
 }

--- a/EasyPost/Shipment.cs
+++ b/EasyPost/Shipment.cs
@@ -135,6 +135,28 @@ namespace EasyPost
         }
 
         /// <summary>
+        ///     Refresh the rates for this Shipment.
+        /// </summary>
+        /// <param name="parameters">Optional dictionary of parameters for the API request.</param>
+        public void RefreshRates(Dictionary<string, object> parameters = null)
+        {
+            if (id == null)
+            {
+                throw new ResourceNotCreated("Shipment must be created before refreshing rates. Try running `shipment.Create()` first.");
+            }
+
+            Request request = new Request("shipments/{id}/rerate", Method.POST);
+            request.AddUrlSegment("id", id);
+            if (parameters != null)
+            {
+                request.AddBody(parameters);
+            }
+
+            Shipment _shipment = request.Execute<Shipment>();
+            rates = _shipment.rates;
+        }
+
+        /// <summary>
         ///     Get the Smartrates for this shipment.
         /// </summary>
         /// <returns>A list of EasyPost.Smartrate instances.</returns>

--- a/EasyPost/Shipment.cs
+++ b/EasyPost/Shipment.cs
@@ -153,8 +153,7 @@ namespace EasyPost
                 request.AddBody(parameters);
             }
 
-            Shipment _shipment = request.Execute<Shipment>();
-            rates = _shipment.rates;
+            rates = request.Execute<Shipment>().rates;
         }
 
         /// <summary>

--- a/EasyPost/Shipment.cs
+++ b/EasyPost/Shipment.cs
@@ -138,12 +138,11 @@ namespace EasyPost
         ///     Refresh the rates for this Shipment.
         /// </summary>
         /// <param name="parameters">Optional dictionary of parameters for the API request.</param>
-        /// <exception cref="ResourceAlreadyCreated">Shipment has not be created server-side yet.</exception>
-        public void RefreshRates(Dictionary<string, object> parameters = null)
+        public void RegenerateRates(Dictionary<string, object> parameters = null)
         {
             if (id == null)
             {
-                throw new ResourceNotCreated("Shipment must be created before refreshing rates. Try running `shipment.Create()` first.");
+                Create();
             }
 
             Request request = new Request("shipments/{id}/rerate", Method.POST);

--- a/EasyPost/Shipment.cs
+++ b/EasyPost/Shipment.cs
@@ -138,6 +138,7 @@ namespace EasyPost
         ///     Refresh the rates for this Shipment.
         /// </summary>
         /// <param name="parameters">Optional dictionary of parameters for the API request.</param>
+        /// <exception cref="ResourceAlreadyCreated">Shipment has not be created server-side yet.</exception>
         public void RefreshRates(Dictionary<string, object> parameters = null)
         {
             if (id == null)


### PR DESCRIPTION
Finally, the C# library supports the ability to re-rate a shipment with `shipment.RefreshRates()`

This PR includes:
- The new `RefreshRates()` method to refresh the rates for a given shipment. Can optionally pass in a `Dictionary<string, object>` as parameter. Function replaces existing `rates` on shipment object, does not return anything.
- Docstring for this function.
- Added new `ResourceNotCreated` exception (extends standard `Exception`). This is used in the tests for this method (and can hopefully be used in the future). Thrown if the resource has not been created server-side.
- `RefreshRates()` throws `ResourceNotCreated` if the shipment object has not been created server-side (the shipment's `ID` is `null`)
- New `ShipmentTest.TestRerateShipment()` and `ShipmentTest.TestRerateShipmentWithoutCreate()` tests for this feature

All tests pass.