### PR TITLE
Add missing class extension

### DIFF
--- a/EasyPost/BatchCollection.cs
+++ b/EasyPost/BatchCollection.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace EasyPost
 {
-    public class BatchCollection
+    public class BatchCollection : Resource
     {
         public List<Batch> batches { get; set; }
         public bool has_more { get; set; }

--- a/EasyPost/EventCollection.cs
+++ b/EasyPost/EventCollection.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace EasyPost
 {
-    public class EventCollection
+    public class EventCollection : Resource
     {
         public List<Event> events { get; set; }
         public bool has_more { get; set; }


### PR DESCRIPTION
During our recent PR requests, we added a `BatchCollection` and `EventCollection` class, but forgot to have these new classes extend the `Resource` class.

All tests passed without it, but let's remain consistent with our class structure.