### PR TITLE
Add support for Insurance objects

### DIFF
--- a/EasyPost.Net35/EasyPost.Net35.csproj
+++ b/EasyPost.Net35/EasyPost.Net35.csproj
@@ -119,6 +119,12 @@
     <Compile Include="..\EasyPost\Exception.cs">
       <Link>Exception.cs</Link>
     </Compile>
+    <Compile Include="..\EasyPost\Insurance.cs">
+      <Link>Insurance.cs</Link>
+    </Compile>
+    <Compile Include="..\EasyPost\InsuranceCollection.cs">
+      <Link>InsuranceCollection.cs</Link>
+    </Compile>
     <Compile Include="..\EasyPost\IResource.cs">
       <Link>IResource.cs</Link>
     </Compile>

--- a/EasyPost.Net40/EasyPost.Net40.csproj
+++ b/EasyPost.Net40/EasyPost.Net40.csproj
@@ -120,6 +120,12 @@
     <Compile Include="..\EasyPost\Exception.cs">
       <Link>Exception.cs</Link>
     </Compile>
+    <Compile Include="..\EasyPost\Insurance.cs">
+      <Link>Insurance.cs</Link>
+    </Compile>
+    <Compile Include="..\EasyPost\InsuranceCollection.cs">
+      <Link>InsuranceCollection.cs</Link>
+    </Compile>
     <Compile Include="..\EasyPost\IResource.cs">
       <Link>IResource.cs</Link>
     </Compile>

--- a/EasyPost.NetCore20/EasyPost.NetCore20.csproj
+++ b/EasyPost.NetCore20/EasyPost.NetCore20.csproj
@@ -94,6 +94,12 @@
     <Compile Include="..\EasyPost\Exception.cs">
       <Link>Exception.cs</Link>
     </Compile>
+    <Compile Include="..\EasyPost\Insurance.cs">
+      <Link>Insurance.cs</Link>
+    </Compile>
+    <Compile Include="..\EasyPost\InsuranceCollection.cs">
+      <Link>InsuranceCollection.cs</Link>
+    </Compile>
     <Compile Include="..\EasyPost\IResource.cs">
       <Link>IResource.cs</Link>
     </Compile>

--- a/EasyPost.NetCore31/EasyPost.NetCore31.csproj
+++ b/EasyPost.NetCore31/EasyPost.NetCore31.csproj
@@ -94,6 +94,12 @@
     <Compile Include="..\EasyPost\Exception.cs">
       <Link>Exception.cs</Link>
     </Compile>
+    <Compile Include="..\EasyPost\Insurance.cs">
+      <Link>Insurance.cs</Link>
+    </Compile>
+    <Compile Include="..\EasyPost\InsuranceCollection.cs">
+      <Link>InsuranceCollection.cs</Link>
+    </Compile>
     <Compile Include="..\EasyPost\IResource.cs">
       <Link>IResource.cs</Link>
     </Compile>

--- a/EasyPost.Tests.Net35/EasyPost.Tests.Net35.csproj
+++ b/EasyPost.Tests.Net35/EasyPost.Tests.Net35.csproj
@@ -110,5 +110,8 @@
     <Compile Include="..\EasyPost.Tests\WebhookTest.cs">
       <Link>WebhookTest.cs</Link>
     </Compile>
+    <Compile Include="..\EasyPost.Tests\InsuranceTest.cs">
+      <Link>InsuranceTest.cs</Link>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/EasyPost.Tests.Net40/EasyPost.Tests.Net40.csproj
+++ b/EasyPost.Tests.Net40/EasyPost.Tests.Net40.csproj
@@ -110,5 +110,8 @@
     <Compile Include="..\EasyPost.Tests\WebhookTest.cs">
       <Link>WebhookTest.cs</Link>
     </Compile>
+    <Compile Include="..\EasyPost.Tests\InsuranceTest.cs">
+      <Link>InsuranceTest.cs</Link>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/EasyPost.Tests.NetCore31/EasyPost.Tests.NetCore31.csproj
+++ b/EasyPost.Tests.NetCore31/EasyPost.Tests.NetCore31.csproj
@@ -110,5 +110,8 @@
     <Compile Include="..\EasyPost.Tests\WebhookTest.cs">
       <Link>WebhookTest.cs</Link>
     </Compile>
+    <Compile Include="..\EasyPost.Tests\InsuranceTest.cs">
+      <Link>InsuranceTest.cs</Link>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/EasyPost.Tests/EasyPost.Tests.csproj
+++ b/EasyPost.Tests/EasyPost.Tests.csproj
@@ -10,22 +10,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0"/>
-    <PackageReference Include="coverlet.collector" Version="1.2.0"/>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2"/>
-    <PackageReference Include="RestSharp" Version="106.15.0"/>
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8"/>
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="RestSharp" Version="106.15.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\EasyPost.Net35\EasyPost.Net35.csproj"/>
+    <ProjectReference Include="..\EasyPost.Net35\EasyPost.Net35.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="Microsoft.VisualStudio.UnitTesting"/>
-    <None Remove="RestSharp"/>
-    <None Remove="MSTest.TestFramework"/>
-    <None Remove="MSTest.TestAdapter"/>
+    <None Remove="Microsoft.VisualStudio.UnitTesting" />
+    <None Remove="RestSharp" />
+    <None Remove="MSTest.TestFramework" />
+    <None Remove="MSTest.TestAdapter" />
   </ItemGroup>
 </Project>

--- a/EasyPost.Tests/InsuranceTest.cs
+++ b/EasyPost.Tests/InsuranceTest.cs
@@ -1,0 +1,128 @@
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EasyPost.Tests
+{
+    [TestClass]
+    public class InsuranceTest
+    {
+        private Insurance _insurance { get; set; }
+        private Dictionary<string, object> InsuranceData { get; set; }
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            ClientManager.SetCurrent("NvBX2hFF44SVvTPtYjF0zQ");
+            Address fromAddress = Address.Create(new Dictionary<string, object>
+            {
+                {
+                    "company", "Simpler Postage Inc"
+                },
+                {
+                    "street1", "164 Townsend St"
+                },
+                {
+                    "street2", "Unit 1"
+                },
+                {
+                    "city", "San Francisco"
+                },
+                {
+                    "state", "CA"
+                },
+                {
+                    "zip", "94107"
+                },
+                {
+                    "country", "US"
+                }
+            });
+            Address toAddress = Address.Create(new Dictionary<string, object>()
+            {
+                {
+                    "company", "The White House"
+                },
+                {
+                    "street1", "1600 Pennsylvania Avenue NW"
+                },
+                {
+                    "street2", "DC 20500"
+                },
+                {
+                    "city", "Washington"
+                },
+                {
+                    "state", "DC"
+                },
+                {
+                    "zip", "20500"
+                },
+                {
+                    "country", "US"
+                }
+            });
+            Tracker tracker = Tracker.Create(trackingCode: "EZ1000000001", carrier: "USPS");
+
+            InsuranceData = new Dictionary<string, object>
+            {
+                {
+                    "to_address", toAddress
+                },
+                {
+                    "from_address", fromAddress
+                },
+                {
+                    "tracker", tracker
+                },
+                {
+                    "amount", (float)100
+                },
+                {
+                    "currency", "USD"
+                }
+            };
+            _insurance = new Insurance
+            {
+                from_address = toAddress,
+                to_address = fromAddress,
+                tracker = tracker,
+                amount = (float)100.00,
+                provider = "USPS"
+            };
+        }
+
+        [TestMethod]
+        public void TestCreateAndRetrieve()
+        {
+            Insurance insurance = Insurance.Create(InsuranceData);
+            Assert.IsNotNull(insurance.id);
+            Assert.AreEqual(insurance.from_address, _insurance.from_address);
+
+            Insurance retrieved = Insurance.Retrieve(insurance.id);
+            Assert.AreEqual(insurance.id, retrieved.id);
+        }
+
+        [TestMethod]
+        public void TestCreateInstance()
+        {
+            _insurance.Create();
+            Assert.IsNotNull(_insurance.id);
+        }
+
+        [TestMethod]
+        public void TestRetrieveAll()
+        {
+            InsuranceCollection insuranceCollection = Insurance.All();
+            Assert.IsNotNull(insuranceCollection);
+            foreach (var insurance in insuranceCollection.insurances)
+            {
+                Assert.IsNotNull(insurance.id);
+                Assert.AreEqual(insurance.id.Substring(0, 4), "ins_");
+            }
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(HttpException))]
+        public void TestRetrieveInvalidId() => Insurance.Retrieve("not-an-id");
+    }
+}

--- a/EasyPost.Tests/InsuranceTest.cs
+++ b/EasyPost.Tests/InsuranceTest.cs
@@ -106,7 +106,7 @@ namespace EasyPost.Tests
                     "tracking_code", shipment.tracking_code
                 },
                 {
-                    "amount", 100.00
+                    "amount", "100.00"
                 },
                 {
                     "carrier", "USPS"

--- a/EasyPost.Tests/InsuranceTest.cs
+++ b/EasyPost.Tests/InsuranceTest.cs
@@ -6,14 +6,17 @@ namespace EasyPost.Tests
     [TestClass]
     public class InsuranceTest
     {
+        private Dictionary<string, object> _fromAddressData { get; set; }
         private Insurance _insurance { get; set; }
+        private Dictionary<string, object> _parcelData { get; set; }
+        private Dictionary<string, object> _toAddressData { get; set; }
         private Dictionary<string, object> InsuranceData { get; set; }
 
         [TestInitialize]
         public void Initialize()
         {
             ClientManager.SetCurrent("NvBX2hFF44SVvTPtYjF0zQ");
-            Address fromAddress = Address.Create(new Dictionary<string, object>
+            _fromAddressData = new Dictionary<string, object>
             {
                 {
                     "company", "Simpler Postage Inc"
@@ -36,8 +39,8 @@ namespace EasyPost.Tests
                 {
                     "country", "US"
                 }
-            });
-            Address toAddress = Address.Create(new Dictionary<string, object>()
+            };
+            _toAddressData = new Dictionary<string, object>()
             {
                 {
                     "company", "The White House"
@@ -60,34 +63,55 @@ namespace EasyPost.Tests
                 {
                     "country", "US"
                 }
+            };
+            _parcelData = new Dictionary<string, object>
+            {
+                {
+                    "weight", 8.0
+                }
+            };
+
+            Shipment shipment = Shipment.Create(new Dictionary<string, object>
+            {
+                {
+                    "from_address", _fromAddressData
+                },
+                {
+                    "to_address", _toAddressData
+                },
+                {
+                    "parcel", _parcelData
+                },
+                {
+                    "service", "First"
+                },
+                {
+                    "carrier_accounts", new List<string>
+                    {
+                        {
+                            "ca_7642d249fdcf47bcb5da9ea34c96dfcf"
+                        }
+                    }
+                }
             });
-            Tracker tracker = Tracker.Create(trackingCode: "EZ1000000001", carrier: "USPS");
 
             InsuranceData = new Dictionary<string, object>
             {
                 {
-                    "to_address", toAddress
+                    "to_address", _toAddressData
                 },
                 {
-                    "from_address", fromAddress
+                    "from_address", _fromAddressData
                 },
                 {
-                    "tracker", tracker
+                    "tracking_code", shipment.tracking_code
                 },
                 {
                     "amount", (float)100
                 },
                 {
-                    "currency", "USD"
+                    "carrier", "USPS"
                 }
-            };
-            _insurance = new Insurance
-            {
-                from_address = toAddress,
-                to_address = fromAddress,
-                tracker = tracker,
-                amount = (float)100.00,
-                provider = "USPS"
             };
         }
 
@@ -96,17 +120,10 @@ namespace EasyPost.Tests
         {
             Insurance insurance = Insurance.Create(InsuranceData);
             Assert.IsNotNull(insurance.id);
-            Assert.AreEqual(insurance.from_address, _insurance.from_address);
+            Assert.AreEqual("SAN FRANCISCO", insurance.from_address.city);
 
             Insurance retrieved = Insurance.Retrieve(insurance.id);
             Assert.AreEqual(insurance.id, retrieved.id);
-        }
-
-        [TestMethod]
-        public void TestCreateInstance()
-        {
-            _insurance.Create();
-            Assert.IsNotNull(_insurance.id);
         }
 
         [TestMethod]

--- a/EasyPost.Tests/InsuranceTest.cs
+++ b/EasyPost.Tests/InsuranceTest.cs
@@ -6,17 +6,16 @@ namespace EasyPost.Tests
     [TestClass]
     public class InsuranceTest
     {
-        private Dictionary<string, object> _fromAddressData { get; set; }
-        private Insurance _insurance { get; set; }
-        private Dictionary<string, object> _parcelData { get; set; }
-        private Dictionary<string, object> _toAddressData { get; set; }
+        private Dictionary<string, object> FromAddressData { get; set; }
+        private Dictionary<string, object> ParcelData { get; set; }
+        private Dictionary<string, object> ToAddressData { get; set; }
         private Dictionary<string, object> InsuranceData { get; set; }
 
         [TestInitialize]
         public void Initialize()
         {
             ClientManager.SetCurrent("NvBX2hFF44SVvTPtYjF0zQ");
-            _fromAddressData = new Dictionary<string, object>
+            FromAddressData = new Dictionary<string, object>
             {
                 {
                     "company", "Simpler Postage Inc"
@@ -40,7 +39,7 @@ namespace EasyPost.Tests
                     "country", "US"
                 }
             };
-            _toAddressData = new Dictionary<string, object>()
+            ToAddressData = new Dictionary<string, object>()
             {
                 {
                     "company", "The White House"
@@ -64,7 +63,7 @@ namespace EasyPost.Tests
                     "country", "US"
                 }
             };
-            _parcelData = new Dictionary<string, object>
+            ParcelData = new Dictionary<string, object>
             {
                 {
                     "weight", 8.0
@@ -74,13 +73,13 @@ namespace EasyPost.Tests
             Shipment shipment = Shipment.Create(new Dictionary<string, object>
             {
                 {
-                    "from_address", _fromAddressData
+                    "from_address", FromAddressData
                 },
                 {
-                    "to_address", _toAddressData
+                    "to_address", ToAddressData
                 },
                 {
-                    "parcel", _parcelData
+                    "parcel", ParcelData
                 },
                 {
                     "service", "First"
@@ -98,16 +97,16 @@ namespace EasyPost.Tests
             InsuranceData = new Dictionary<string, object>
             {
                 {
-                    "to_address", _toAddressData
+                    "to_address", ToAddressData
                 },
                 {
-                    "from_address", _fromAddressData
+                    "from_address", FromAddressData
                 },
                 {
                     "tracking_code", shipment.tracking_code
                 },
                 {
-                    "amount", (float)100
+                    "amount", 100.00
                 },
                 {
                     "carrier", "USPS"

--- a/EasyPost/EasyPost.csproj
+++ b/EasyPost/EasyPost.csproj
@@ -88,6 +88,8 @@
     <Compile Include="Error.cs" />
     <Compile Include="Event.cs" />
     <Compile Include="EventCollection.cs" />
+    <Compile Include="Insurance.cs" />
+    <Compile Include="InsuranceCollection.cs" />
     <Compile Include="Message.cs" />
     <Compile Include="Options.cs" />
     <Compile Include="ClientConfiguration.cs" />

--- a/EasyPost/Insurance.cs
+++ b/EasyPost/Insurance.cs
@@ -1,0 +1,129 @@
+using System.Collections.Generic;
+using RestSharp;
+
+namespace EasyPost
+{
+    public class Insurance : Resource
+    {
+        public float amount { get; set; }
+        public Address from_address { get; set; }
+        public string id { get; set; }
+        public List<string> messages { get; set; }
+        public string mode { get; set; }
+        public string provider { get; set; }
+        public string provider_id { get; set; }
+        public string reference { get; set; }
+        public string shipment_id { get; set; }
+        public string status { get; set; }
+        public Address to_address { get; set; }
+        public Tracker tracker { get; set; }
+        public string tracking_code { get; set; }
+
+        /// <summary>
+        ///     Create this Insurance.
+        /// </summary>
+        /// <exception cref="ResourceAlreadyCreated">Insurance has already been created server-side.</exception>
+        public void Create()
+        {
+            if (id != null)
+            {
+                throw new ResourceAlreadyCreated();
+            }
+            Merge(SendCreate(AsDictionary()));
+        }
+
+        /// <summary>
+        ///     Refresh this Insurance.
+        /// </summary>
+        /// <param name="parameters">Optional dictionary of parameters to use when refreshing this insurance.</param>
+        /// <returns>This refreshed EasyPost.Insurance object.</returns>
+        public Insurance Refresh(Dictionary<string, object> parameters = null)
+        {
+            parameters = parameters ?? new Dictionary<string, object>();
+            Request request = new Request("insurances/{id}");
+            request.AddUrlSegment("id", id);
+            request.AddQueryString(parameters);
+
+            Insurance refreshedInsurance = request.Execute<Insurance>();
+            Merge(refreshedInsurance);
+            return this;
+        }
+
+        /// <summary>
+        ///     List all Insurance objects.
+        /// </summary>
+        /// <param name="parameters">
+        ///     Optional dictionary containing parameters to filter the list with. Valid pairs:
+        ///     * {"before_id", string} String representing an Insurance ID. Starts with "ins_". Only retrieve insurances created
+        ///     before this id. Takes precedence over after_id.
+        ///     * {"after_id", string} String representing an Insurance ID. Starts with "ins_". Only retrieve insurances created after
+        ///     this id.
+        ///     * {"start_datetime", string} ISO 8601 datetime string. Only retrieve insurances created after this datetime.
+        ///     * {"end_datetime", string} ISO 8601 datetime string. Only retrieve insurances created before this datetime.
+        ///     * {"page_size", int} Max size of list. Default to 20.
+        ///     All invalid keys will be ignored.
+        /// </param>
+        /// <returns>EasyPost.InsuranceCollection instance.</returns>
+        public static InsuranceCollection All(Dictionary<string, object> parameters = null)
+        {
+            parameters = parameters ?? new Dictionary<string, object>();
+            Request request = new Request("insurances");
+            request.AddQueryString(parameters);
+
+            return request.Execute<InsuranceCollection>();
+        }
+
+        /// <summary>
+        ///     Create an Insurance.
+        /// </summary>
+        /// <param name="parameters">
+        ///     Dictionary containing parameters to create the insurance with. Valid pairs:
+        ///     * {"to_address", Address} The actual destination of the package to be insured
+        ///     * {"from_address", Address} The actual origin of the package to be insured
+        ///     * {"tracking_code", string} The tracking code associated with the non-EasyPost-purchased package you'd like to insure
+        ///     * {"reference", string} Optional. A unique value that may be used in place of ID when doing Retrieve calls for this insurance
+        ///     * {"amount", float} The USD value of contents you would like to insure. Currently the maximum is $5000
+        ///     * {"carrier", string} Optional. The carrier associated with the tracking_code you provided. The carrier will get auto-detected if none is provided
+        ///     All invalid keys will be ignored.
+        /// </param>
+        /// <returns>EasyPost.Insurance instance.</returns>
+        public static Insurance Create(Dictionary<string, object> parameters)
+        {
+            Request request = new Request("insurances", Method.POST);
+            request.AddBody(new Dictionary<string, object>()
+            {
+                {
+                    "insurance", parameters
+                }
+            });
+
+            return request.Execute<Insurance>();
+        }
+
+        /// <summary>
+        ///     Retrieve an Insurance from its id.
+        /// </summary>
+        /// <param name="id">String representing an Insurance. Starts with "ins_".</param>
+        /// <returns>EasyPost.Insurance instance.</returns>
+        public static Insurance Retrieve(string id)
+        {
+            Request request = new Request("insurances/{id}");
+            request.AddUrlSegment("id", id);
+
+            return request.Execute<Insurance>();
+        }
+
+        private static Insurance SendCreate(Dictionary<string, object> parameters)
+        {
+            Request request = new Request("insurances", Method.POST);
+            request.AddBody(new Dictionary<string, object>()
+            {
+                {
+                    "insurance", parameters
+                }
+            });
+
+            return request.Execute<Insurance>();
+        }
+    }
+}

--- a/EasyPost/Insurance.cs
+++ b/EasyPost/Insurance.cs
@@ -5,7 +5,7 @@ namespace EasyPost
 {
     public class Insurance : Resource
     {
-        public float amount { get; set; }
+        public decimal amount { get; set; }
         public Address from_address { get; set; }
         public string id { get; set; }
         public List<string> messages { get; set; }
@@ -69,7 +69,7 @@ namespace EasyPost
         ///     * {"from_address", Address} The actual origin of the package to be insured
         ///     * {"tracking_code", string} The tracking code associated with the non-EasyPost-purchased package you'd like to insure
         ///     * {"reference", string} Optional. A unique value that may be used in place of ID when doing Retrieve calls for this insurance
-        ///     * {"amount", float} The USD value of contents you would like to insure. Currently the maximum is $5000
+        ///     * {"amount", decimal} The USD value of contents you would like to insure. Currently the maximum is $5000
         ///     * {"carrier", string} Optional. The carrier associated with the tracking_code you provided. The carrier will get auto-detected if none is provided
         ///     All invalid keys will be ignored.
         /// </param>

--- a/EasyPost/Insurance.cs
+++ b/EasyPost/Insurance.cs
@@ -5,7 +5,7 @@ namespace EasyPost
 {
     public class Insurance : Resource
     {
-        public decimal amount { get; set; }
+        public string amount { get; set; }
         public Address from_address { get; set; }
         public string id { get; set; }
         public List<string> messages { get; set; }

--- a/EasyPost/Insurance.cs
+++ b/EasyPost/Insurance.cs
@@ -20,19 +20,6 @@ namespace EasyPost
         public string tracking_code { get; set; }
 
         /// <summary>
-        ///     Create this Insurance.
-        /// </summary>
-        /// <exception cref="ResourceAlreadyCreated">Insurance has already been created server-side.</exception>
-        public void Create()
-        {
-            if (id != null)
-            {
-                throw new ResourceAlreadyCreated();
-            }
-            Merge(SendCreate(AsDictionary()));
-        }
-
-        /// <summary>
         ///     Refresh this Insurance.
         /// </summary>
         /// <param name="parameters">Optional dictionary of parameters to use when refreshing this insurance.</param>
@@ -90,7 +77,7 @@ namespace EasyPost
         public static Insurance Create(Dictionary<string, object> parameters)
         {
             Request request = new Request("insurances", Method.POST);
-            request.AddBody(new Dictionary<string, object>()
+            request.AddBody(new Dictionary<string, object>
             {
                 {
                     "insurance", parameters
@@ -116,7 +103,7 @@ namespace EasyPost
         private static Insurance SendCreate(Dictionary<string, object> parameters)
         {
             Request request = new Request("insurances", Method.POST);
-            request.AddBody(new Dictionary<string, object>()
+            request.AddBody(new Dictionary<string, object>
             {
                 {
                     "insurance", parameters

--- a/EasyPost/InsuranceCollection.cs
+++ b/EasyPost/InsuranceCollection.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace EasyPost
+{
+    public class InsuranceCollection
+    {
+        public bool has_more { get; set; }
+        public List<Insurance> insurances { get; set; }
+    }
+}

--- a/EasyPost/Tracker.cs
+++ b/EasyPost/Tracker.cs
@@ -102,7 +102,12 @@ namespace EasyPost
         public static bool CreateList(Dictionary<string, object> param)
         {
             Request request = new Request("trackers/create_list", RestSharp.Method.POST);
-            request.AddBody(new Dictionary<string, object>() { { "trackers", param } });
+            request.AddBody(new Dictionary<string, object>
+            {
+                {
+                    "trackers", param
+                }
+            });
             request.Execute<Tracker>();
             // This endpoint does not return a response so we return true here
             return true;

--- a/EasyPost/Tracker.cs
+++ b/EasyPost/Tracker.cs
@@ -97,15 +97,15 @@ namespace EasyPost
         /// <summary>
         ///     Create a list of trackers
         /// </summary>
-        /// <param name="param">A dictionary of tracking codes and carriers</param>
+        /// <param name="parameters">A dictionary of tracking codes and carriers</param>
         /// <returns>True</returns>
-        public static bool CreateList(Dictionary<string, object> param)
+        public static bool CreateList(Dictionary<string, object> parameters)
         {
             Request request = new Request("trackers/create_list", RestSharp.Method.POST);
             request.AddBody(new Dictionary<string, object>
             {
                 {
-                    "trackers", param
+                    "trackers", parameters
                 }
             });
             request.Execute<Tracker>();


### PR DESCRIPTION
Finally, our C# library supports Insurance!

This PR includes:
- A new `Insurance` class, with `Create()`, `Retrieve()`, `Refresh()` and `All()` functions
- A new `InsuranceCollection` class required for the `Insurance.All()` function
- Tests for all functionalities