### PR TITLE
rename method List() to All().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next release
+
+* Rename method from List() to All() to make our library consistent
+
 ## v2.8.1 (2022-02-17)
 
 * Repackaged the project which contains all the changes made from `2.6.0` - `2.8.0` (see details below)

--- a/EasyPost.Net/CarrierAccount.cs
+++ b/EasyPost.Net/CarrierAccount.cs
@@ -76,7 +76,7 @@ namespace EasyPost
         ///     List all available carrier accounts.
         /// </summary>
         /// <returns>A list of EasyPost.CarrierAccount instances.</returns>
-        public static List<CarrierAccount> List()
+        public static List<CarrierAccount> All()
         {
             Request request = new Request("carrier_accounts");
             return request.Execute<List<CarrierAccount>>();

--- a/EasyPost.Net/Report.cs
+++ b/EasyPost.Net/Report.cs
@@ -55,7 +55,7 @@ namespace EasyPost
         /// </param>
         /// <param name="type">The type of report, e.g. "shipment", "tracker", "payment_log", etc.</param>
         /// <returns>Instance of EasyPost.ScanForm.</returns>
-        public static ReportList List(string type, Dictionary<string, object> parameters = null)
+        public static ReportList All(string type, Dictionary<string, object> parameters = null)
         {
             Request request = new Request("reports/{type}");
             request.AddUrlSegment("type", type);

--- a/EasyPost.Net/ReportList.cs
+++ b/EasyPost.Net/ReportList.cs
@@ -11,7 +11,7 @@ namespace EasyPost
         public string type { get; set; }
 
         /// <summary>
-        ///     Get the next page of reports based on the original parameters passed to ReportList.List().
+        ///     Get the next page of reports based on the original parameters passed to ReportList.All().
         /// </summary>
         /// <returns>A new EasyPost.ScanFormList instance.</returns>
         public ReportList Next()
@@ -19,7 +19,7 @@ namespace EasyPost
             filters = filters ?? new Dictionary<string, object>();
             filters["before_id"] = reports.Last().id;
 
-            return Report.List(type, filters);
+            return Report.All(type, filters);
         }
     }
 }

--- a/EasyPost.Net/ScanForm.cs
+++ b/EasyPost.Net/ScanForm.cs
@@ -59,7 +59,7 @@ namespace EasyPost
         ///     All invalid keys will be ignored.
         /// </param>
         /// <returns>Instance of EasyPost.ScanForm.</returns>
-        public static ScanFormList List(Dictionary<string, object> parameters = null)
+        public static ScanFormList All(Dictionary<string, object> parameters = null)
         {
             Request request = new Request("scan_forms");
             request.AddQueryString(parameters ?? new Dictionary<string, object>());

--- a/EasyPost.Net/ScanFormList.cs
+++ b/EasyPost.Net/ScanFormList.cs
@@ -10,7 +10,7 @@ namespace EasyPost
         public List<ScanForm> scan_forms { get; set; }
 
         /// <summary>
-        ///     Get the next page of scan forms based on the original parameters passed to ScanForm.List().
+        ///     Get the next page of scan forms based on the original parameters passed to ScanForm.All().
         /// </summary>
         /// <returns>A new EasyPost.ScanFormList instance.</returns>
         public ScanFormList Next()
@@ -18,7 +18,7 @@ namespace EasyPost
             filters = filters ?? new Dictionary<string, object>();
             filters["before_id"] = scan_forms.Last().id;
 
-            return ScanForm.List(filters);
+            return ScanForm.All(filters);
         }
     }
 }

--- a/EasyPost.Net/Shipment.cs
+++ b/EasyPost.Net/Shipment.cs
@@ -282,7 +282,7 @@ namespace EasyPost
         ///     All invalid keys will be ignored.
         /// </param>
         /// <returns>Instance of EasyPost.ShipmentList.</returns>
-        public static ShipmentList List(Dictionary<string, object> parameters = null)
+        public static ShipmentList All(Dictionary<string, object> parameters = null)
         {
             Request request = new Request("shipments");
             request.AddQueryString(parameters ?? new Dictionary<string, object>());

--- a/EasyPost.Net/ShipmentList.cs
+++ b/EasyPost.Net/ShipmentList.cs
@@ -10,7 +10,7 @@ namespace EasyPost
         public List<Shipment> shipments { get; set; }
 
         /// <summary>
-        ///     Get the next page of shipments based on the original parameters passed to Shipment.List().
+        ///     Get the next page of shipments based on the original parameters passed to Shipment.All().
         /// </summary>
         /// <returns>A new EasyPost.ShipmentList instance.</returns>
         public ShipmentList Next()
@@ -18,7 +18,7 @@ namespace EasyPost
             filters = filters ?? new Dictionary<string, object>();
             filters["before_id"] = shipments.Last().id;
 
-            return Shipment.List(filters);
+            return Shipment.All(filters);
         }
     }
 }

--- a/EasyPost.Net/Tracker.cs
+++ b/EasyPost.Net/Tracker.cs
@@ -71,7 +71,7 @@ namespace EasyPost
         ///     All invalid keys will be ignored.
         /// </param>
         /// <returns>Instance of EasyPost.ShipmentList.</returns>
-        public static TrackerList List(Dictionary<string, object> parameters = null)
+        public static TrackerList All(Dictionary<string, object> parameters = null)
         {
             Request request = new Request("trackers");
             request.AddQueryString(parameters ?? new Dictionary<string, object>());

--- a/EasyPost.Net/TrackerList.cs
+++ b/EasyPost.Net/TrackerList.cs
@@ -10,7 +10,7 @@ namespace EasyPost
         public List<Tracker> trackers { get; set; }
 
         /// <summary>
-        ///     Get the next page of shipments based on the original parameters passed to Shipment.List().
+        ///     Get the next page of shipments based on the original parameters passed to Shipment.All().
         /// </summary>
         /// <returns>A new EasyPost.ShipmentList instance.</returns>
         public TrackerList Next()
@@ -18,7 +18,7 @@ namespace EasyPost
             filters = filters ?? new Dictionary<string, object>();
             filters["before_id"] = trackers.Last().id;
 
-            return Tracker.List(filters);
+            return Tracker.All(filters);
         }
     }
 }

--- a/EasyPost.Net/Webhook.cs
+++ b/EasyPost.Net/Webhook.cs
@@ -59,7 +59,7 @@ namespace EasyPost
         ///     Get a list of scan forms.
         /// </summary>
         /// <returns>List of EasyPost.Webhook instances.</returns>
-        public static List<Webhook> List(Dictionary<string, object> parameters = null)
+        public static List<Webhook> All(Dictionary<string, object> parameters = null)
         {
             Request request = new Request("webhooks");
 

--- a/EasyPost.NetFramework/CarrierAccount.cs
+++ b/EasyPost.NetFramework/CarrierAccount.cs
@@ -76,7 +76,7 @@ namespace EasyPost
         ///     List all available carrier accounts.
         /// </summary>
         /// <returns>A list of EasyPost.CarrierAccount instances.</returns>
-        public static List<CarrierAccount> List()
+        public static List<CarrierAccount> All()
         {
             Request request = new Request("carrier_accounts");
             return request.Execute<List<CarrierAccount>>();

--- a/EasyPost.NetFramework/Report.cs
+++ b/EasyPost.NetFramework/Report.cs
@@ -55,7 +55,7 @@ namespace EasyPost
         /// </param>
         /// <param name="type">The type of report, e.g. "shipment", "tracker", "payment_log", etc.</param>
         /// <returns>Instance of EasyPost.ScanForm.</returns>
-        public static ReportList List(string type, Dictionary<string, object> parameters = null)
+        public static ReportList All(string type, Dictionary<string, object> parameters = null)
         {
             Request request = new Request("reports/{type}");
             request.AddUrlSegment("type", type);

--- a/EasyPost.NetFramework/ReportList.cs
+++ b/EasyPost.NetFramework/ReportList.cs
@@ -11,7 +11,7 @@ namespace EasyPost
         public string type { get; set; }
 
         /// <summary>
-        ///     Get the next page of reports based on the original parameters passed to ReportList.List().
+        ///     Get the next page of reports based on the original parameters passed to ReportList.All().
         /// </summary>
         /// <returns>A new EasyPost.ScanFormList instance.</returns>
         public ReportList Next()
@@ -19,7 +19,7 @@ namespace EasyPost
             filters = filters ?? new Dictionary<string, object>();
             filters["before_id"] = reports.Last().id;
 
-            return Report.List(type, filters);
+            return Report.All(type, filters);
         }
     }
 }

--- a/EasyPost.NetFramework/ScanForm.cs
+++ b/EasyPost.NetFramework/ScanForm.cs
@@ -59,7 +59,7 @@ namespace EasyPost
         ///     All invalid keys will be ignored.
         /// </param>
         /// <returns>Instance of EasyPost.ScanForm.</returns>
-        public static ScanFormList List(Dictionary<string, object> parameters = null)
+        public static ScanFormList All(Dictionary<string, object> parameters = null)
         {
             Request request = new Request("scan_forms");
             request.AddQueryString(parameters ?? new Dictionary<string, object>());

--- a/EasyPost.NetFramework/ScanFormList.cs
+++ b/EasyPost.NetFramework/ScanFormList.cs
@@ -10,7 +10,7 @@ namespace EasyPost
         public List<ScanForm> scan_forms { get; set; }
 
         /// <summary>
-        ///     Get the next page of scan forms based on the original parameters passed to ScanForm.List().
+        ///     Get the next page of scan forms based on the original parameters passed to ScanForm.All().
         /// </summary>
         /// <returns>A new EasyPost.ScanFormList instance.</returns>
         public ScanFormList Next()
@@ -18,7 +18,7 @@ namespace EasyPost
             filters = filters ?? new Dictionary<string, object>();
             filters["before_id"] = scan_forms.Last().id;
 
-            return ScanForm.List(filters);
+            return ScanForm.All(filters);
         }
     }
 }

--- a/EasyPost.NetFramework/Shipment.cs
+++ b/EasyPost.NetFramework/Shipment.cs
@@ -282,7 +282,7 @@ namespace EasyPost
         ///     All invalid keys will be ignored.
         /// </param>
         /// <returns>Instance of EasyPost.ShipmentList.</returns>
-        public static ShipmentList List(Dictionary<string, object> parameters = null)
+        public static ShipmentList All(Dictionary<string, object> parameters = null)
         {
             Request request = new Request("shipments");
             request.AddQueryString(parameters ?? new Dictionary<string, object>());

--- a/EasyPost.NetFramework/ShipmentList.cs
+++ b/EasyPost.NetFramework/ShipmentList.cs
@@ -10,7 +10,7 @@ namespace EasyPost
         public List<Shipment> shipments { get; set; }
 
         /// <summary>
-        ///     Get the next page of shipments based on the original parameters passed to Shipment.List().
+        ///     Get the next page of shipments based on the original parameters passed to Shipment.All().
         /// </summary>
         /// <returns>A new EasyPost.ShipmentList instance.</returns>
         public ShipmentList Next()
@@ -18,7 +18,7 @@ namespace EasyPost
             filters = filters ?? new Dictionary<string, object>();
             filters["before_id"] = shipments.Last().id;
 
-            return Shipment.List(filters);
+            return Shipment.All(filters);
         }
     }
 }

--- a/EasyPost.NetFramework/Tracker.cs
+++ b/EasyPost.NetFramework/Tracker.cs
@@ -71,7 +71,7 @@ namespace EasyPost
         ///     All invalid keys will be ignored.
         /// </param>
         /// <returns>Instance of EasyPost.ShipmentList.</returns>
-        public static TrackerList List(Dictionary<string, object> parameters = null)
+        public static TrackerList All(Dictionary<string, object> parameters = null)
         {
             Request request = new Request("trackers");
             request.AddQueryString(parameters ?? new Dictionary<string, object>());

--- a/EasyPost.NetFramework/TrackerList.cs
+++ b/EasyPost.NetFramework/TrackerList.cs
@@ -10,7 +10,7 @@ namespace EasyPost
         public List<Tracker> trackers { get; set; }
 
         /// <summary>
-        ///     Get the next page of shipments based on the original parameters passed to Shipment.List().
+        ///     Get the next page of shipments based on the original parameters passed to Shipment.All().
         /// </summary>
         /// <returns>A new EasyPost.ShipmentList instance.</returns>
         public TrackerList Next()
@@ -18,7 +18,7 @@ namespace EasyPost
             filters = filters ?? new Dictionary<string, object>();
             filters["before_id"] = trackers.Last().id;
 
-            return Tracker.List(filters);
+            return Tracker.All(filters);
         }
     }
 }

--- a/EasyPost.NetFramework/Webhook.cs
+++ b/EasyPost.NetFramework/Webhook.cs
@@ -59,7 +59,7 @@ namespace EasyPost
         ///     Get a list of scan forms.
         /// </summary>
         /// <returns>List of EasyPost.Webhook instances.</returns>
-        public static List<Webhook> List(Dictionary<string, object> parameters = null)
+        public static List<Webhook> All(Dictionary<string, object> parameters = null)
         {
             Request request = new Request("webhooks");
 

--- a/EasyPost.Tests.Net/ApiKeyTest.cs
+++ b/EasyPost.Tests.Net/ApiKeyTest.cs
@@ -10,7 +10,7 @@ namespace EasyPost.Tests.Net
         public void Initialize() => ClientManager.SetCurrent("GxhY479LTioDWsGcEtSAfQ");
 
         [TestMethod]
-        public void TestList()
+        public void TestAll()
         {
             List<ApiKey> keys = ApiKey.All();
             Assert.AreEqual(keys.Count, 2);

--- a/EasyPost.Tests.Net/CarrierAccountTest.cs
+++ b/EasyPost.Tests.Net/CarrierAccountTest.cs
@@ -47,9 +47,9 @@ namespace EasyPost.Tests.Net
         }
 
         [TestMethod]
-        public void TestList()
+        public void TestAll()
         {
-            List<CarrierAccount> accounts = CarrierAccount.List();
+            List<CarrierAccount> accounts = CarrierAccount.All();
             Assert.AreEqual(accounts[0].id, "ca_7642d249fdcf47bcb5da9ea34c96dfcf");
         }
 

--- a/EasyPost.Tests.Net/ReportTest.cs
+++ b/EasyPost.Tests.Net/ReportTest.cs
@@ -25,9 +25,9 @@ namespace EasyPost.Tests.Net
         }
 
         [TestMethod]
-        public void TestList()
+        public void TestAll()
         {
-            ReportList reportList = Report.List("shipment", new Dictionary<string, object>
+            ReportList reportList = Report.All("shipment", new Dictionary<string, object>
             {
                 {
                     "page_size", 1

--- a/EasyPost.Tests.Net/ScanFormTest.cs
+++ b/EasyPost.Tests.Net/ScanFormTest.cs
@@ -26,7 +26,7 @@ namespace EasyPost.Tests.Net
                     "page_size", 1
                 }
             };
-            ScanFormList scanFormList = ScanForm.List(dict);
+            ScanFormList scanFormList = ScanForm.All(dict);
             Assert.AreNotEqual(null, scanFormList.scan_forms[0].batch_id);
             Assert.AreNotEqual(0, scanFormList.scan_forms.Count);
             ScanFormList nextScanFormList = scanFormList.Next();

--- a/EasyPost.Tests.Net/ShipmentTest.cs
+++ b/EasyPost.Tests.Net/ShipmentTest.cs
@@ -282,9 +282,9 @@ namespace EasyPost.Tests.Net
         }
 
         [TestMethod]
-        public void TestList()
+        public void TestAll()
         {
-            ShipmentList shipmentList = Shipment.List(new Dictionary<string, object>
+            ShipmentList shipmentList = Shipment.All(new Dictionary<string, object>
             {
                 {
                     "page_size", 1

--- a/EasyPost.Tests.Net/TrackerTest.cs
+++ b/EasyPost.Tests.Net/TrackerTest.cs
@@ -53,9 +53,9 @@ namespace EasyPost.Tests.Net
         }
 
         [TestMethod]
-        public void TestList()
+        public void TestAll()
         {
-            TrackerList trackerList = Tracker.List(new Dictionary<string, object>
+            TrackerList trackerList = Tracker.All(new Dictionary<string, object>
             {
                 {
                     "page_size", 1

--- a/EasyPost.Tests.Net/WebhookTest.cs
+++ b/EasyPost.Tests.Net/WebhookTest.cs
@@ -18,7 +18,7 @@
 
 //             webhook.Update();
 
-//             WebhookList webhooks = Webhook.List();
+//             WebhookList webhooks = Webhook.All();
 //             CollectionAssert.Contains(webhooks.Select(w => w.id).ToList(), webhook.id);
 
 //             webhook.Destroy();

--- a/EasyPost.Tests.NetFramework/ApiKeyTest.cs
+++ b/EasyPost.Tests.NetFramework/ApiKeyTest.cs
@@ -11,7 +11,7 @@ namespace EasyPost.Tests.Net
         public void Initialize() => ClientManager.SetCurrent("GxhY479LTioDWsGcEtSAfQ");
 
         [TestMethod]
-        public void TestList()
+        public void TestAll()
         {
             List<ApiKey> keys = ApiKey.All();
             Assert.AreEqual(keys.Count, 2);

--- a/EasyPost.Tests.NetFramework/CarrierAccountTest.cs
+++ b/EasyPost.Tests.NetFramework/CarrierAccountTest.cs
@@ -47,9 +47,9 @@ namespace EasyPost.Tests.Net
         }
 
         [TestMethod]
-        public void TestList()
+        public void TestAll()
         {
-            List<CarrierAccount> accounts = CarrierAccount.List();
+            List<CarrierAccount> accounts = CarrierAccount.All();
             Assert.AreEqual(accounts[0].id, "ca_7642d249fdcf47bcb5da9ea34c96dfcf");
         }
 

--- a/EasyPost.Tests.NetFramework/ReportTest.cs
+++ b/EasyPost.Tests.NetFramework/ReportTest.cs
@@ -25,9 +25,9 @@ namespace EasyPost.Tests.Net
         }
 
         [TestMethod]
-        public void TestList()
+        public void TestAll()
         {
-            ReportList reportList = Report.List("shipment", new Dictionary<string, object>
+            ReportList reportList = Report.All("shipment", new Dictionary<string, object>
             {
                 {
                     "page_size", 1

--- a/EasyPost.Tests.NetFramework/ScanFormTest.cs
+++ b/EasyPost.Tests.NetFramework/ScanFormTest.cs
@@ -26,7 +26,7 @@ namespace EasyPost.Tests.Net
                     "page_size", 1
                 }
             };
-            ScanFormList scanFormList = ScanForm.List(dict);
+            ScanFormList scanFormList = ScanForm.All(dict);
             Assert.AreNotEqual(null, scanFormList.scan_forms[0].batch_id);
             Assert.AreNotEqual(0, scanFormList.scan_forms.Count);
             ScanFormList nextScanFormList = scanFormList.Next();

--- a/EasyPost.Tests.NetFramework/ShipmentTest.cs
+++ b/EasyPost.Tests.NetFramework/ShipmentTest.cs
@@ -304,9 +304,9 @@ namespace EasyPost.Tests.Net
         }
 
         [TestMethod]
-        public void TestList()
+        public void TestAll()
         {
-            ShipmentList shipmentList = Shipment.List(new Dictionary<string, object>
+            ShipmentList shipmentList = Shipment.All(new Dictionary<string, object>
             {
                 {
                     "page_size", 1

--- a/EasyPost.Tests.NetFramework/TrackerTest.cs
+++ b/EasyPost.Tests.NetFramework/TrackerTest.cs
@@ -53,9 +53,9 @@ namespace EasyPost.Tests.Net
         }
 
         [TestMethod]
-        public void TestList()
+        public void TestAll()
         {
-            TrackerList trackerList = Tracker.List(new Dictionary<string, object>
+            TrackerList trackerList = Tracker.All(new Dictionary<string, object>
             {
                 {
                     "page_size", 1

--- a/EasyPost.Tests.NetFramework/WebhookTest.cs
+++ b/EasyPost.Tests.NetFramework/WebhookTest.cs
@@ -17,7 +17,7 @@
 
 //             webhook.Update();
 
-//             WebhookList webhooks = Webhook.List();
+//             WebhookList webhooks = Webhook.All();
 //             CollectionAssert.Contains(webhooks.Select(w => w.id).ToList(), webhook.id);
 
 //             webhook.Destroy();


### PR DESCRIPTION
Currently, our C# library C# library has inconsistent naming conventions on retrieving all records. Some are **All()** and some are **List()**. This PR renames the current method from **List()** to **All()** to make our C# more consistent. This is going to be a breaking change, this PR will be in draft mode until we are ready to make a major bump for C#.