### PR TITLE
Bump RestSharp to v107

### DIFF
--- a/EasyPost.Net/Address.cs
+++ b/EasyPost.Net/Address.cs
@@ -1,33 +1,57 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Address : Resource
     {
+        [JsonProperty("carrier_facility")]
         public string carrier_facility { get; set; }
+        [JsonProperty("city")]
         public string city { get; set; }
+        [JsonProperty("company")]
         public string company { get; set; }
+        [JsonProperty("country")]
         public string country { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("email")]
         public string email { get; set; }
+        [JsonProperty("error")]
         public string error { get; set; }
+        [JsonProperty("federal_tax_id")]
         public string federal_tax_id { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("message")]
         public string message { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("name")]
         public string name { get; set; }
+        [JsonProperty("phone")]
         public string phone { get; set; }
+        [JsonProperty("residential")]
         public bool? residential { get; set; }
+        [JsonProperty("state")]
         public string state { get; set; }
+        [JsonProperty("state_tax_id")]
         public string state_tax_id { get; set; }
+        [JsonProperty("street1")]
         public string street1 { get; set; }
+        [JsonProperty("street2")]
         public string street2 { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
+        [JsonProperty("verifications")]
         public Verifications verifications { get; set; }
+        [JsonProperty("verify")]
         public List<string> verify { get; set; }
+        [JsonProperty("verify_strict")]
         public List<string> verify_strict { get; set; }
+        [JsonProperty("zip")]
         public string zip { get; set; }
 
         /// <summary>
@@ -191,7 +215,7 @@ namespace EasyPost
         private static Address SendCreate(Dictionary<string, object> parameters, List<string> verifications = null,
             List<string> strictVerifications = null)
         {
-            Request request = new Request("addresses", Method.POST);
+            Request request = new Request("addresses", Method.Post);
             request.AddBody(new Dictionary<string, object>
             {
                 {

--- a/EasyPost.Net/AddressCollection.cs
+++ b/EasyPost.Net/AddressCollection.cs
@@ -1,10 +1,13 @@
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class AddressCollection : Resource
     {
+        [JsonProperty("addresses")]
         public List<Batch> addresses { get; set; }
+        [JsonProperty("has_more")]
         public bool has_more { get; set; }
     }
 }

--- a/EasyPost.Net/ApiKey.cs
+++ b/EasyPost.Net/ApiKey.cs
@@ -1,14 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class ApiKey : Resource
     {
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("key")]
         public string key { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
 
         /// <summary>
@@ -18,16 +20,11 @@ namespace EasyPost
         /// <exception cref="ResourceAlreadyCreated">Address already has an id.</exception>
         public static List<ApiKey> All()
         {
-            Request request = new Request("api_keys");
-            Dictionary<string, object> response = request.Execute<Dictionary<string, object>>();
-            List<object> keys = (List<object>)response["keys"];
-            foreach (Dictionary<string, object> key in keys)
+            Request request = new Request("api_keys")
             {
-                key["created_at"] = DateTime.ParseExact((string)key["created_at"], "yyyy-MM-ddTHH:mm:ssZ",
-                    CultureInfo.InvariantCulture);
-            }
-
-            return keys.Select(key => LoadFromDictionary<ApiKey>((Dictionary<string, object>)key)).ToList();
+                RootElement = "keys"
+            };
+            return request.Execute<List<ApiKey>>();
         }
     }
 }

--- a/EasyPost.Net/Batch.cs
+++ b/EasyPost.Net/Batch.cs
@@ -1,24 +1,38 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Batch : Resource
     {
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("error")]
         public string error { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("label_url")]
         public string label_url { get; set; }
+        [JsonProperty("message")]
         public string message { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("num_shipments")]
         public int num_shipments { get; set; }
+        [JsonProperty("reference")]
         public string reference { get; set; }
+        [JsonProperty("scan_form")]
         public ScanForm scan_form { get; set; }
+        [JsonProperty("shipments")]
         public List<BatchShipment> shipments { get; set; }
+        [JsonProperty("state")]
         public string state { get; set; }
+        [JsonProperty("status")]
         public Dictionary<string, int> status { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
 
         /// <summary>
@@ -27,7 +41,7 @@ namespace EasyPost
         /// <param name="shipmentIds">List of shipment ids to be added.</param>
         public void AddShipments(IEnumerable<string> shipmentIds)
         {
-            Request request = new Request("batches/{id}/add_shipments", Method.POST);
+            Request request = new Request("batches/{id}/add_shipments", Method.Post);
             request.AddUrlSegment("id", id);
 
             List<Dictionary<string, object>> lShipments = shipmentIds
@@ -58,7 +72,7 @@ namespace EasyPost
         /// </summary>
         public void Buy()
         {
-            Request request = new Request("batches/{id}/buy", Method.POST);
+            Request request = new Request("batches/{id}/buy", Method.Post);
             request.AddUrlSegment("id", id);
 
             Merge(request.Execute<Batch>());
@@ -70,7 +84,7 @@ namespace EasyPost
         /// <param name="fileFormat">Format to generate the label in. Valid formats: "pdf", "zpl" and "epl2".</param>
         public void GenerateLabel(string fileFormat)
         {
-            Request request = new Request("batches/{id}/label", Method.POST);
+            Request request = new Request("batches/{id}/label", Method.Post);
             request.AddUrlSegment("id", id);
 
             Dictionary<string, object> parameters = new Dictionary<string, object>
@@ -89,7 +103,7 @@ namespace EasyPost
         /// </summary>
         public void GenerateScanForm()
         {
-            Request request = new Request("batches/{id}/scan_form", Method.POST);
+            Request request = new Request("batches/{id}/scan_form", Method.Post);
             request.AddUrlSegment("id", id);
 
             Merge(request.Execute<Batch>());
@@ -101,7 +115,7 @@ namespace EasyPost
         /// <param name="shipmentIds">List of shipment ids to be removed.</param>
         public void RemoveShipments(IEnumerable<string> shipmentIds)
         {
-            Request request = new Request("batches/{id}/remove_shipments", Method.POST);
+            Request request = new Request("batches/{id}/remove_shipments", Method.Post);
             request.AddUrlSegment("id", id);
 
             List<Dictionary<string, object>> lShipments = shipmentIds
@@ -141,7 +155,7 @@ namespace EasyPost
         {
             parameters = parameters ?? new Dictionary<string, object>();
 
-            Request request = new Request("batches", Method.POST);
+            Request request = new Request("batches", Method.Post);
             request.AddBody(new Dictionary<string, object>
             {
                 {

--- a/EasyPost.Net/BatchCollection.cs
+++ b/EasyPost.Net/BatchCollection.cs
@@ -1,10 +1,13 @@
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class BatchCollection : Resource
     {
+        [JsonProperty("batches")]
         public List<Batch> batches { get; set; }
+        [JsonProperty("has_more")]
         public bool has_more { get; set; }
     }
 }

--- a/EasyPost.Net/BatchShipment.cs
+++ b/EasyPost.Net/BatchShipment.cs
@@ -1,10 +1,16 @@
-﻿namespace EasyPost
+﻿using Newtonsoft.Json;
+
+namespace EasyPost
 {
     public class BatchShipment : Resource
     {
+        [JsonProperty("batch_message")]
         public string batch_message { get; set; }
+        [JsonProperty("batch_status")]
         public string batch_status { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("tracking_code")]
         public string tracking_code { get; set; }
     }
 }

--- a/EasyPost.Net/Brand.cs
+++ b/EasyPost.Net/Brand.cs
@@ -1,15 +1,26 @@
+using Newtonsoft.Json;
+
 namespace EasyPost
 {
     public class Brand
     {
+        [JsonProperty("ad")]
         public string ad { get; set; }
+        [JsonProperty("ad_href")]
         public string ad_href { get; set; }
+        [JsonProperty("background_color")]
         public string background_color { get; set; }
+        [JsonProperty("color")]
         public string color { get; set; }
+        [JsonProperty("logo")]
         public string logo { get; set; }
+        [JsonProperty("logo_href")]
         public string logo_href { get; set; }
+        [JsonProperty("name")]
         public string name { get; set; }
+        [JsonProperty("theme")]
         public string theme { get; set; }
+        [JsonProperty("user_id")]
         public string user_id { get; set; }
     }
 }

--- a/EasyPost.Net/CarrierAccount.cs
+++ b/EasyPost.Net/CarrierAccount.cs
@@ -1,30 +1,41 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class CarrierAccount : Resource
     {
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("credentials")]
         public Dictionary<string, object> credentials { get; set; }
+        [JsonProperty("description")]
         public string description { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("readable")]
         public string readable { get; set; }
+        [JsonProperty("reference")]
         public string reference { get; set; }
+        [JsonProperty("test_credentials")]
         public Dictionary<string, object> test_credentials { get; set; }
+        [JsonProperty("type")]
         public string type { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
 
         /// <summary>
         ///     Remove this CarrierAccount from your account.
         /// </summary>
-        public void Destroy()
+        /// <returns>Whether the request was successful or not.</returns>
+        public bool Destroy()
         {
-            Request request = new Request("carrier_accounts/{id}", Method.DELETE);
+            Request request = new Request("carrier_accounts/{id}", Method.Delete);
             request.AddUrlSegment("id", id);
 
-            request.Execute();
+            return request.Execute();
         }
 
         /// <summary>
@@ -33,7 +44,7 @@ namespace EasyPost
         /// <param name="parameters">See CarrierAccount.Create for more details.</param>
         public void Update(Dictionary<string, object> parameters)
         {
-            Request request = new Request("carrier_accounts/{id}", Method.PUT);
+            Request request = new Request("carrier_accounts/{id}", Method.Put);
             request.AddUrlSegment("id", id);
             request.AddBody(new Dictionary<string, object>
             {
@@ -60,7 +71,7 @@ namespace EasyPost
         /// <returns>EasyPost.CarrierAccount instance.</returns>
         public static CarrierAccount Create(Dictionary<string, object> parameters)
         {
-            Request request = new Request("carrier_accounts", Method.POST);
+            Request request = new Request("carrier_accounts", Method.Post);
             request.AddBody(new Dictionary<string, object>
             {
                 {

--- a/EasyPost.Net/CarrierDetail.cs
+++ b/EasyPost.Net/CarrierDetail.cs
@@ -1,17 +1,27 @@
 ﻿using System;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class CarrierDetail
     {
+        [JsonProperty("alternate_identifier")]
         public string alternate_identifier { get; set; }
+        [JsonProperty("container_type")]
         public string container_type { get; set; }
+        [JsonProperty("destination_location")]
         public string destination_location { get; set; }
+        [JsonProperty("est_delivery_date_local")]
         public string est_delivery_date_local { get; set; }
+        [JsonProperty("est_delivery_time_local")]
         public string est_delivery_time_local { get; set; }
+        [JsonProperty("guaranteed_delivery_date")]
         public DateTime? guaranteed_delivery_date { get; set; }
+        [JsonProperty("initial_delivery_attempt")]
         public DateTime? initial_delivery_attempt { get; set; }
+        [JsonProperty("origin_location")]
         public string origin_location { get; set; }
+        [JsonProperty("service")]
         public string service { get; set; }
     }
 }

--- a/EasyPost.Net/CarrierType.cs
+++ b/EasyPost.Net/CarrierType.cs
@@ -1,12 +1,17 @@
 ﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class CarrierType : Resource
     {
+        [JsonProperty("fields")]
         public Dictionary<string, object> fields { get; set; }
+        [JsonProperty("logo")]
         public string logo { get; set; }
+        [JsonProperty("readable")]
         public string readable { get; set; }
+        [JsonProperty("type")]
         public string type { get; set; }
 
         /// <summary>

--- a/EasyPost.Net/CustomsInfo.cs
+++ b/EasyPost.Net/CustomsInfo.cs
@@ -1,23 +1,37 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class CustomsInfo : Resource
     {
+        [JsonProperty("contents_explanation")]
         public string contents_explanation { get; set; }
+        [JsonProperty("contents_type")]
         public string contents_type { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("customs_certify")]
         public string customs_certify { get; set; }
+        [JsonProperty("customs_items")]
         public List<CustomsItem> customs_items { get; set; }
+        [JsonProperty("customs_signer")]
         public string customs_signer { get; set; }
+        [JsonProperty("eel_pfc")]
         public string eel_pfc { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("non_delivery_option")]
         public string non_delivery_option { get; set; }
+        [JsonProperty("restriction_comments")]
         public string restriction_comments { get; set; }
+        [JsonProperty("restriction_type")]
         public string restriction_type { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
 
         /// <summary>
@@ -38,7 +52,7 @@ namespace EasyPost
         /// <returns>EasyPost.CustomsInfo instance.</returns>
         public static CustomsInfo Create(Dictionary<string, object> parameters)
         {
-            Request request = new Request("customs_infos", Method.POST);
+            Request request = new Request("customs_infos", Method.Post);
             request.AddBody(new Dictionary<string, object>
             {
                 {

--- a/EasyPost.Net/CustomsItem.cs
+++ b/EasyPost.Net/CustomsItem.cs
@@ -1,22 +1,35 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class CustomsItem : Resource
     {
+        [JsonProperty("code")]
         public string code { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("currency")]
         public string currency { get; set; }
+        [JsonProperty("description")]
         public string description { get; set; }
+        [JsonProperty("hs_tariff_number")]
         public string hs_tariff_number { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("origin_country")]
         public string origin_country { get; set; }
+        [JsonProperty("quantity")]
         public int quantity { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
-        public double value { get; set; }
+        [JsonProperty("value")]
+        public double? value { get; set; }
+        [JsonProperty("weight")]
         public double weight { get; set; }
 
         /// <summary>
@@ -35,7 +48,7 @@ namespace EasyPost
         /// <returns>EasyPost.CustomsItem instance.</returns>
         public static CustomsItem Create(Dictionary<string, object> parameters)
         {
-            Request request = new Request("customs_items", Method.POST);
+            Request request = new Request("customs_items", Method.Post);
             request.AddBody(new Dictionary<string, object>
             {
                 {

--- a/EasyPost.Net/EasyPost.Net.csproj
+++ b/EasyPost.Net/EasyPost.Net.csproj
@@ -2,12 +2,16 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>
     <RootNamespace>EasyPost</RootNamespace>
     <AssemblyName>EasyPost.Net</AssemblyName>
-    <Configurations>Release;Debug;Test</Configurations>
+    <Configurations>Release;Debug</Configurations>
     <Platforms>AnyCPU</Platforms>
     <PackageId>EasyPost.Net</PackageId>
+    <LangVersion>8.0</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -45,7 +49,8 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2"/>
-    <PackageReference Include="RestSharp" Version="106.15.0"/>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="RestSharp" Version="107.3.0" />
   </ItemGroup>
+
 </Project>

--- a/EasyPost.Net/Error.cs
+++ b/EasyPost.Net/Error.cs
@@ -5,10 +5,15 @@ namespace EasyPost
 {
     public class Error : Resource
     {
+        [JsonProperty("code")]
         public string code { get; set; }
+        [JsonProperty("errors")]
         public List<Error> errors { get; set; }
+        [JsonProperty("field")]
         public string field { get; set; }
+        [JsonProperty("message")]
         public string message { get; set; }
+        [JsonProperty("suggestion")]
         public string suggestion { get; set; }
 
         /// <summary>

--- a/EasyPost.Net/Event.cs
+++ b/EasyPost.Net/Event.cs
@@ -1,20 +1,31 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Event : Resource
     {
+        [JsonProperty("completed_urls")]
         public List<string> completed_urls { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("description")]
         public string description { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("pending_urls")]
         public List<string> pending_urls { get; set; }
+        [JsonProperty("previous_attributes")]
         public Dictionary<string, object> previous_attributes { get; set; }
+        [JsonProperty("result")]
         public Dictionary<string, object> result { get; set; }
+        [JsonProperty("status")]
         public string status { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
 
         /// <summary>
@@ -23,7 +34,7 @@ namespace EasyPost
         /// <param name="id">String representing an EasyPost object instance.</param>
         public static void Create(string id)
         {
-            Request request = new Request("events", Method.POST);
+            Request request = new Request("events", Method.Post);
             request.AddQueryString(new Dictionary<string, object>
             {
                 {

--- a/EasyPost.Net/EventCollection.cs
+++ b/EasyPost.Net/EventCollection.cs
@@ -1,10 +1,13 @@
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class EventCollection : Resource
     {
+        [JsonProperty("events")]
         public List<Event> events { get; set; }
+        [JsonProperty("has_more")]
         public bool has_more { get; set; }
     }
 }

--- a/EasyPost.Net/Fee.cs
+++ b/EasyPost.Net/Fee.cs
@@ -1,10 +1,16 @@
-﻿namespace EasyPost
+﻿using Newtonsoft.Json;
+
+namespace EasyPost
 {
     public class Fee : Resource
     {
+        [JsonProperty("amount")]
         public double amount { get; set; }
+        [JsonProperty("charged")]
         public bool charged { get; set; }
+        [JsonProperty("refunded")]
         public bool refunded { get; set; }
+        [JsonProperty("type")]
         public string type { get; set; }
     }
 }

--- a/EasyPost.Net/Form.cs
+++ b/EasyPost.Net/Form.cs
@@ -1,15 +1,23 @@
 ﻿using System;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class Form : Resource
     {
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("form_type")]
         public string form_type { get; set; }
+        [JsonProperty("form_url")]
         public string form_url { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("submitted_electronically")]
         public bool submitted_electronically { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
     }
 }

--- a/EasyPost.Net/Insurance.cs
+++ b/EasyPost.Net/Insurance.cs
@@ -1,22 +1,36 @@
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Insurance : Resource
     {
+        [JsonProperty("amount")]
         public string amount { get; set; }
+        [JsonProperty("from_address")]
         public Address from_address { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("messages")]
         public List<string> messages { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("provider")]
         public string provider { get; set; }
+        [JsonProperty("provider_id")]
         public string provider_id { get; set; }
+        [JsonProperty("reference")]
         public string reference { get; set; }
+        [JsonProperty("shipment_id")]
         public string shipment_id { get; set; }
+        [JsonProperty("status")]
         public string status { get; set; }
+        [JsonProperty("to_address")]
         public Address to_address { get; set; }
+        [JsonProperty("tracker")]
         public Tracker tracker { get; set; }
+        [JsonProperty("tracking_code")]
         public string tracking_code { get; set; }
 
         /// <summary>
@@ -76,7 +90,7 @@ namespace EasyPost
         /// <returns>EasyPost.Insurance instance.</returns>
         public static Insurance Create(Dictionary<string, object> parameters)
         {
-            Request request = new Request("insurances", Method.POST);
+            Request request = new Request("insurances", Method.Post);
             request.AddBody(new Dictionary<string, object>
             {
                 {
@@ -102,7 +116,7 @@ namespace EasyPost
 
         private static Insurance SendCreate(Dictionary<string, object> parameters)
         {
-            Request request = new Request("insurances", Method.POST);
+            Request request = new Request("insurances", Method.Post);
             request.AddBody(new Dictionary<string, object>
             {
                 {

--- a/EasyPost.Net/InsuranceCollection.cs
+++ b/EasyPost.Net/InsuranceCollection.cs
@@ -1,10 +1,13 @@
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class InsuranceCollection
     {
+        [JsonProperty("has_more")]
         public bool has_more { get; set; }
+        [JsonProperty("insurances")]
         public List<Insurance> insurances { get; set; }
     }
 }

--- a/EasyPost.Net/Message.cs
+++ b/EasyPost.Net/Message.cs
@@ -1,9 +1,14 @@
-﻿namespace EasyPost
+﻿using Newtonsoft.Json;
+
+namespace EasyPost
 {
     public class Message : Resource
     {
+        [JsonProperty("carrier")]
         public string carrier { get; set; }
+        [JsonProperty("message")]
         public string message { get; set; }
+        [JsonProperty("type")]
         public string type { get; set; }
     }
 }

--- a/EasyPost.Net/Options.cs
+++ b/EasyPost.Net/Options.cs
@@ -1,91 +1,174 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class Options : Resource
     {
+        [JsonProperty("additional_handling")]
         public bool? additional_handling { get; set; }
+        [JsonProperty("address_validation_level")]
         public string address_validation_level { get; set; }
+        [JsonProperty("alcohol")]
         public bool? alcohol { get; set; }
+        [JsonProperty("bill_receiver_account")]
         public string bill_receiver_account { get; set; }
+        [JsonProperty("bill_receiver_postal_code")]
         public string bill_receiver_postal_code { get; set; }
+        [JsonProperty("bill_third_party_account")]
         public string bill_third_party_account { get; set; }
+        [JsonProperty("bill_third_party_country")]
         public string bill_third_party_country { get; set; }
+        [JsonProperty("bill_third_party_postal_code")]
         public string bill_third_party_postal_code { get; set; }
+        [JsonProperty("by_drone")]
         public bool? by_drone { get; set; }
+        [JsonProperty("carbon_neutral")]
         public bool? carbon_neutral { get; set; }
+        [JsonProperty("carrier_insurance_amount")]
         public string carrier_insurance_amount { get; set; }
+        [JsonProperty("carrier_notification_email")]
         public string carrier_notification_email { get; set; }
+        [JsonProperty("carrier_notification_sms")]
         public string carrier_notification_sms { get; set; }
+        [JsonProperty("certified_mail")]
         public bool? certified_mail { get; set; }
+        [JsonProperty("cod_address_id")]
         public string cod_address_id { get; set; }
+        [JsonProperty("cod_amount")]
         public string cod_amount { get; set; }
+        [JsonProperty("cod_method")]
         public string cod_method { get; set; }
+        [JsonProperty("commercial_invoice_format")]
         public string commercial_invoice_format { get; set; }
+        [JsonProperty("commercial_invoice_letterhead")]
         public string commercial_invoice_letterhead { get; set; }
+        [JsonProperty("commercial_invoice_signature")]
         public string commercial_invoice_signature { get; set; }
+        [JsonProperty("commercial_invoice_size")]
         public string commercial_invoice_size { get; set; }
+        [JsonProperty("cost_center")]
         public string cost_center { get; set; }
+        [JsonProperty("currency")]
         public string currency { get; set; }
+        [JsonProperty("customs_broker_address_id")]
         public string customs_broker_address_id { get; set; }
+        [JsonProperty("customs_include_shipping")]
         public string customs_include_shipping { get; set; }
+        [JsonProperty("declared_value")]
         public double? declared_value { get; set; }
+        [JsonProperty("delivered_duty_paid")]
         public bool? delivered_duty_paid { get; set; }
+        [JsonProperty("delivery_confirmation")]
         public string delivery_confirmation { get; set; }
+        [JsonProperty("delivery_time_preference")]
         public string delivery_time_preference { get; set; }
+        [JsonProperty("dry_ice")]
         public bool? dry_ice { get; set; }
+        [JsonProperty("dry_ice_medical")]
         public string dry_ice_medical { get; set; }
+        [JsonProperty("dry_ice_weight")]
         public string dry_ice_weight { get; set; }
+        [JsonProperty("duty_payment_account")]
         public string duty_payment_account { get; set; }
+        [JsonProperty("endorsement")]
         public string endorsement { get; set; }
+        [JsonProperty("freight_charge")]
         public string freight_charge { get; set; }
+        [JsonProperty("group")]
         public string group { get; set; }
+        [JsonProperty("handling_instructions")]
         public string handling_instructions { get; set; }
+        [JsonProperty("hazmat")]
         public string hazmat { get; set; }
+        [JsonProperty("hold_for_pickup")]
         public bool? hold_for_pickup { get; set; }
+        [JsonProperty("image_format")]
         public string image_format { get; set; }
+        [JsonProperty("import_federal_tax_id")]
         public string import_federal_tax_id { get; set; }
+        [JsonProperty("import_state_tax_id")]
         public string import_state_tax_id { get; set; }
+        [JsonProperty("importer_address_id")]
         public string importer_address_id { get; set; }
+        [JsonProperty("incoterm")]
         public string incoterm { get; set; }
+        [JsonProperty("invoice_number")]
         public string invoice_number { get; set; }
+        [JsonProperty("label_date")]
         public DateTime? label_date { get; set; }
+        [JsonProperty("label_format")]
         public string label_format { get; set; }
+        [JsonProperty("label_size")]
         public string label_size { get; set; }
+        [JsonProperty("license_number")]
         public string license_number { get; set; }
+        [JsonProperty("machinable")]
         public string machinable { get; set; }
+        [JsonProperty("neutral_delivery")]
         public bool? neutral_delivery { get; set; }
+        [JsonProperty("non_contact")]
         public bool? non_contract { get; set; }
+        [JsonProperty("overlabel_construct_code")]
         public string overlabel_construct_code { get; set; }
+        [JsonProperty("overlabel_construct_tracking_number")]
         public string overlabel_original_tracking_number { get; set; }
+        [JsonProperty("parties_to_transaction_are_related")]
         public string parties_to_transaction_are_related { get; set; }
+        [JsonProperty("payment")]
         public Dictionary<string, object> payment { get; set; }
+        [JsonProperty("peel_and_return")]
         public bool peel_and_return { get; set; }
+        [JsonProperty("pickup_min_datetime")]
         public DateTime? pickup_min_datetime { get; set; }
+        [JsonProperty("po_sort")]
         public string po_sort { get; set; }
+        [JsonProperty("postage_label_inline")]
         public bool? postage_label_inline { get; set; }
+        [JsonProperty("print_custom")]
         public List<Dictionary<string, object>> print_custom { get; set; }
+        [JsonProperty("print_custom_1")]
         public string print_custom_1 { get; set; }
+        [JsonProperty("print_custom_1_barcode")]
         public bool? print_custom_1_barcode { get; set; }
+        [JsonProperty("print_custom_1_code")]
         public string print_custom_1_code { get; set; }
+        [JsonProperty("print_custom_2")]
         public string print_custom_2 { get; set; }
+        [JsonProperty("print_custom_2_barcode")]
         public bool? print_custom_2_barcode { get; set; }
+        [JsonProperty("print_custom_2_code")]
         public string print_custom_2_code { get; set; }
+        [JsonProperty("print_custom_3")]
         public string print_custom_3 { get; set; }
+        [JsonProperty("print_custom_3_barcode")]
         public bool? print_custom_3_barcode { get; set; }
+        [JsonProperty("print_custom_3_code")]
         public string print_custom_3_code { get; set; }
+        [JsonProperty("print_rate")]
         public bool? print_rate { get; set; }
+        [JsonProperty("receiver_liquor_license")]
         public string receiver_liquor_license { get; set; }
+        [JsonProperty("registered_mail")]
         public bool? registered_mail { get; set; }
+        [JsonProperty("registered_mail_amount")]
         public double? registered_mail_amount { get; set; }
+        [JsonProperty("return_receipt")]
         public bool? return_receipt { get; set; }
+        [JsonProperty("return_service")]
         public string return_service { get; set; }
+        [JsonProperty("saturday_delivery")]
         public bool? saturday_delivery { get; set; }
+        [JsonProperty("settlement_method")]
         public string settlement_method { get; set; }
+        [JsonProperty("smartpost_hub")]
         public string smartpost_hub { get; set; }
+        [JsonProperty("smartpost_manifest")]
         public string smartpost_manifest { get; set; }
+        [JsonProperty("special_rates_eligibility")]
         public string special_rates_eligibility { get; set; }
+        [JsonProperty("suppress_etd")]
         public bool? suppress_etd { get; set; }
     }
 }

--- a/EasyPost.Net/Order.cs
+++ b/EasyPost.Net/Order.cs
@@ -1,26 +1,43 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Order : Resource
     {
+        [JsonProperty("buyer_address")]
         public Address buyer_address { get; set; }
+        [JsonProperty("carrier_accounts")]
         public List<CarrierAccount> carrier_accounts { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("customs_info")]
         public CustomsInfo customs_info { get; set; }
+        [JsonProperty("from_address")]
         public Address from_address { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("is_return")]
         public bool? is_return { get; set; }
+        [JsonProperty("messages")]
         public List<Message> messages { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("rates")]
         public List<Rate> rates { get; set; }
+        [JsonProperty("reference")]
         public string reference { get; set; }
+        [JsonProperty("return_address")]
         public Address return_address { get; set; }
+        [JsonProperty("service")]
         public string service { get; set; }
+        [JsonProperty("shipments")]
         public List<Shipment> shipments { get; set; }
+        [JsonProperty("to_address")]
         public Address to_address { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
 
         /// <summary>
@@ -30,7 +47,7 @@ namespace EasyPost
         /// <param name="service">The service to purchase.</param>
         public void Buy(string carrier, string service)
         {
-            Request request = new Request("orders/{id}/buy", Method.POST);
+            Request request = new Request("orders/{id}/buy", Method.Post);
             request.AddUrlSegment("id", id);
             request.AddQueryString(new Dictionary<string, object>
             {
@@ -102,7 +119,7 @@ namespace EasyPost
         /// <returns>EasyPost.Order instance.</returns>
         public static Order Create(Dictionary<string, object> parameters)
         {
-            Request request = new Request("orders", Method.POST);
+            Request request = new Request("orders", Method.Post);
             request.AddBody(new Dictionary<string, object>
             {
                 {
@@ -129,7 +146,7 @@ namespace EasyPost
 
         private static Order SendCreate(Dictionary<string, object> parameters)
         {
-            Request request = new Request("orders", Method.POST);
+            Request request = new Request("orders", Method.Post);
             request.AddBody(new Dictionary<string, object>
             {
                 {

--- a/EasyPost.Net/Parcel.cs
+++ b/EasyPost.Net/Parcel.cs
@@ -1,19 +1,29 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Parcel : Resource
     {
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("height")]
         public double? height { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("length")]
         public double? length { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("predefined_package")]
         public string predefined_package { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
+        [JsonProperty("weight")]
         public double weight { get; set; }
+        [JsonProperty("width")]
         public double? width { get; set; }
 
         /// <summary>
@@ -31,7 +41,7 @@ namespace EasyPost
         /// <returns>EasyPost.Parcel instance.</returns>
         public static Parcel Create(Dictionary<string, object> parameters)
         {
-            Request request = new Request("parcels", Method.POST);
+            Request request = new Request("parcels", Method.Post);
             request.AddBody(new Dictionary<string, object>
             {
                 {

--- a/EasyPost.Net/Pickup.cs
+++ b/EasyPost.Net/Pickup.cs
@@ -1,26 +1,43 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Pickup : Resource
     {
+        [JsonProperty("address")]
         public Address address { get; set; }
+        [JsonProperty("carrier_accounts")]
         public List<CarrierAccount> carrier_accounts { get; set; }
+        [JsonProperty("confirmation")]
         public string confirmation { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("instructions")]
         public string instructions { get; set; }
+        [JsonProperty("is_account_address")]
         public bool is_account_address { get; set; }
+        [JsonProperty("max_datetime")]
         public DateTime max_datetime { get; set; }
+        [JsonProperty("messages")]
         public List<string> messages { get; set; }
+        [JsonProperty("min_datetime")]
         public DateTime min_datetime { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("name")]
         public string name { get; set; }
+        [JsonProperty("pickup_rates")]
         public List<Rate> pickup_rates { get; set; }
+        [JsonProperty("reference")]
         public string reference { get; set; }
+        [JsonProperty("status")]
         public string status { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
 
         /// <summary>
@@ -30,7 +47,7 @@ namespace EasyPost
         /// <param name="service">The name of the service to purchase.</param>
         public void Buy(string carrier, string service)
         {
-            Request request = new Request("pickups/{id}/buy", Method.POST);
+            Request request = new Request("pickups/{id}/buy", Method.Post);
             request.AddUrlSegment("id", id);
             request.AddQueryString(new Dictionary<string, object>
             {
@@ -50,7 +67,7 @@ namespace EasyPost
         /// </summary>
         public void Cancel()
         {
-            Request request = new Request("pickups/{id}/cancel", Method.POST);
+            Request request = new Request("pickups/{id}/cancel", Method.Post);
             request.AddUrlSegment("id", id);
 
             Merge(request.Execute<Pickup>());
@@ -105,7 +122,7 @@ namespace EasyPost
 
         private static Pickup SendCreate(Dictionary<string, object> parameters)
         {
-            Request request = new Request("pickups", Method.POST);
+            Request request = new Request("pickups", Method.Post);
             request.AddBody(new Dictionary<string, object>
             {
                 {

--- a/EasyPost.Net/PostageLabel.cs
+++ b/EasyPost.Net/PostageLabel.cs
@@ -1,24 +1,41 @@
 ﻿using System;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class PostageLabel : Resource
     {
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("date_advance")]
         public int date_advance { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("integrated_form")]
         public string integrated_form { get; set; }
+        [JsonProperty("label_date")]
         public DateTime label_date { get; set; }
+        [JsonProperty("label_epl2_url")]
         public string label_epl2_url { get; set; }
+        [JsonProperty("label_file")]
         public string label_file { get; set; }
+        [JsonProperty("label_file_type")]
         public string label_file_type { get; set; }
+        [JsonProperty("label_pdf_url")]
         public string label_pdf_url { get; set; }
+        [JsonProperty("label_resolution")]
         public int label_resolution { get; set; }
+        [JsonProperty("label_size")]
         public string label_size { get; set; }
+        [JsonProperty("label_type")]
         public string label_type { get; set; }
+        [JsonProperty("label_url")]
         public string label_url { get; set; }
+        [JsonProperty("label_zpl_url")]
         public string label_zpl_url { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
     }
 }

--- a/EasyPost.Net/Rate.cs
+++ b/EasyPost.Net/Rate.cs
@@ -1,26 +1,45 @@
 ﻿using System;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class Rate : Resource
     {
+        [JsonProperty("carrier")]
         public string carrier { get; set; }
+        [JsonProperty("carrier_account_id")]
         public string carrier_account_id { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("currency")]
         public string currency { get; set; }
+        [JsonProperty("delivery_date")]
         public DateTime? delivery_date { get; set; }
+        [JsonProperty("delivery_date_guaranteed")]
         public bool delivery_date_guaranteed { get; set; }
+        [JsonProperty("delivery_days")]
         public int? delivery_days { get; set; }
+        [JsonProperty("est_delivery_days")]
         public int? est_delivery_days { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("list_currency")]
         public string list_currency { get; set; }
+        [JsonProperty("list_rate")]
         public string list_rate { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("rate")]
         public string rate { get; set; }
+        [JsonProperty("retail_currency")]
         public string retail_currency { get; set; }
+        [JsonProperty("retail_rate")]
         public string retail_rate { get; set; }
+        [JsonProperty("service")]
         public string service { get; set; }
+        [JsonProperty("shipment_id")]
         public string shipment_id { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
 
         /// <summary>

--- a/EasyPost.Net/Rating.cs
+++ b/EasyPost.Net/Rating.cs
@@ -1,14 +1,20 @@
 ﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Rating : Resource
     {
+        [JsonProperty("carrier_accounts")]
         public List<CarrierAccount> carrier_accounts { get; set; }
+        [JsonProperty("from_address")]
         public Address from_address { get; set; }
+        [JsonProperty("parcels")]
         public List<Parcel> parcels { get; set; }
+        [JsonProperty("ratings")]
         public List<object> ratings { get; set; }
+        [JsonProperty("to_address")]
         public Address to_address { get; set; }
 
         /// <summary>
@@ -25,7 +31,7 @@ namespace EasyPost
         /// <returns>EasyPost.Rating instance.</returns>
         public static Rating Create(Dictionary<string, object> parameters)
         {
-            Request request = new Request("rating/v1/rates", Method.POST);
+            Request request = new Request("rating/v1/rates", Method.Post);
             request.AddBody(parameters);
 
             return request.Execute<Rating>();

--- a/EasyPost.Net/Report.cs
+++ b/EasyPost.Net/Report.cs
@@ -1,20 +1,31 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Report : Resource
     {
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("end_date")]
         public DateTime? end_date { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("include_children")]
         public bool include_children { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("start_date")]
         public DateTime? start_date { get; set; }
+        [JsonProperty("status")]
         public string status { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
+        [JsonProperty("url")]
         public string url { get; set; }
+        [JsonProperty("url_expires_at")]
         public DateTime? url_expires_at { get; set; }
 
         /// <summary>
@@ -33,7 +44,7 @@ namespace EasyPost
         /// <returns>EasyPost.Report instance.</returns>
         public static Report Create(string type, Dictionary<string, object> parameters = null)
         {
-            Request request = new Request("reports/{type}", Method.POST);
+            Request request = new Request("reports/{type}", Method.Post);
             request.AddUrlSegment("type", type);
             request.AddQueryString(parameters ?? new Dictionary<string, object>());
 

--- a/EasyPost.Net/ReportList.cs
+++ b/EasyPost.Net/ReportList.cs
@@ -1,13 +1,18 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class ReportList
     {
+        [JsonProperty("filters")]
         public Dictionary<string, object> filters { get; set; }
+        [JsonProperty("has_more")]
         public bool has_more { get; set; }
+        [JsonProperty("reports")]
         public List<Report> reports { get; set; }
+        [JsonProperty("type")]
         public string type { get; set; }
 
         /// <summary>

--- a/EasyPost.Net/Request.cs
+++ b/EasyPost.Net/Request.cs
@@ -1,32 +1,27 @@
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using EasyPost.Utilities;
 using RestSharp;
+using RestSharp.Serializers;
 
 namespace EasyPost
 {
     public class Request
     {
-        internal RestRequest restRequest;
+        private readonly RestRequest _restRequest;
+        public string RootElement { get; set; }
 
-        [Obsolete]
-        public string RootElement
+        public Request(string iResource, Method method = Method.Get)
         {
-            get => restRequest.RootElement;
-            set => restRequest.RootElement = value;
-        }
-
-        public Request(string IResource, Method method = Method.GET)
-        {
-            restRequest = new RestRequest(IResource, method);
-            restRequest.AddHeader("Accept", "application/json");
+            _restRequest = new RestRequest(iResource, method);
+            _restRequest.AddHeader("Accept", "application/json");
         }
 
         /// <summary>
         ///     Add a body to the request.
         /// </summary>
         /// <param name="parameters">Dictionary of key-value pairs for creating request body.</param>
-        public void AddBody(Dictionary<string, object> parameters) => AddParameter("application/json", JsonConvert.SerializeObject(parameters), ParameterType.RequestBody);
+        public void AddBody(Dictionary<string, object> parameters) => _restRequest.AddStringBody(JsonSerialization.ConvertObjectToJson(parameters), ContentType.Json);
 
         /// <summary>
         ///     Add a parameter to the request.
@@ -34,7 +29,7 @@ namespace EasyPost
         /// <param name="name">Name of parameter.</param>
         /// <param name="value">Value of parameter.</param>
         /// <param name="type">Type of parameter.</param>
-        public void AddParameter(string name, string value, ParameterType type) => restRequest.AddParameter(name, value, type);
+        public void AddParameter(string name, string value, ParameterType type) => _restRequest.AddParameter(name, value, type);
 
         /// <summary>
         ///     Add a query string parameter to the request.
@@ -42,9 +37,9 @@ namespace EasyPost
         /// <param name="parameters">Dictionary of key-value pairs for creating URL query parameters.</param>
         public void AddQueryString(IDictionary<string, object> parameters)
         {
-            foreach (KeyValuePair<string, object> pair in parameters)
+            foreach ((string key, object value) in parameters)
             {
-                AddParameter(pair.Key, Convert.ToString(pair.Value), ParameterType.QueryString);
+                AddParameter(key, Convert.ToString(value), ParameterType.QueryString);
             }
         }
 
@@ -53,7 +48,7 @@ namespace EasyPost
         /// </summary>
         /// <param name="name">Name of segment.</param>
         /// <param name="value">Value of segment.</param>
-        public void AddUrlSegment(string name, string value) => restRequest.AddUrlSegment(name, value);
+        public void AddUrlSegment(string name, string value) => _restRequest.AddUrlSegment(name, value);
 
         /// <summary>
         ///     Execute the request.
@@ -63,19 +58,19 @@ namespace EasyPost
         public T Execute<T>() where T : new()
         {
             Client client = ClientManager.Build();
-            return client.Execute<T>(this);
+            return client.Execute<T>(this, RootElement);
         }
 
         /// <summary>
         ///     Execute the request.
         /// </summary>
-        /// <returns>An IRestResponse object instance.</returns>
-        public IRestResponse Execute()
+        /// <returns>Whether the request was successful or not.</returns>
+        public bool Execute()
         {
             Client client = ClientManager.Build();
             return client.Execute(this);
         }
 
-        public static explicit operator RestRequest(Request request) => request.restRequest;
+        public static explicit operator RestRequest(Request request) => request._restRequest;
     }
 }

--- a/EasyPost.Net/ScanForm.cs
+++ b/EasyPost.Net/ScanForm.cs
@@ -1,21 +1,33 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class ScanForm : Resource
     {
+        [JsonProperty("address")]
         public Address address { get; set; }
+        [JsonProperty("batch_id")]
         public string batch_id { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("form_file_type")]
         public string form_file_type { get; set; }
+        [JsonProperty("form_url")]
         public string form_url { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("message")]
         public string message { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("status")]
         public string status { get; set; }
+        [JsonProperty("tracking_codes")]
         public List<string> tracking_codes { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
 
         /// <summary>
@@ -32,7 +44,7 @@ namespace EasyPost
                 }
             };
 
-            Request request = new Request("scan_forms", Method.POST);
+            Request request = new Request("scan_forms", Method.Post);
             request.AddBody(new Dictionary<string, object>
             {
                 {

--- a/EasyPost.Net/ScanFormList.cs
+++ b/EasyPost.Net/ScanFormList.cs
@@ -1,12 +1,16 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class ScanFormList : Resource
     {
+        [JsonProperty("filters")]
         public Dictionary<string, object> filters { get; set; }
+        [JsonProperty("has_more")]
         public bool has_more { get; set; }
+        [JsonProperty("scan_forms")]
         public List<ScanForm> scan_forms { get; set; }
 
         /// <summary>

--- a/EasyPost.Net/Shipment.cs
+++ b/EasyPost.Net/Shipment.cs
@@ -1,44 +1,78 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Shipment : Resource
     {
+        [JsonProperty("batch_id")]
         public string batch_id { get; set; }
+        [JsonProperty("batch_message")]
         public string batch_message { get; set; }
+        [JsonProperty("batch_status")]
         public string batch_status { get; set; }
+        [JsonProperty("buyer_address")]
         public Address buyer_address { get; set; }
+        [JsonProperty("carrier_accounts")]
         public List<CarrierAccount> carrier_accounts { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("customs_info")]
         public CustomsInfo customs_info { get; set; }
+        [JsonProperty("fees")]
         public List<Fee> fees { get; set; }
+        [JsonProperty("forms")]
         public List<Form> forms { get; set; }
+        [JsonProperty("from_address")]
         public Address from_address { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("insurance")]
         public string insurance { get; set; }
+        [JsonProperty("is_return")]
         public bool? is_return { get; set; }
+        [JsonProperty("messages")]
         public List<Message> messages { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("options")]
         public Options options { get; set; }
+        [JsonProperty("order_id")]
         public string order_id { get; set; }
+        [JsonProperty("parcel")]
         public Parcel parcel { get; set; }
+        [JsonProperty("postage_label")]
         public PostageLabel postage_label { get; set; }
+        [JsonProperty("rates")]
         public List<Rate> rates { get; set; }
+        [JsonProperty("reference")]
         public string reference { get; set; }
+        [JsonProperty("refund_status")]
         public string refund_status { get; set; }
+        [JsonProperty("return_address")]
         public Address return_address { get; set; }
+        [JsonProperty("scan_form")]
         public ScanForm scan_form { get; set; }
+        [JsonProperty("selected_rate")]
         public Rate selected_rate { get; set; }
+        [JsonProperty("service")]
         public string service { get; set; }
+        [JsonProperty("status")]
         public string status { get; set; }
+        [JsonProperty("tax_identifiers")]
         public List<TaxIdentifier> tax_identifiers { get; set; }
+        [JsonProperty("to_address")]
         public Address to_address { get; set; }
+        [JsonProperty("tracker")]
         public Tracker tracker { get; set; }
+        [JsonProperty("tracking_code")]
         public string tracking_code { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
+        [JsonProperty("usps_zone")]
         public string usps_zone { get; set; }
 
         /// <summary>
@@ -48,7 +82,7 @@ namespace EasyPost
         /// <param name="insuranceValue">The value to insure the shipment for.</param>
         public void Buy(string rateId, string insuranceValue = null)
         {
-            Request request = new Request("shipments/{id}/buy", Method.POST);
+            Request request = new Request("shipments/{id}/buy", Method.Post);
             request.AddUrlSegment("id", id);
 
             Dictionary<string, object> body =
@@ -145,7 +179,7 @@ namespace EasyPost
                 Create();
             }
 
-            Request request = new Request("shipments/{id}/rerate", Method.POST);
+            Request request = new Request("shipments/{id}/rerate", Method.Post);
             request.AddUrlSegment("id", id);
             if (parameters != null)
             {
@@ -179,7 +213,7 @@ namespace EasyPost
         /// <param name="amount">The amount to insure the shipment for. Currency is provided when creating a shipment.</param>
         public void Insure(double amount)
         {
-            Request request = new Request("shipments/{id}/insure", Method.POST);
+            Request request = new Request("shipments/{id}/insure", Method.Post);
             request.AddUrlSegment("id", id);
             request.AddQueryString(new Dictionary<string, object>
             {
@@ -309,7 +343,7 @@ namespace EasyPost
 
         private static Shipment SendCreate(Dictionary<string, object> parameters)
         {
-            Request request = new Request("shipments", Method.POST);
+            Request request = new Request("shipments", Method.Post);
             request.AddBody(new Dictionary<string, object>
             {
                 {

--- a/EasyPost.Net/ShipmentList.cs
+++ b/EasyPost.Net/ShipmentList.cs
@@ -1,12 +1,16 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class ShipmentList : Resource
     {
+        [JsonProperty("filters")]
         public Dictionary<string, object> filters { get; set; }
+        [JsonProperty("has_more")]
         public bool has_more { get; set; }
+        [JsonProperty("shipments")]
         public List<Shipment> shipments { get; set; }
 
         /// <summary>

--- a/EasyPost.Net/Smartrate.cs
+++ b/EasyPost.Net/Smartrate.cs
@@ -1,33 +1,54 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class SmartrateResult : Resource
     {
+        [JsonProperty("result")]
         public List<Smartrate> result { get; set; }
     }
 
     public class Smartrate : Resource
     {
+        [JsonProperty("carrier")]
         public string carrier { get; set; }
+        [JsonProperty("carrier_account_id")]
         public string carrier_account_id { get; set; }
+        [JsonProperty("created_at")]
         public DateTime created_at { get; set; }
+        [JsonProperty("currency")]
         public string currency { get; set; }
+        [JsonProperty("delivery_date")]
         public DateTime? delivery_date { get; set; }
+        [JsonProperty("delivery_date_guaranteed")]
         public bool delivery_date_guaranteed { get; set; }
+        [JsonProperty("delivery_days")]
         public int? delivery_days { get; set; }
+        [JsonProperty("est_delivery_days")]
         public int? est_delivery_days { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("list_currency")]
         public string list_currency { get; set; }
+        [JsonProperty("list_rate")]
         public double list_rate { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("rate")]
         public double rate { get; set; }
+        [JsonProperty("retail_currency")]
         public string retail_currency { get; set; }
+        [JsonProperty("retail_rate")]
         public double retail_rate { get; set; }
+        [JsonProperty("service")]
         public string service { get; set; }
+        [JsonProperty("shipment_id")]
         public string shipment_id { get; set; }
+        [JsonProperty("time_in_transit")]
         public TimeInTransit time_in_transit { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime updated_at { get; set; }
     }
 }

--- a/EasyPost.Net/TaxIdentifier.cs
+++ b/EasyPost.Net/TaxIdentifier.cs
@@ -1,10 +1,16 @@
-﻿namespace EasyPost
+﻿using Newtonsoft.Json;
+
+namespace EasyPost
 {
     public class TaxIdentifier
     {
+        [JsonProperty("entity")]
         public string entity { get; set; }
+        [JsonProperty("issuing_country")]
         public string issuing_country { get; set; }
+        [JsonProperty("tax_id")]
         public string tax_id { get; set; }
+        [JsonProperty("tax_id_type")]
         public string tax_id_type { get; set; }
     }
 }

--- a/EasyPost.Net/TimeInTransit.cs
+++ b/EasyPost.Net/TimeInTransit.cs
@@ -1,13 +1,22 @@
-﻿namespace EasyPost
+﻿using Newtonsoft.Json;
+
+namespace EasyPost
 {
     public class TimeInTransit
     {
+        [JsonProperty("percentile_50")]
         public int? percentile_50 { get; set; }
+        [JsonProperty("percentile_75")]
         public int? percentile_75 { get; set; }
+        [JsonProperty("percentile_85")]
         public int? percentile_85 { get; set; }
+        [JsonProperty("percentile_90")]
         public int? percentile_90 { get; set; }
+        [JsonProperty("percentile_95")]
         public int? percentile_95 { get; set; }
+        [JsonProperty("percentile_97")]
         public int? percentile_97 { get; set; }
+        [JsonProperty("percentile_99")]
         public int? percentile_99 { get; set; }
     }
 }

--- a/EasyPost.Net/Tracker.cs
+++ b/EasyPost.Net/Tracker.cs
@@ -1,25 +1,41 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Tracker : Resource
     {
+        [JsonProperty("carrier")]
         public string carrier { get; set; }
+        [JsonProperty("carrier_detail")]
         public CarrierDetail carrier_detail { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("est_delivery_date")]
         public DateTime? est_delivery_date { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("public_url")]
         public string public_url { get; set; }
+        [JsonProperty("shipment_id")]
         public string shipment_id { get; set; }
+        [JsonProperty("signed_by")]
         public string signed_by { get; set; }
+        [JsonProperty("status")]
         public string status { get; set; }
+        [JsonProperty("tracking_code")]
         public string tracking_code { get; set; }
+        [JsonProperty("tracking_details")]
         public List<TrackingDetail> tracking_details { get; set; }
+        [JsonProperty("tracking_updated_at")]
         public DateTime tracking_updated_at { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
+        [JsonProperty("weight")]
         public double? weight { get; set; }
 
         /// <summary>
@@ -30,7 +46,7 @@ namespace EasyPost
         /// <returns>An EasyPost.Tracker instance.</returns>
         public static Tracker Create(string carrier, string trackingCode)
         {
-            Request request = new Request("trackers", Method.POST);
+            Request request = new Request("trackers", Method.Post);
             Dictionary<string, object> parameters = new Dictionary<string, object>
             {
                 {
@@ -101,7 +117,7 @@ namespace EasyPost
         /// <returns>True</returns>
         public static bool CreateList(Dictionary<string, object> parameters)
         {
-            Request request = new Request("trackers/create_list", RestSharp.Method.POST);
+            Request request = new Request("trackers/create_list", RestSharp.Method.Post);
             request.AddBody(new Dictionary<string, object>
             {
                 {

--- a/EasyPost.Net/TrackerList.cs
+++ b/EasyPost.Net/TrackerList.cs
@@ -1,12 +1,16 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class TrackerList
     {
+        [JsonProperty("filters")]
         public Dictionary<string, object> filters { get; set; }
+        [JsonProperty("has_more")]
         public bool has_more { get; set; }
+        [JsonProperty("trackers")]
         public List<Tracker> trackers { get; set; }
 
         /// <summary>

--- a/EasyPost.Net/TrackingDetail.cs
+++ b/EasyPost.Net/TrackingDetail.cs
@@ -1,12 +1,17 @@
 ﻿using System;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class TrackingDetail : Resource
     {
+        [JsonProperty("datetime")]
         public DateTime? datetime { get; set; }
+        [JsonProperty("message")]
         public string message { get; set; }
+        [JsonProperty("status")]
         public string status { get; set; }
+        [JsonProperty("tracking_location")]
         public TrackingLocation tracking_location { get; set; }
     }
 }

--- a/EasyPost.Net/TrackingLocation.cs
+++ b/EasyPost.Net/TrackingLocation.cs
@@ -1,14 +1,21 @@
 ﻿using System;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class TrackingLocation
     {
+        [JsonProperty("city")]
         public string city { get; set; }
+        [JsonProperty("country")]
         public string country { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("state")]
         public string state { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
+        [JsonProperty("zip")]
         public string zip { get; set; }
     }
 }

--- a/EasyPost.Net/User.cs
+++ b/EasyPost.Net/User.cs
@@ -1,36 +1,54 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class User : Resource
     {
+        [JsonProperty("api_keys")]
         public List<ApiKey> api_keys { get; set; }
+        [JsonProperty("balance")]
         public string balance { get; set; }
+        [JsonProperty("children")]
         public List<User> children { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("email")]
         public string email { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("name")]
         public string name { get; set; }
+        [JsonProperty("parent_id")]
         public string parent_id { get; set; }
+        [JsonProperty("password")]
         public string password { get; set; }
+        [JsonProperty("password_confirmation")]
         public string password_confirmation { get; set; }
+        [JsonProperty("phone_number")]
         public string phone_number { get; set; }
+        [JsonProperty("price_per_shipment")]
         public string price_per_shipment { get; set; }
+        [JsonProperty("recharge_amount")]
         public string recharge_amount { get; set; }
+        [JsonProperty("recharge_threshold")]
         public string recharge_threshold { get; set; }
+        [JsonProperty("secondary_recharge_amount")]
         public string secondary_recharge_amount { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
 
         /// <summary>
         ///     Delete the user.
         /// </summary>
-        public void Destroy()
+        /// <returns>Whether the request was successful or not.</returns>
+        public bool Destroy()
         {
-            Request request = new Request("users/{id}", Method.DELETE);
+            Request request = new Request("users/{id}", Method.Delete);
             request.AddUrlSegment("id", id);
-            request.Execute();
+            return request.Execute();
         }
 
         /// <summary>
@@ -50,7 +68,7 @@ namespace EasyPost
         /// </param>
         public void Update(Dictionary<string, object> parameters)
         {
-            Request request = new Request("users/{id}", Method.PUT);
+            Request request = new Request("users/{id}", Method.Put);
             request.AddUrlSegment("id", id);
             request.AddBody(new Dictionary<string, object>
             {
@@ -86,7 +104,7 @@ namespace EasyPost
                 }
             };
 
-            Request request = new Request("users/{id}/brand", Method.PUT);
+            Request request = new Request("users/{id}/brand", Method.Put);
             request.AddUrlSegment("id", id);
             request.AddBody(wrappedParameters);
 
@@ -104,7 +122,7 @@ namespace EasyPost
         /// <returns>EasyPost.User instance.</returns>
         public static User Create(Dictionary<string, object> parameters)
         {
-            Request request = new Request("users", Method.POST);
+            Request request = new Request("users", Method.Post);
             request.AddBody(new Dictionary<string, object>
             {
                 {

--- a/EasyPost.Net/Utilities/JsonSerialization.cs
+++ b/EasyPost.Net/Utilities/JsonSerialization.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using RestSharp;
+
+namespace EasyPost.Utilities
+{
+    /// <summary>
+    /// Instance of a JSON de/serializer with custom serialization settings
+    /// </summary>
+    public class JsonSerializer
+    {
+        private JsonSerializerSettings JsonSerializerSettings { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JsonSerializer"/> class.
+        /// </summary>
+        /// <param name="jsonSerializerSettings">Custom <see cref="Newtonsoft.Json.JsonSerializerSettings"/> to override default built-in settings.</param>
+        public JsonSerializer(JsonSerializerSettings? jsonSerializerSettings = null)
+        {
+            JsonSerializerSettings = jsonSerializerSettings ?? JsonSerialization.DefaultJsonSerializerSettings;
+        }
+
+        /// <summary>
+        /// Deserialize a JSON string into a dynamic object, using this instance's <see cref="JsonSerializerSettings"/>
+        /// </summary>
+        /// <param name="data">A string of JSON data</param>
+        /// <param name="rootElementKeys">List, in order, of sub-keys path to follow to deserialization starting position.</param>
+        /// <returns>A dynamic object</returns>
+        public dynamic ConvertJsonToObject(string data, List<string>? rootElementKeys = null) => JsonSerialization.ConvertJsonToObject(data, JsonSerializerSettings, rootElementKeys);
+
+        /// <summary>
+        /// Deserialize a JSON string into a T-type object, using this instance's <see cref="JsonSerializerSettings"/>
+        /// </summary>
+        /// <param name="data">A string of JSON data</param>
+        /// <param name="rootElementKeys">List, in order, of sub-keys path to follow to deserialization starting position.</param>
+        /// <typeparam name="T">Type of object to deserialize to</typeparam>
+        /// <returns>A T-type object</returns>
+        public T ConvertJsonToObject<T>(string data, List<string>? rootElementKeys = null) => JsonSerialization.ConvertJsonToObject<T>(data, JsonSerializerSettings, rootElementKeys);
+
+        /// <summary>
+        /// Deserialize data from a RestSharp.RestResponse into a dynamic object, using this instance's <see cref="JsonSerializerSettings"/>
+        /// </summary>
+        /// <param name="response">RestSharp.RestResponse object to extract data from.</param>
+        /// <param name="rootElementKeys">List, in order, of sub-keys path to follow to deserialization starting position.</param>
+        /// <returns>A dynamic object</returns>
+        public dynamic ConvertJsonToObject(RestResponse response, List<string>? rootElementKeys = null) => JsonSerialization.ConvertJsonToObject(response, JsonSerializerSettings, rootElementKeys);
+
+        /// <summary>
+        /// Deserialize data from a RestSharp.RestResponse into a T-type object, using this instance's <see cref="JsonSerializerSettings"/>
+        /// </summary>
+        /// <param name="response">RestSharp.RestResponse object to extract data from.</param>
+        /// <param name="rootElementKeys">List, in order, of sub-keys path to follow to deserialization starting position.</param>
+        /// <typeparam name="T">Type of object to deserialize to</typeparam>
+        /// <returns>A T-type object</returns>
+        public T ConvertJsonToObject<T>(RestResponse response, List<string>? rootElementKeys = null) => JsonSerialization.ConvertJsonToObject<T>(response, JsonSerializerSettings, rootElementKeys);
+
+        /// <summary>
+        /// Serialize an object into a JSON string, using this instance's <see cref="JsonSerializerSettings"/>
+        /// </summary>
+        /// <param name="data">An object to serialize into a string</param>
+        /// <returns>A string of JSON data</returns>
+        public string? ConvertObjectToJson(object data) => JsonSerialization.ConvertObjectToJson(data, JsonSerializerSettings);
+    }
+
+    /// <summary>
+    /// JSON de/serialization utilities
+    /// </summary>
+    public static class JsonSerialization
+    {
+        /// <summary>
+        /// The default <see cref="Newtonsoft.Json.JsonSerializerSettings"/> to use for de/serialization
+        /// </summary>
+        public static JsonSerializerSettings DefaultJsonSerializerSettings
+        {
+            get
+            {
+                return new JsonSerializerSettings
+                {
+                    NullValueHandling = NullValueHandling.Ignore,
+                    MissingMemberHandling = MissingMemberHandling.Ignore,
+                    DateFormatHandling = DateFormatHandling.IsoDateFormat,
+                    DateTimeZoneHandling = DateTimeZoneHandling.Utc
+                };
+            }
+        }
+
+        /// <summary>
+        /// Deserialize a JSON string into a dynamic object
+        /// </summary>
+        /// <param name="data">A string of JSON data</param>
+        /// <param name="jsonSerializerSettings">The <see cref="Newtonsoft.Json.JsonSerializerSettings"/> to use for deserialization. Defaults to <see cref="DefaultJsonSerializerSettings"/> if not provided.</param>
+        /// <param name="rootElementKeys">List, in order, of sub-keys path to follow to deserialization starting position.</param>
+        /// <returns>A dynamic object</returns>
+        public static dynamic ConvertJsonToObject(string? data, JsonSerializerSettings? jsonSerializerSettings = null, List<string>? rootElementKeys = null)
+        {
+            if (rootElementKeys != null && rootElementKeys.Any())
+            {
+                data = GoToRootElement(data, rootElementKeys);
+            }
+
+            return JsonConvert.DeserializeObject(data, jsonSerializerSettings ?? DefaultJsonSerializerSettings);
+        }
+
+        /// <summary>
+        /// Deserialize a JSON string into a T-type object
+        /// </summary>
+        /// <param name="data">A string of JSON data</param>
+        /// <param name="jsonSerializerSettings">The <see cref="Newtonsoft.Json.JsonSerializerSettings"/> to use for deserialization. Defaults to <see cref="DefaultJsonSerializerSettings"/> if not provided.</param>
+        /// <param name="rootElementKeys">List, in order, of sub-keys path to follow to deserialization starting position.</param>
+        /// <typeparam name="T">Type of object to deserialize to</typeparam>
+        /// <returns>A T-type object</returns>
+        public static T ConvertJsonToObject<T>(string? data, JsonSerializerSettings? jsonSerializerSettings = null, List<string>? rootElementKeys = null)
+        {
+            if (rootElementKeys != null && rootElementKeys.Any())
+            {
+                data = GoToRootElement(data, rootElementKeys);
+            }
+
+            try
+            {
+                return JsonConvert.DeserializeObject<T>(data, jsonSerializerSettings ?? DefaultJsonSerializerSettings);
+            }
+            catch (Exception)
+            {
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// Deserialize data from a RestSharp.RestResponse into a dynamic object, using this instance's <see cref="JsonSerializerSettings"/>
+        /// </summary>
+        /// <param name="response">RestSharp.RestResponse object to extract data from.</param>
+        /// <param name="jsonSerializerSettings">The <see cref="Newtonsoft.Json.JsonSerializerSettings"/> to use for deserialization. Defaults to <see cref="DefaultJsonSerializerSettings"/> if not provided.</param>
+        /// <param name="rootElementKeys">List, in order, of sub-keys path to follow to deserialization starting position.</param>
+        /// <returns>A dynamic object</returns>
+        public static dynamic ConvertJsonToObject(RestResponse response, JsonSerializerSettings? jsonSerializerSettings = null, List<string>? rootElementKeys = null) => ConvertJsonToObject(response.Content, jsonSerializerSettings, rootElementKeys);
+
+        /// <summary>
+        /// Deserialize data from a RestSharp.RestResponse into a T-type object, using this instance's <see cref="JsonSerializerSettings"/>
+        /// </summary>
+        /// <param name="response">RestSharp.RestResponse object to extract data from.</param>
+        /// <param name="jsonSerializerSettings">The <see cref="Newtonsoft.Json.JsonSerializerSettings"/> to use for deserialization. Defaults to <see cref="DefaultJsonSerializerSettings"/> if not provided.</param>
+        /// <param name="rootElementKeys">List, in order, of sub-keys path to follow to deserialization starting position.</param>
+        /// <typeparam name="T">Type of object to deserialize to</typeparam>
+        /// <returns>A T-type object</returns>
+        public static T ConvertJsonToObject<T>(RestResponse response, JsonSerializerSettings? jsonSerializerSettings = null, List<string>? rootElementKeys = null) => ConvertJsonToObject<T>(response.Content, jsonSerializerSettings, rootElementKeys);
+
+        /// <summary>
+        /// Serialize an object into a JSON string, using this instance's <see cref="JsonSerializerSettings"/>
+        /// </summary>
+        /// <param name="data">An object to serialize into a string</param>
+        /// <param name="jsonSerializerSettings">The <see cref="Newtonsoft.Json.JsonSerializerSettings"/> to use for serialization. Defaults to <see cref="DefaultJsonSerializerSettings"/> if not provided.</param>
+        /// <returns>A string of JSON data</returns>
+        public static string? ConvertObjectToJson(object data, JsonSerializerSettings? jsonSerializerSettings = null)
+        {
+            try
+            {
+                return JsonConvert.SerializeObject(data, jsonSerializerSettings ?? DefaultJsonSerializerSettings);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Venture through the root element keys to find the root element of the JSON string.
+        /// </summary>
+        /// <param name="data">A string of JSON data</param>
+        /// <param name="rootElementKeys">List, in order, of sub-keys path to follow to deserialization starting position.</param>
+        /// <returns>The value of the JSON sub-element key path</returns>
+        private static string? GoToRootElement(string? data, List<string> rootElementKeys)
+        {
+            dynamic json = JsonConvert.DeserializeObject(data);
+            try
+            {
+                rootElementKeys.ForEach(key => { json = json[key]; });
+                return json.ToString();
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/EasyPost.Net/Verification.cs
+++ b/EasyPost.Net/Verification.cs
@@ -1,11 +1,15 @@
 ﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class Verification : Resource
     {
-        public List<VerificationDetails> details { get; set; }
+        [JsonProperty("details")]
+        public VerificationDetails details { get; set; }
+        [JsonProperty("errors")]
         public List<Error> errors { get; set; }
+        [JsonProperty("success")]
         public bool success { get; set; }
     }
 }

--- a/EasyPost.Net/VerificationDetails.cs
+++ b/EasyPost.Net/VerificationDetails.cs
@@ -4,8 +4,11 @@ namespace EasyPost
 {
     public class VerificationDetails : Resource
     {
-        public string latitude { get; set; }
-        public string longitude { get; set; }
+        [JsonProperty("latitude")]
+        public float latitude { get; set; }
+        [JsonProperty("longitude")]
+        public float longitude { get; set; }
+        [JsonProperty("time_zone")]
         public string time_zone { get; set; }
 
         /// <summary>

--- a/EasyPost.Net/Verifications.cs
+++ b/EasyPost.Net/Verifications.cs
@@ -1,8 +1,12 @@
-﻿namespace EasyPost
+﻿using Newtonsoft.Json;
+
+namespace EasyPost
 {
     public class Verifications : Resource
     {
+        [JsonProperty("delivery")]
         public Verification delivery { get; set; }
+        [JsonProperty("zip4")]
         public Verification zip4 { get; set; }
     }
 }

--- a/EasyPost.Net/Webhook.cs
+++ b/EasyPost.Net/Webhook.cs
@@ -1,24 +1,30 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Webhook : Resource
     {
+        [JsonProperty("disabled_at")]
         public DateTime? disabled_at { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("url")]
         public string url { get; set; }
 
         /// <summary>
         ///     Delete this webhook.
         /// </summary>
-        public void Destroy()
+        /// <returns>Whether the request was successful or not.</returns>
+        public bool Destroy()
         {
-            Request request = new Request("webhooks/{id}", Method.DELETE);
+            Request request = new Request("webhooks/{id}", Method.Delete);
             request.AddUrlSegment("id", id);
-            request.Execute();
+            return request.Execute();
         }
 
         /// <summary>
@@ -26,7 +32,7 @@ namespace EasyPost
         /// </summary>
         public void Update()
         {
-            Request request = new Request("webhooks/{id}", Method.PUT);
+            Request request = new Request("webhooks/{id}", Method.Put);
             request.AddUrlSegment("id", id);
 
             Merge(request.Execute<Webhook>());
@@ -43,7 +49,7 @@ namespace EasyPost
         /// <returns>EasyPost.Webhook instance.</returns>
         public static Webhook Create(Dictionary<string, object> parameters)
         {
-            Request request = new Request("webhooks", Method.POST);
+            Request request = new Request("webhooks", Method.Post);
             request.AddBody(new Dictionary<string, object>
             {
                 {

--- a/EasyPost.Net/WebhookList.cs
+++ b/EasyPost.Net/WebhookList.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class WebhookList : Resource
     {
+        [JsonProperty("webhooks")]
         public List<Webhook> webhooks { get; set; }
     }
 }

--- a/EasyPost.NetFramework/Address.cs
+++ b/EasyPost.NetFramework/Address.cs
@@ -1,33 +1,57 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Address : Resource
     {
+        [JsonProperty("carrier_facility")]
         public string carrier_facility { get; set; }
+        [JsonProperty("city")]
         public string city { get; set; }
+        [JsonProperty("company")]
         public string company { get; set; }
+        [JsonProperty("country")]
         public string country { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("email")]
         public string email { get; set; }
+        [JsonProperty("error")]
         public string error { get; set; }
+        [JsonProperty("federal_tax_id")]
         public string federal_tax_id { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("message")]
         public string message { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("name")]
         public string name { get; set; }
+        [JsonProperty("phone")]
         public string phone { get; set; }
+        [JsonProperty("residential")]
         public bool? residential { get; set; }
+        [JsonProperty("state")]
         public string state { get; set; }
+        [JsonProperty("state_tax_id")]
         public string state_tax_id { get; set; }
+        [JsonProperty("street1")]
         public string street1 { get; set; }
+        [JsonProperty("street2")]
         public string street2 { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
+        [JsonProperty("verifications")]
         public Verifications verifications { get; set; }
+        [JsonProperty("verify")]
         public List<string> verify { get; set; }
+        [JsonProperty("verify_strict")]
         public List<string> verify_strict { get; set; }
+        [JsonProperty("zip")]
         public string zip { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/AddressCollection.cs
+++ b/EasyPost.NetFramework/AddressCollection.cs
@@ -1,10 +1,13 @@
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class AddressCollection : Resource
     {
+        [JsonProperty("addresses")]
         public List<Batch> addresses { get; set; }
+        [JsonProperty("has_more")]
         public bool has_more { get; set; }
     }
 }

--- a/EasyPost.NetFramework/ApiKey.cs
+++ b/EasyPost.NetFramework/ApiKey.cs
@@ -2,13 +2,17 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class ApiKey : Resource
     {
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("key")]
         public string key { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/Batch.cs
+++ b/EasyPost.NetFramework/Batch.cs
@@ -1,25 +1,40 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Batch : Resource
     {
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("error")]
         public string error { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("label_url")]
         public string label_url { get; set; }
+        [JsonProperty("message")]
         public string message { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("num_shipments")]
         public int num_shipments { get; set; }
+        [JsonProperty("reference")]
         public string reference { get; set; }
+        [JsonProperty("scan_form")]
         public ScanForm scan_form { get; set; }
+        [JsonProperty("shipments")]
         public List<BatchShipment> shipments { get; set; }
+        [JsonProperty("state")]
         public string state { get; set; }
+        [JsonProperty("status")]
         public Dictionary<string, int> status { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
+
 
         /// <summary>
         ///     Add shipments to this batch.

--- a/EasyPost.NetFramework/BatchCollection.cs
+++ b/EasyPost.NetFramework/BatchCollection.cs
@@ -1,10 +1,13 @@
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class BatchCollection : Resource
     {
+        [JsonProperty("batches")]
         public List<Batch> batches { get; set; }
+        [JsonProperty("has_more")]
         public bool has_more { get; set; }
     }
 }

--- a/EasyPost.NetFramework/BatchShipment.cs
+++ b/EasyPost.NetFramework/BatchShipment.cs
@@ -1,10 +1,16 @@
-﻿namespace EasyPost
+﻿using Newtonsoft.Json;
+
+namespace EasyPost
 {
     public class BatchShipment : Resource
     {
+        [JsonProperty("batch_message")]
         public string batch_message { get; set; }
+        [JsonProperty("batch_status")]
         public string batch_status { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("tracking_code")]
         public string tracking_code { get; set; }
     }
 }

--- a/EasyPost.NetFramework/Brand.cs
+++ b/EasyPost.NetFramework/Brand.cs
@@ -1,15 +1,26 @@
+using Newtonsoft.Json;
+
 namespace EasyPost
 {
     public class Brand
     {
+        [JsonProperty("ad")]
         public string ad { get; set; }
+        [JsonProperty("ad_href")]
         public string ad_href { get; set; }
+        [JsonProperty("background_color")]
         public string background_color { get; set; }
+        [JsonProperty("color")]
         public string color { get; set; }
+        [JsonProperty("logo")]
         public string logo { get; set; }
+        [JsonProperty("logo_href")]
         public string logo_href { get; set; }
+        [JsonProperty("name")]
         public string name { get; set; }
+        [JsonProperty("theme")]
         public string theme { get; set; }
+        [JsonProperty("user_id")]
         public string user_id { get; set; }
     }
 }

--- a/EasyPost.NetFramework/CarrierAccount.cs
+++ b/EasyPost.NetFramework/CarrierAccount.cs
@@ -1,19 +1,29 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class CarrierAccount : Resource
     {
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("credentials")]
         public Dictionary<string, object> credentials { get; set; }
+        [JsonProperty("description")]
         public string description { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("readable")]
         public string readable { get; set; }
+        [JsonProperty("reference")]
         public string reference { get; set; }
+        [JsonProperty("test_credentials")]
         public Dictionary<string, object> test_credentials { get; set; }
+        [JsonProperty("type")]
         public string type { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/CarrierDetail.cs
+++ b/EasyPost.NetFramework/CarrierDetail.cs
@@ -1,17 +1,27 @@
 ﻿using System;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class CarrierDetail
     {
+        [JsonProperty("alternate_identifier")]
         public string alternate_identifier { get; set; }
+        [JsonProperty("container_type")]
         public string container_type { get; set; }
+        [JsonProperty("destination_location")]
         public string destination_location { get; set; }
+        [JsonProperty("est_delivery_date_local")]
         public string est_delivery_date_local { get; set; }
+        [JsonProperty("est_delivery_time_local")]
         public string est_delivery_time_local { get; set; }
+        [JsonProperty("guaranteed_delivery_date")]
         public DateTime? guaranteed_delivery_date { get; set; }
+        [JsonProperty("initial_delivery_attempt")]
         public DateTime? initial_delivery_attempt { get; set; }
+        [JsonProperty("origin_location")]
         public string origin_location { get; set; }
+        [JsonProperty("service")]
         public string service { get; set; }
     }
 }

--- a/EasyPost.NetFramework/CarrierType.cs
+++ b/EasyPost.NetFramework/CarrierType.cs
@@ -1,12 +1,17 @@
 ﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class CarrierType : Resource
     {
+        [JsonProperty("fields")]
         public Dictionary<string, object> fields { get; set; }
+        [JsonProperty("logo")]
         public string logo { get; set; }
+        [JsonProperty("readable")]
         public string readable { get; set; }
+        [JsonProperty("type")]
         public string type { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/CustomsInfo.cs
+++ b/EasyPost.NetFramework/CustomsInfo.cs
@@ -1,23 +1,37 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class CustomsInfo : Resource
     {
+        [JsonProperty("contents_explanation")]
         public string contents_explanation { get; set; }
+        [JsonProperty("contents_type")]
         public string contents_type { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("customs_certify")]
         public string customs_certify { get; set; }
+        [JsonProperty("customs_items")]
         public List<CustomsItem> customs_items { get; set; }
+        [JsonProperty("customs_signer")]
         public string customs_signer { get; set; }
+        [JsonProperty("eel_pfc")]
         public string eel_pfc { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("non_delivery_option")]
         public string non_delivery_option { get; set; }
+        [JsonProperty("restriction_comments")]
         public string restriction_comments { get; set; }
+        [JsonProperty("restriction_type")]
         public string restriction_type { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/CustomsItem.cs
+++ b/EasyPost.NetFramework/CustomsItem.cs
@@ -1,22 +1,35 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class CustomsItem : Resource
     {
+        [JsonProperty("code")]
         public string code { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("currency")]
         public string currency { get; set; }
+        [JsonProperty("description")]
         public string description { get; set; }
+        [JsonProperty("hs_tariff_number")]
         public string hs_tariff_number { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("origin_country")]
         public string origin_country { get; set; }
+        [JsonProperty("quantity")]
         public int quantity { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
-        public double value { get; set; }
+        [JsonProperty("value")]
+        public double? value { get; set; }
+        [JsonProperty("weight")]
         public double weight { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/EasyPost.NetFramework.csproj
+++ b/EasyPost.NetFramework/EasyPost.NetFramework.csproj
@@ -9,10 +9,12 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EasyPost</RootNamespace>
     <AssemblyName>EasyPost.NetFramework</AssemblyName>
-    <Configurations>Release;Debug;Test</Configurations>
+    <Configurations>Release;Debug</Configurations>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <LangVersion>8.0</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/EasyPost.NetFramework/Error.cs
+++ b/EasyPost.NetFramework/Error.cs
@@ -5,10 +5,15 @@ namespace EasyPost
 {
     public class Error : Resource
     {
+        [JsonProperty("code")]
         public string code { get; set; }
+        [JsonProperty("errors")]
         public List<Error> errors { get; set; }
+        [JsonProperty("field")]
         public string field { get; set; }
+        [JsonProperty("message")]
         public string message { get; set; }
+        [JsonProperty("suggestion")]
         public string suggestion { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/Event.cs
+++ b/EasyPost.NetFramework/Event.cs
@@ -1,20 +1,31 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Event : Resource
     {
+        [JsonProperty("completed_urls")]
         public List<string> completed_urls { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("description")]
         public string description { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("pending_urls")]
         public List<string> pending_urls { get; set; }
+        [JsonProperty("previous_attributes")]
         public Dictionary<string, object> previous_attributes { get; set; }
+        [JsonProperty("result")]
         public Dictionary<string, object> result { get; set; }
+        [JsonProperty("status")]
         public string status { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/EventCollection.cs
+++ b/EasyPost.NetFramework/EventCollection.cs
@@ -1,10 +1,13 @@
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class EventCollection : Resource
     {
+        [JsonProperty("events")]
         public List<Event> events { get; set; }
+        [JsonProperty("has_more")]
         public bool has_more { get; set; }
     }
 }

--- a/EasyPost.NetFramework/Fee.cs
+++ b/EasyPost.NetFramework/Fee.cs
@@ -1,10 +1,16 @@
-﻿namespace EasyPost
+﻿using Newtonsoft.Json;
+
+namespace EasyPost
 {
     public class Fee : Resource
     {
+        [JsonProperty("amount")]
         public double amount { get; set; }
+        [JsonProperty("charged")]
         public bool charged { get; set; }
+        [JsonProperty("refunded")]
         public bool refunded { get; set; }
+        [JsonProperty("type")]
         public string type { get; set; }
     }
 }

--- a/EasyPost.NetFramework/Form.cs
+++ b/EasyPost.NetFramework/Form.cs
@@ -1,15 +1,23 @@
 ﻿using System;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class Form : Resource
     {
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("form_type")]
         public string form_type { get; set; }
+        [JsonProperty("form_url")]
         public string form_url { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("submitted_electronically")]
         public bool submitted_electronically { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
     }
 }

--- a/EasyPost.NetFramework/Insurance.cs
+++ b/EasyPost.NetFramework/Insurance.cs
@@ -1,22 +1,36 @@
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Insurance : Resource
     {
+        [JsonProperty("amount")]
         public string amount { get; set; }
+        [JsonProperty("from_address")]
         public Address from_address { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("messages")]
         public List<string> messages { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("provider")]
         public string provider { get; set; }
+        [JsonProperty("provider_id")]
         public string provider_id { get; set; }
+        [JsonProperty("reference")]
         public string reference { get; set; }
+        [JsonProperty("shipment_id")]
         public string shipment_id { get; set; }
+        [JsonProperty("status")]
         public string status { get; set; }
+        [JsonProperty("to_address")]
         public Address to_address { get; set; }
+        [JsonProperty("tracker")]
         public Tracker tracker { get; set; }
+        [JsonProperty("tracking_code")]
         public string tracking_code { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/InsuranceCollection.cs
+++ b/EasyPost.NetFramework/InsuranceCollection.cs
@@ -1,10 +1,13 @@
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class InsuranceCollection
     {
+        [JsonProperty("has_more")]
         public bool has_more { get; set; }
+        [JsonProperty("insurances")]
         public List<Insurance> insurances { get; set; }
     }
 }

--- a/EasyPost.NetFramework/Message.cs
+++ b/EasyPost.NetFramework/Message.cs
@@ -1,9 +1,14 @@
-﻿namespace EasyPost
+﻿using Newtonsoft.Json;
+
+namespace EasyPost
 {
     public class Message : Resource
     {
+        [JsonProperty("carrier")]
         public string carrier { get; set; }
+        [JsonProperty("message")]
         public string message { get; set; }
+        [JsonProperty("type")]
         public string type { get; set; }
     }
 }

--- a/EasyPost.NetFramework/Options.cs
+++ b/EasyPost.NetFramework/Options.cs
@@ -1,91 +1,174 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class Options : Resource
     {
+        [JsonProperty("additional_handling")]
         public bool? additional_handling { get; set; }
+        [JsonProperty("address_validation_level")]
         public string address_validation_level { get; set; }
+        [JsonProperty("alcohol")]
         public bool? alcohol { get; set; }
+        [JsonProperty("bill_receiver_account")]
         public string bill_receiver_account { get; set; }
+        [JsonProperty("bill_receiver_postal_code")]
         public string bill_receiver_postal_code { get; set; }
+        [JsonProperty("bill_third_party_account")]
         public string bill_third_party_account { get; set; }
+        [JsonProperty("bill_third_party_country")]
         public string bill_third_party_country { get; set; }
+        [JsonProperty("bill_third_party_postal_code")]
         public string bill_third_party_postal_code { get; set; }
+        [JsonProperty("by_drone")]
         public bool? by_drone { get; set; }
+        [JsonProperty("carbon_neutral")]
         public bool? carbon_neutral { get; set; }
+        [JsonProperty("carrier_insurance_amount")]
         public string carrier_insurance_amount { get; set; }
+        [JsonProperty("carrier_notification_email")]
         public string carrier_notification_email { get; set; }
+        [JsonProperty("carrier_notification_sms")]
         public string carrier_notification_sms { get; set; }
+        [JsonProperty("certified_mail")]
         public bool? certified_mail { get; set; }
+        [JsonProperty("cod_address_id")]
         public string cod_address_id { get; set; }
+        [JsonProperty("cod_amount")]
         public string cod_amount { get; set; }
+        [JsonProperty("cod_method")]
         public string cod_method { get; set; }
+        [JsonProperty("commercial_invoice_format")]
         public string commercial_invoice_format { get; set; }
+        [JsonProperty("commercial_invoice_letterhead")]
         public string commercial_invoice_letterhead { get; set; }
+        [JsonProperty("commercial_invoice_signature")]
         public string commercial_invoice_signature { get; set; }
+        [JsonProperty("commercial_invoice_size")]
         public string commercial_invoice_size { get; set; }
+        [JsonProperty("cost_center")]
         public string cost_center { get; set; }
+        [JsonProperty("currency")]
         public string currency { get; set; }
+        [JsonProperty("customs_broker_address_id")]
         public string customs_broker_address_id { get; set; }
+        [JsonProperty("customs_include_shipping")]
         public string customs_include_shipping { get; set; }
+        [JsonProperty("declared_value")]
         public double? declared_value { get; set; }
+        [JsonProperty("delivered_duty_paid")]
         public bool? delivered_duty_paid { get; set; }
+        [JsonProperty("delivery_confirmation")]
         public string delivery_confirmation { get; set; }
+        [JsonProperty("delivery_time_preference")]
         public string delivery_time_preference { get; set; }
+        [JsonProperty("dry_ice")]
         public bool? dry_ice { get; set; }
+        [JsonProperty("dry_ice_medical")]
         public string dry_ice_medical { get; set; }
+        [JsonProperty("dry_ice_weight")]
         public string dry_ice_weight { get; set; }
+        [JsonProperty("duty_payment_account")]
         public string duty_payment_account { get; set; }
+        [JsonProperty("endorsement")]
         public string endorsement { get; set; }
+        [JsonProperty("freight_charge")]
         public string freight_charge { get; set; }
+        [JsonProperty("group")]
         public string group { get; set; }
+        [JsonProperty("handling_instructions")]
         public string handling_instructions { get; set; }
+        [JsonProperty("hazmat")]
         public string hazmat { get; set; }
+        [JsonProperty("hold_for_pickup")]
         public bool? hold_for_pickup { get; set; }
+        [JsonProperty("image_format")]
         public string image_format { get; set; }
+        [JsonProperty("import_federal_tax_id")]
         public string import_federal_tax_id { get; set; }
+        [JsonProperty("import_state_tax_id")]
         public string import_state_tax_id { get; set; }
+        [JsonProperty("importer_address_id")]
         public string importer_address_id { get; set; }
+        [JsonProperty("incoterm")]
         public string incoterm { get; set; }
+        [JsonProperty("invoice_number")]
         public string invoice_number { get; set; }
+        [JsonProperty("label_date")]
         public DateTime? label_date { get; set; }
+        [JsonProperty("label_format")]
         public string label_format { get; set; }
+        [JsonProperty("label_size")]
         public string label_size { get; set; }
+        [JsonProperty("license_number")]
         public string license_number { get; set; }
+        [JsonProperty("machinable")]
         public string machinable { get; set; }
+        [JsonProperty("neutral_delivery")]
         public bool? neutral_delivery { get; set; }
+        [JsonProperty("non_contact")]
         public bool? non_contract { get; set; }
+        [JsonProperty("overlabel_construct_code")]
         public string overlabel_construct_code { get; set; }
+        [JsonProperty("overlabel_construct_tracking_number")]
         public string overlabel_original_tracking_number { get; set; }
+        [JsonProperty("parties_to_transaction_are_related")]
         public string parties_to_transaction_are_related { get; set; }
+        [JsonProperty("payment")]
         public Dictionary<string, object> payment { get; set; }
+        [JsonProperty("peel_and_return")]
         public bool peel_and_return { get; set; }
+        [JsonProperty("pickup_min_datetime")]
         public DateTime? pickup_min_datetime { get; set; }
+        [JsonProperty("po_sort")]
         public string po_sort { get; set; }
+        [JsonProperty("postage_label_inline")]
         public bool? postage_label_inline { get; set; }
+        [JsonProperty("print_custom")]
         public List<Dictionary<string, object>> print_custom { get; set; }
+        [JsonProperty("print_custom_1")]
         public string print_custom_1 { get; set; }
+        [JsonProperty("print_custom_1_barcode")]
         public bool? print_custom_1_barcode { get; set; }
+        [JsonProperty("print_custom_1_code")]
         public string print_custom_1_code { get; set; }
+        [JsonProperty("print_custom_2")]
         public string print_custom_2 { get; set; }
+        [JsonProperty("print_custom_2_barcode")]
         public bool? print_custom_2_barcode { get; set; }
+        [JsonProperty("print_custom_2_code")]
         public string print_custom_2_code { get; set; }
+        [JsonProperty("print_custom_3")]
         public string print_custom_3 { get; set; }
+        [JsonProperty("print_custom_3_barcode")]
         public bool? print_custom_3_barcode { get; set; }
+        [JsonProperty("print_custom_3_code")]
         public string print_custom_3_code { get; set; }
+        [JsonProperty("print_rate")]
         public bool? print_rate { get; set; }
+        [JsonProperty("receiver_liquor_license")]
         public string receiver_liquor_license { get; set; }
+        [JsonProperty("registered_mail")]
         public bool? registered_mail { get; set; }
+        [JsonProperty("registered_mail_amount")]
         public double? registered_mail_amount { get; set; }
+        [JsonProperty("return_receipt")]
         public bool? return_receipt { get; set; }
+        [JsonProperty("return_service")]
         public string return_service { get; set; }
+        [JsonProperty("saturday_delivery")]
         public bool? saturday_delivery { get; set; }
+        [JsonProperty("settlement_method")]
         public string settlement_method { get; set; }
+        [JsonProperty("smartpost_hub")]
         public string smartpost_hub { get; set; }
+        [JsonProperty("smartpost_manifest")]
         public string smartpost_manifest { get; set; }
+        [JsonProperty("special_rates_eligibility")]
         public string special_rates_eligibility { get; set; }
+        [JsonProperty("suppress_etd")]
         public bool? suppress_etd { get; set; }
     }
 }

--- a/EasyPost.NetFramework/Order.cs
+++ b/EasyPost.NetFramework/Order.cs
@@ -1,26 +1,43 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Order : Resource
     {
+        [JsonProperty("buyer_address")]
         public Address buyer_address { get; set; }
+        [JsonProperty("carrier_accounts")]
         public List<CarrierAccount> carrier_accounts { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("customs_info")]
         public CustomsInfo customs_info { get; set; }
+        [JsonProperty("from_address")]
         public Address from_address { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("is_return")]
         public bool? is_return { get; set; }
+        [JsonProperty("messages")]
         public List<Message> messages { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("rates")]
         public List<Rate> rates { get; set; }
+        [JsonProperty("reference")]
         public string reference { get; set; }
+        [JsonProperty("return_address")]
         public Address return_address { get; set; }
+        [JsonProperty("service")]
         public string service { get; set; }
+        [JsonProperty("shipments")]
         public List<Shipment> shipments { get; set; }
+        [JsonProperty("to_address")]
         public Address to_address { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/Parcel.cs
+++ b/EasyPost.NetFramework/Parcel.cs
@@ -1,19 +1,29 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Parcel : Resource
     {
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("height")]
         public double? height { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("length")]
         public double? length { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("predefined_package")]
         public string predefined_package { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
+        [JsonProperty("weight")]
         public double weight { get; set; }
+        [JsonProperty("width")]
         public double? width { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/Pickup.cs
+++ b/EasyPost.NetFramework/Pickup.cs
@@ -1,26 +1,43 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Pickup : Resource
     {
+        [JsonProperty("address")]
         public Address address { get; set; }
+        [JsonProperty("carrier_accounts")]
         public List<CarrierAccount> carrier_accounts { get; set; }
+        [JsonProperty("confirmation")]
         public string confirmation { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("instructions")]
         public string instructions { get; set; }
+        [JsonProperty("is_account_address")]
         public bool is_account_address { get; set; }
+        [JsonProperty("max_datetime")]
         public DateTime max_datetime { get; set; }
+        [JsonProperty("messages")]
         public List<string> messages { get; set; }
+        [JsonProperty("min_datetime")]
         public DateTime min_datetime { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("name")]
         public string name { get; set; }
+        [JsonProperty("pickup_rates")]
         public List<Rate> pickup_rates { get; set; }
+        [JsonProperty("reference")]
         public string reference { get; set; }
+        [JsonProperty("status")]
         public string status { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/PostageLabel.cs
+++ b/EasyPost.NetFramework/PostageLabel.cs
@@ -1,24 +1,41 @@
 ﻿using System;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class PostageLabel : Resource
     {
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("date_advance")]
         public int date_advance { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("integrated_form")]
         public string integrated_form { get; set; }
+        [JsonProperty("label_date")]
         public DateTime label_date { get; set; }
+        [JsonProperty("label_epl2_url")]
         public string label_epl2_url { get; set; }
+        [JsonProperty("label_file")]
         public string label_file { get; set; }
+        [JsonProperty("label_file_type")]
         public string label_file_type { get; set; }
+        [JsonProperty("label_pdf_url")]
         public string label_pdf_url { get; set; }
+        [JsonProperty("label_resolution")]
         public int label_resolution { get; set; }
+        [JsonProperty("label_size")]
         public string label_size { get; set; }
+        [JsonProperty("label_type")]
         public string label_type { get; set; }
+        [JsonProperty("label_url")]
         public string label_url { get; set; }
+        [JsonProperty("label_zpl_url")]
         public string label_zpl_url { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
     }
 }

--- a/EasyPost.NetFramework/Rate.cs
+++ b/EasyPost.NetFramework/Rate.cs
@@ -1,26 +1,45 @@
 ﻿using System;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class Rate : Resource
     {
+        [JsonProperty("carrier")]
         public string carrier { get; set; }
+        [JsonProperty("carrier_account_id")]
         public string carrier_account_id { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("currency")]
         public string currency { get; set; }
+        [JsonProperty("delivery_date")]
         public DateTime? delivery_date { get; set; }
+        [JsonProperty("delivery_date_guaranteed")]
         public bool delivery_date_guaranteed { get; set; }
+        [JsonProperty("delivery_days")]
         public int? delivery_days { get; set; }
+        [JsonProperty("est_delivery_days")]
         public int? est_delivery_days { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("list_currency")]
         public string list_currency { get; set; }
+        [JsonProperty("list_rate")]
         public string list_rate { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("rate")]
         public string rate { get; set; }
+        [JsonProperty("retail_currency")]
         public string retail_currency { get; set; }
+        [JsonProperty("retail_rate")]
         public string retail_rate { get; set; }
+        [JsonProperty("service")]
         public string service { get; set; }
+        [JsonProperty("shipment_id")]
         public string shipment_id { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/Rating.cs
+++ b/EasyPost.NetFramework/Rating.cs
@@ -1,14 +1,20 @@
 ﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Rating : Resource
     {
+        [JsonProperty("carrier_accounts")]
         public List<CarrierAccount> carrier_accounts { get; set; }
+        [JsonProperty("from_address")]
         public Address from_address { get; set; }
+        [JsonProperty("parcels")]
         public List<Parcel> parcels { get; set; }
+        [JsonProperty("ratings")]
         public List<object> ratings { get; set; }
+        [JsonProperty("to_address")]
         public Address to_address { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/Report.cs
+++ b/EasyPost.NetFramework/Report.cs
@@ -1,20 +1,31 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Report : Resource
     {
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("end_date")]
         public DateTime? end_date { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("include_children")]
         public bool include_children { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("start_date")]
         public DateTime? start_date { get; set; }
+        [JsonProperty("status")]
         public string status { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
+        [JsonProperty("url")]
         public string url { get; set; }
+        [JsonProperty("url_expires_at")]
         public DateTime? url_expires_at { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/ReportList.cs
+++ b/EasyPost.NetFramework/ReportList.cs
@@ -1,13 +1,18 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class ReportList
     {
+        [JsonProperty("filters")]
         public Dictionary<string, object> filters { get; set; }
+        [JsonProperty("has_more")]
         public bool has_more { get; set; }
+        [JsonProperty("reports")]
         public List<Report> reports { get; set; }
+        [JsonProperty("type")]
         public string type { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/ScanForm.cs
+++ b/EasyPost.NetFramework/ScanForm.cs
@@ -1,21 +1,33 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class ScanForm : Resource
     {
+        [JsonProperty("address")]
         public Address address { get; set; }
+        [JsonProperty("batch_id")]
         public string batch_id { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("form_file_type")]
         public string form_file_type { get; set; }
+        [JsonProperty("form_url")]
         public string form_url { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("message")]
         public string message { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("status")]
         public string status { get; set; }
+        [JsonProperty("tracking_codes")]
         public List<string> tracking_codes { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/ScanFormList.cs
+++ b/EasyPost.NetFramework/ScanFormList.cs
@@ -1,12 +1,16 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class ScanFormList : Resource
     {
+        [JsonProperty("filters")]
         public Dictionary<string, object> filters { get; set; }
+        [JsonProperty("has_more")]
         public bool has_more { get; set; }
+        [JsonProperty("scan_forms")]
         public List<ScanForm> scan_forms { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/Security.cs
+++ b/EasyPost.NetFramework/Security.cs
@@ -11,7 +11,7 @@ namespace EasyPost
         public static SecurityProtocolType GetProtocol()
         {
 #if NET45
-            return SecurityProtocolType.Tls | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls12;
+            return SecurityProtocolType.Tls;
 #else
             return (SecurityProtocolType)0x00000C00;
 #endif

--- a/EasyPost.NetFramework/Shipment.cs
+++ b/EasyPost.NetFramework/Shipment.cs
@@ -1,44 +1,78 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Shipment : Resource
     {
+        [JsonProperty("batch_id")]
         public string batch_id { get; set; }
+        [JsonProperty("batch_message")]
         public string batch_message { get; set; }
+        [JsonProperty("batch_status")]
         public string batch_status { get; set; }
+        [JsonProperty("buyer_address")]
         public Address buyer_address { get; set; }
+        [JsonProperty("carrier_accounts")]
         public List<CarrierAccount> carrier_accounts { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("customs_info")]
         public CustomsInfo customs_info { get; set; }
+        [JsonProperty("fees")]
         public List<Fee> fees { get; set; }
+        [JsonProperty("forms")]
         public List<Form> forms { get; set; }
+        [JsonProperty("from_address")]
         public Address from_address { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("insurance")]
         public string insurance { get; set; }
+        [JsonProperty("is_return")]
         public bool? is_return { get; set; }
+        [JsonProperty("messages")]
         public List<Message> messages { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("options")]
         public Options options { get; set; }
+        [JsonProperty("order_id")]
         public string order_id { get; set; }
+        [JsonProperty("parcel")]
         public Parcel parcel { get; set; }
+        [JsonProperty("postage_label")]
         public PostageLabel postage_label { get; set; }
+        [JsonProperty("rates")]
         public List<Rate> rates { get; set; }
+        [JsonProperty("reference")]
         public string reference { get; set; }
+        [JsonProperty("refund_status")]
         public string refund_status { get; set; }
+        [JsonProperty("return_address")]
         public Address return_address { get; set; }
+        [JsonProperty("scan_form")]
         public ScanForm scan_form { get; set; }
+        [JsonProperty("selected_rate")]
         public Rate selected_rate { get; set; }
+        [JsonProperty("service")]
         public string service { get; set; }
+        [JsonProperty("status")]
         public string status { get; set; }
+        [JsonProperty("tax_identifiers")]
         public List<TaxIdentifier> tax_identifiers { get; set; }
+        [JsonProperty("to_address")]
         public Address to_address { get; set; }
+        [JsonProperty("tracker")]
         public Tracker tracker { get; set; }
+        [JsonProperty("tracking_code")]
         public string tracking_code { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
+        [JsonProperty("usps_zone")]
         public string usps_zone { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/ShipmentList.cs
+++ b/EasyPost.NetFramework/ShipmentList.cs
@@ -1,12 +1,16 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class ShipmentList : Resource
     {
+        [JsonProperty("filters")]
         public Dictionary<string, object> filters { get; set; }
+        [JsonProperty("has_more")]
         public bool has_more { get; set; }
+        [JsonProperty("shipments")]
         public List<Shipment> shipments { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/SmartRate.cs
+++ b/EasyPost.NetFramework/SmartRate.cs
@@ -1,33 +1,54 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class SmartrateResult : Resource
     {
+        [JsonProperty("result")]
         public List<Smartrate> result { get; set; }
     }
 
     public class Smartrate : Resource
     {
+        [JsonProperty("carrier")]
         public string carrier { get; set; }
+        [JsonProperty("carrier_account_id")]
         public string carrier_account_id { get; set; }
+        [JsonProperty("created_at")]
         public DateTime created_at { get; set; }
+        [JsonProperty("currency")]
         public string currency { get; set; }
+        [JsonProperty("delivery_date")]
         public DateTime? delivery_date { get; set; }
+        [JsonProperty("delivery_date_guaranteed")]
         public bool delivery_date_guaranteed { get; set; }
+        [JsonProperty("delivery_days")]
         public int? delivery_days { get; set; }
+        [JsonProperty("est_delivery_days")]
         public int? est_delivery_days { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("list_currency")]
         public string list_currency { get; set; }
+        [JsonProperty("list_rate")]
         public double list_rate { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("rate")]
         public double rate { get; set; }
+        [JsonProperty("retail_currency")]
         public string retail_currency { get; set; }
+        [JsonProperty("retail_rate")]
         public double retail_rate { get; set; }
+        [JsonProperty("service")]
         public string service { get; set; }
+        [JsonProperty("shipment_id")]
         public string shipment_id { get; set; }
+        [JsonProperty("time_in_transit")]
         public TimeInTransit time_in_transit { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime updated_at { get; set; }
     }
 }

--- a/EasyPost.NetFramework/TaxIdentifier.cs
+++ b/EasyPost.NetFramework/TaxIdentifier.cs
@@ -1,10 +1,16 @@
-﻿namespace EasyPost
+﻿using Newtonsoft.Json;
+
+namespace EasyPost
 {
     public class TaxIdentifier
     {
+        [JsonProperty("entity")]
         public string entity { get; set; }
+        [JsonProperty("issuing_country")]
         public string issuing_country { get; set; }
+        [JsonProperty("tax_id")]
         public string tax_id { get; set; }
+        [JsonProperty("tax_id_type")]
         public string tax_id_type { get; set; }
     }
 }

--- a/EasyPost.NetFramework/TimeInTransit.cs
+++ b/EasyPost.NetFramework/TimeInTransit.cs
@@ -1,13 +1,22 @@
-﻿namespace EasyPost
+﻿using Newtonsoft.Json;
+
+namespace EasyPost
 {
     public class TimeInTransit
     {
+        [JsonProperty("percentile_50")]
         public int? percentile_50 { get; set; }
+        [JsonProperty("percentile_75")]
         public int? percentile_75 { get; set; }
+        [JsonProperty("percentile_85")]
         public int? percentile_85 { get; set; }
+        [JsonProperty("percentile_90")]
         public int? percentile_90 { get; set; }
+        [JsonProperty("percentile_95")]
         public int? percentile_95 { get; set; }
+        [JsonProperty("percentile_97")]
         public int? percentile_97 { get; set; }
+        [JsonProperty("percentile_99")]
         public int? percentile_99 { get; set; }
     }
 }

--- a/EasyPost.NetFramework/Tracker.cs
+++ b/EasyPost.NetFramework/Tracker.cs
@@ -1,25 +1,41 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Tracker : Resource
     {
+        [JsonProperty("carrier")]
         public string carrier { get; set; }
+        [JsonProperty("carrier_detail")]
         public CarrierDetail carrier_detail { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("est_delivery_date")]
         public DateTime? est_delivery_date { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("public_url")]
         public string public_url { get; set; }
+        [JsonProperty("shipment_id")]
         public string shipment_id { get; set; }
+        [JsonProperty("signed_by")]
         public string signed_by { get; set; }
+        [JsonProperty("status")]
         public string status { get; set; }
+        [JsonProperty("tracking_code")]
         public string tracking_code { get; set; }
+        [JsonProperty("tracking_details")]
         public List<TrackingDetail> tracking_details { get; set; }
+        [JsonProperty("tracking_updated_at")]
         public DateTime tracking_updated_at { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
+        [JsonProperty("weight")]
         public double? weight { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/TrackerList.cs
+++ b/EasyPost.NetFramework/TrackerList.cs
@@ -1,12 +1,16 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class TrackerList
     {
+        [JsonProperty("filters")]
         public Dictionary<string, object> filters { get; set; }
+        [JsonProperty("has_more")]
         public bool has_more { get; set; }
+        [JsonProperty("trackers")]
         public List<Tracker> trackers { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/TrackingDetail.cs
+++ b/EasyPost.NetFramework/TrackingDetail.cs
@@ -1,12 +1,17 @@
 ﻿using System;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class TrackingDetail : Resource
     {
+        [JsonProperty("datetime")]
         public DateTime? datetime { get; set; }
+        [JsonProperty("message")]
         public string message { get; set; }
+        [JsonProperty("status")]
         public string status { get; set; }
+        [JsonProperty("tracking_location")]
         public TrackingLocation tracking_location { get; set; }
     }
 }

--- a/EasyPost.NetFramework/TrackingLocation.cs
+++ b/EasyPost.NetFramework/TrackingLocation.cs
@@ -1,14 +1,21 @@
 ﻿using System;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class TrackingLocation
     {
+        [JsonProperty("city")]
         public string city { get; set; }
+        [JsonProperty("country")]
         public string country { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("state")]
         public string state { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
+        [JsonProperty("zip")]
         public string zip { get; set; }
     }
 }

--- a/EasyPost.NetFramework/User.cs
+++ b/EasyPost.NetFramework/User.cs
@@ -1,26 +1,43 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class User : Resource
     {
+        [JsonProperty("api_keys")]
         public List<ApiKey> api_keys { get; set; }
+        [JsonProperty("balance")]
         public string balance { get; set; }
+        [JsonProperty("children")]
         public List<User> children { get; set; }
+        [JsonProperty("created_at")]
         public DateTime? created_at { get; set; }
+        [JsonProperty("email")]
         public string email { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("name")]
         public string name { get; set; }
+        [JsonProperty("parent_id")]
         public string parent_id { get; set; }
+        [JsonProperty("password")]
         public string password { get; set; }
+        [JsonProperty("password_confirmation")]
         public string password_confirmation { get; set; }
+        [JsonProperty("phone_number")]
         public string phone_number { get; set; }
+        [JsonProperty("price_per_shipment")]
         public string price_per_shipment { get; set; }
+        [JsonProperty("recharge_amount")]
         public string recharge_amount { get; set; }
+        [JsonProperty("recharge_threshold")]
         public string recharge_threshold { get; set; }
+        [JsonProperty("secondary_recharge_amount")]
         public string secondary_recharge_amount { get; set; }
+        [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/Verification.cs
+++ b/EasyPost.NetFramework/Verification.cs
@@ -1,11 +1,15 @@
 ﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class Verification : Resource
     {
+        [JsonProperty("details")]
         public List<VerificationDetails> details { get; set; }
+        [JsonProperty("errors")]
         public List<Error> errors { get; set; }
+        [JsonProperty("success")]
         public bool success { get; set; }
     }
 }

--- a/EasyPost.NetFramework/VerificationDetails.cs
+++ b/EasyPost.NetFramework/VerificationDetails.cs
@@ -4,8 +4,11 @@ namespace EasyPost
 {
     public class VerificationDetails : Resource
     {
-        public string latitude { get; set; }
-        public string longitude { get; set; }
+        [JsonProperty("latitude")]
+        public float latitude { get; set; }
+        [JsonProperty("longitude")]
+        public float longitude { get; set; }
+        [JsonProperty("time_zone")]
         public string time_zone { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/Verifications.cs
+++ b/EasyPost.NetFramework/Verifications.cs
@@ -1,8 +1,12 @@
-﻿namespace EasyPost
+﻿using Newtonsoft.Json;
+
+namespace EasyPost
 {
     public class Verifications : Resource
     {
+        [JsonProperty("delivery")]
         public Verification delivery { get; set; }
+        [JsonProperty("zip4")]
         public Verification zip4 { get; set; }
     }
 }

--- a/EasyPost.NetFramework/Webhook.cs
+++ b/EasyPost.NetFramework/Webhook.cs
@@ -1,14 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using RestSharp;
 
 namespace EasyPost
 {
     public class Webhook : Resource
     {
+        [JsonProperty("disabled_at")]
         public DateTime? disabled_at { get; set; }
+        [JsonProperty("id")]
         public string id { get; set; }
+        [JsonProperty("mode")]
         public string mode { get; set; }
+        [JsonProperty("url")]
         public string url { get; set; }
 
         /// <summary>

--- a/EasyPost.NetFramework/WebhookList.cs
+++ b/EasyPost.NetFramework/WebhookList.cs
@@ -1,9 +1,11 @@
 ﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace EasyPost
 {
     public class WebhookList : Resource
     {
+        [JsonProperty("webhooks")]
         public List<Webhook> webhooks { get; set; }
     }
 }

--- a/EasyPost.Tests.Net/ClientTest.cs
+++ b/EasyPost.Tests.Net/ClientTest.cs
@@ -54,7 +54,7 @@
 //            Request request = new Request("resource");
 
 //            List<String> parameters = client.PrepareRequest(request).Parameters.Select(parameter => parameter.ToString()).ToList();
-//            CollectionAssert.Contains(parameters, "user_agent=EasyPost.NetFramework/v2 CSharp/" + client.version);
+//            CollectionAssert.Contains(parameters, "user_agent=EasyPost/v2 CSharp/" + client.version);
 //            CollectionAssert.Contains(parameters, "authorization=Bearer someapikey");
 //            CollectionAssert.Contains(parameters, "content_type=application/json");
 //        }

--- a/EasyPost.Tests.Net/EasyPost.Tests.Net.csproj
+++ b/EasyPost.Tests.Net/EasyPost.Tests.Net.csproj
@@ -4,7 +4,7 @@
         <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
       <IsPackable>false</IsPackable>
 
-      <Configurations>Debug;Release;Test</Configurations>
+      <Configurations>Release;Debug</Configurations>
 
       <Platforms>AnyCPU</Platforms>
 
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="RestSharp" Version="106.15.0" />
+    <PackageReference Include="RestSharp" Version="107.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
   </ItemGroup>

--- a/EasyPost.Tests.Net/RequestTest.cs
+++ b/EasyPost.Tests.Net/RequestTest.cs
@@ -24,8 +24,8 @@ namespace EasyPost.Tests.Net
             });
 
             RestRequest restRequest = (RestRequest)request;
-            CollectionAssert.Contains(restRequest.Parameters.Select(parameter => parameter.ToString()).ToList(),
-                "application/json={\"foo\":\"bar\"}");
+            List<string> parameters = restRequest.Parameters.Select(p => p.Value.ToString()).ToList();
+            CollectionAssert.Contains(parameters, "{\"foo\":\"bar\"}");
         }
 
         [TestMethod]

--- a/EasyPost.Tests.Net/ShipmentTest.cs
+++ b/EasyPost.Tests.Net/ShipmentTest.cs
@@ -268,7 +268,7 @@ namespace EasyPost.Tests.Net
         [TestMethod]
         public void TestInstanceOptions()
         {
-            DateTime tomorrow = DateTime.SpecifyKind(DateTime.Now.AddDays(1), DateTimeKind.Utc);
+            DateTime tomorrow = DateTime.Now.AddDays(1).ToUniversalTime();
 
             Shipment shipment = CreateShipmentResource();
             shipment.options = new Options
@@ -277,8 +277,7 @@ namespace EasyPost.Tests.Net
             };
             shipment.Create();
 
-            Assert.AreEqual(tomorrow.ToString("yyyy-MM-ddTHH:mm:ssZ"),
-                ((DateTime)shipment.options.label_date).ToString("yyyy-MM-ddTHH:mm:ssZ"));
+            Assert.AreEqual(tomorrow.ToString(), shipment.options.label_date.ToString());
         }
 
         [TestMethod]
@@ -373,8 +372,8 @@ namespace EasyPost.Tests.Net
         [TestMethod]
         public void TestOptions()
         {
-            string tomorrow = DateTime.Now.AddDays(1).ToString("yyyy-MM-ddTHH:mm:ssZ");
-            options["label_date"] = tomorrow;
+            DateTime tomorrow = DateTime.Now.AddDays(1);
+            options["label_date"] = tomorrow.ToString("yyyy-MM-ddTHH:mm:ssZ");
             options["print_custom"] = new List<Dictionary<string, object>>
             {
                 new Dictionary<string, object>
@@ -408,14 +407,14 @@ namespace EasyPost.Tests.Net
 
             Shipment shipment = Shipment.Create(parameters);
 
-            Assert.AreEqual(((DateTime)shipment.options.label_date).ToString("yyyy-MM-ddTHH:mm:ssZ"), tomorrow);
-            Assert.AreEqual(shipment.options.print_custom[0]["value"], "value");
-            Assert.AreEqual(shipment.options.print_custom[0]["name"], "name");
-            Assert.AreEqual(shipment.options.print_custom[0]["barcode"], true);
-            Assert.AreEqual(shipment.options.payment["type"], "THIRD_PARTY");
-            Assert.AreEqual(shipment.options.payment["account"], "12345");
-            Assert.AreEqual(shipment.options.payment["postal_code"], "54321");
-            Assert.AreEqual(shipment.options.payment["country"], "US");
+            Assert.AreEqual(tomorrow.ToString(), shipment.options.label_date.ToString());
+            Assert.AreEqual("value", shipment.options.print_custom[0]["value"]);
+            Assert.AreEqual("name", shipment.options.print_custom[0]["name"]);
+            Assert.AreEqual(true, shipment.options.print_custom[0]["barcode"]);
+            Assert.AreEqual("THIRD_PARTY", shipment.options.payment["type"]);
+            Assert.AreEqual("12345", shipment.options.payment["account"]);
+            Assert.AreEqual("54321", shipment.options.payment["postal_code"]);
+            Assert.AreEqual("US", shipment.options.payment["country"]);
         }
 
         [TestMethod]

--- a/EasyPost.Tests.Net50/EasyPost.Tests.Net50.csproj
+++ b/EasyPost.Tests.Net50/EasyPost.Tests.Net50.csproj
@@ -4,7 +4,7 @@
 
     <IsPackable>false</IsPackable>
 
-    <Configurations>Debug;Release;Test</Configurations>
+    <Configurations>Release;Debug</Configurations>
 
     <Platforms>AnyCPU</Platforms>
 
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="RestSharp" Version="106.15.0" />
+    <PackageReference Include="RestSharp" Version="107.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
   </ItemGroup>

--- a/EasyPost.Tests.Net60/EasyPost.Tests.Net60.csproj
+++ b/EasyPost.Tests.Net60/EasyPost.Tests.Net60.csproj
@@ -4,7 +4,7 @@
 
     <IsPackable>false</IsPackable>
 
-    <Configurations>Debug;Release;Test</Configurations>
+    <Configurations>Release;Debug</Configurations>
 
     <Platforms>AnyCPU</Platforms>
 
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="RestSharp" Version="106.15.0" />
+    <PackageReference Include="RestSharp" Version="107.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
   </ItemGroup>

--- a/EasyPost.Tests.NetCore31/EasyPost.Tests.NetCore31.csproj
+++ b/EasyPost.Tests.NetCore31/EasyPost.Tests.NetCore31.csproj
@@ -4,7 +4,7 @@
 
     <IsPackable>false</IsPackable>
 
-    <Configurations>Debug;Release;Test</Configurations>
+    <Configurations>Release;Debug</Configurations>
 
     <Platforms>AnyCPU</Platforms>
 
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="RestSharp" Version="106.15.0" />
+    <PackageReference Include="RestSharp" Version="107.3.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
   </ItemGroup>

--- a/EasyPost.Tests.NetFramework/ClientTest.cs
+++ b/EasyPost.Tests.NetFramework/ClientTest.cs
@@ -54,7 +54,7 @@
 //            Request request = new Request("resource");
 
 //            List<String> parameters = client.PrepareRequest(request).Parameters.Select(parameter => parameter.ToString()).ToList();
-//            CollectionAssert.Contains(parameters, "user_agent=EasyPost.NetFramework/v2 CSharp/" + client.version);
+//            CollectionAssert.Contains(parameters, "user_agent=EasyPost/v2 CSharp/" + client.version);
 //            CollectionAssert.Contains(parameters, "authorization=Bearer someapikey");
 //            CollectionAssert.Contains(parameters, "content_type=application/json");
 //        }

--- a/EasyPost.Tests.NetFramework/EasyPost.Tests.NetFramework.csproj
+++ b/EasyPost.Tests.NetFramework/EasyPost.Tests.NetFramework.csproj
@@ -4,7 +4,7 @@
 
     <IsPackable>false</IsPackable>
 
-    <Configurations>Debug;Release;Test</Configurations>
+    <Configurations>Release;Debug</Configurations>
 
     <Platforms>AnyCPU</Platforms>
 

--- a/EasyPost.Tests.NetFramework35/EasyPost.Tests.NetFramework35.csproj
+++ b/EasyPost.Tests.NetFramework35/EasyPost.Tests.NetFramework35.csproj
@@ -4,7 +4,7 @@
 
     <IsPackable>false</IsPackable>
 
-    <Configurations>Debug;Release;Test</Configurations>
+    <Configurations>Release;Debug</Configurations>
 
     <Platforms>AnyCPU</Platforms>
 
@@ -30,7 +30,7 @@
     <None Remove="MSTest.TestFramework" />
     <None Remove="MSTest.TestAdapter" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Compile Include="..\EasyPost.Tests.NetFramework\AddressTest.cs">
       <Link>AddressTest.cs</Link>


### PR DESCRIPTION
We've had some issues reported to us where RestSharp v107 (used by other applications on a user's system) is incompatible with our library. RestSharp v107 is [a major update](https://restsharp.dev/v107/#restsharp-v107) for the RestSharp package with a number of breaking changes, including a syntax change that makes it incompatible with our code as it was written.

This PR:
- Bumps the minimum version of RestSharp for our .NET/.NET Core versions (3.1, 5.0, 6.0) to RestSharp `v107.3.0`, the latest version of RestSharp at time of publication.
- .NET Framework 3.5 version will continue to use RestSharpSigned v105 (which is RestSharp `v100` under the hood). This is fine, since RestSharp v107 is not compatible with .NET Framework anyway.
- A custom JSON de/serializing class. RestSharp v107 removed/deprecated the `RootElement` attribute, which broke how some of our JSON bodies are deserialized. The custom JSON de/serializer reintroduces this concept, and hands fine-grain control over de/serialization back to the EasyPost developers.

RestSharp v107 introduces a number of new features that we can now explore in future improvements, including asynchronous requests by default (for this PR, this action has been override, so requests remain synchronous) and custom HTTP client injection that will allow us to implement VCR support for testing.

Closes #190 