### PR TITLE
Add RetrieveMe Convenience Functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Rename method from List() to All() to make our library consistent
 * Remove `Rating` class since it's not being used in anywhere
+* Add `RetrieveMe()` convenience function that allow users to retrieve without specifying an ID.
 
 ## v2.8.1 (2022-02-17)
 

--- a/EasyPost.Net/User.cs
+++ b/EasyPost.Net/User.cs
@@ -155,5 +155,19 @@ namespace EasyPost
 
             return request.Execute<User>();
         }
+
+
+        /// <summary>
+        ///     Retrieve the current user.
+        /// </summary>
+        /// <returns>EasyPost.User instance.</returns>
+        public static User RetrieveMe()
+        {
+            Request request;
+
+            request = new Request("users");
+
+            return request.Execute<User>();
+        }
     }
 }

--- a/EasyPost.NetFramework/User.cs
+++ b/EasyPost.NetFramework/User.cs
@@ -132,7 +132,6 @@ namespace EasyPost
             return request.Execute<User>();
         }
 
-
         /// <summary>
         ///     Retrieve a User from its id. If no id is specified, it returns the user for the api_key specified.
         /// </summary>
@@ -151,6 +150,19 @@ namespace EasyPost
                 request = new Request("users/{id}");
                 request.AddUrlSegment("id", id);
             }
+
+            return request.Execute<User>();
+        }
+
+        /// <summary>
+        ///     Retrieve the current user.
+        /// </summary>
+        /// <returns>EasyPost.User instance.</returns>
+        public static User RetrieveMe()
+        {
+            Request request;
+
+            request = new Request("users");
 
             return request.Execute<User>();
         }

--- a/EasyPost.Tests.Net/UserTest.cs
+++ b/EasyPost.Tests.Net/UserTest.cs
@@ -11,6 +11,13 @@ namespace EasyPost.Tests.Net
         public void Initialize() => ClientManager.SetCurrent("GxhY479LTioDWsGcEtSAfQ");
 
         [TestMethod]
+        public void TestRetrieveMe()
+        {
+            User user = User.RetrieveMe();
+            Assert.IsNotNull(user.id);
+        }
+
+        [TestMethod]
         public void TestRetrieveSelf()
         {
             User user = User.Retrieve();

--- a/EasyPost.Tests.NetFramework/UserTest.cs
+++ b/EasyPost.Tests.NetFramework/UserTest.cs
@@ -11,6 +11,13 @@ namespace EasyPost.Tests.Net
         public void Initialize() => ClientManager.SetCurrent("GxhY479LTioDWsGcEtSAfQ");
 
         [TestMethod]
+        public void TestRetrieveMe()
+        {
+            User user = User.RetrieveMe();
+            Assert.IsNotNull(user.id);
+        }
+
+        [TestMethod]
         public void TestRetrieveSelf()
         {
             User user = User.Retrieve();


### PR DESCRIPTION
C# library is currently missing the retrieve_me function. This is the same as retrieving a user without specifying an ID, but some libs have a specific function for this. Unifying this to make our libraries more consistent.