### PR TITLE
Fix Assembly information retrieval

### DIFF
--- a/EasyPost/Client.cs
+++ b/EasyPost/Client.cs
@@ -48,9 +48,15 @@ namespace EasyPost
             _restClient = new RestClient(clientConfiguration.ApiBase);
             _restClient.Timeout = ConnectTimeoutMilliseconds;
 
-            Assembly assembly = Assembly.GetExecutingAssembly();
-            FileVersionInfo info = FileVersionInfo.GetVersionInfo(assembly.Location);
-            _libraryVersion = info.FileVersion;
+            try
+            {
+                // ref Example 1: https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assemblyname.version?view=netframework-4.8#examples
+                _libraryVersion = typeof(Client).Assembly.GetName().Version.ToString();
+            } catch (Exception)
+            {
+                _libraryVersion = "Unknown";
+            }
+
 
             string dotNetVersion = Environment.Version.ToString();
             if (dotNetVersion == "4.0.30319.42000")


### PR DESCRIPTION
In `v2.8.1`, we introduced a functionality that retrieves the assembly version number of the EasyPost library being used, for inclusion in the User-Agent during API calls. This function, however, seems to be throwing an error on end-user systems, making the library effectively unusable.

After further research, it appears the initial implementation of collecting this information was incorrect. This PR:
- Introduces a new (better) way of getting the assembly information, following [Microsoft's own example](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assemblyname.version?view=netframework-4.8#examples) for .NET Framework 4.8 (the system used by the user that first reported the error; the solution is the same for all .NET/.NET Core/.NET Framework versions)
- Wraps this functionality in a try-catch to fail gracefully in the event the assembly information is unavailable, marking the library version in the User-Agent as "Unknown"

This PR should be merged into tag `2.8.1` rather than `master`, as `master` has since diverged into a major refactor. This code will also be implemented in a separate PR fit for `master`.