### PR TITLE
chore: prepare v2.8.2 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.8.2 (2022-02-25)
+
+* Fixes a bug where failure to retrieve Assembly information to populate the `User-Agent` header on some platforms/versions would result in the inability to make HTTP requests
+
 ## v2.8.1 (2022-02-17)
 
 * Repackaged the project which contains all the changes made from `2.6.0` - `2.8.0`

--- a/EasyPost.nuspec
+++ b/EasyPost.nuspec
@@ -3,7 +3,7 @@
     <metadata>
         <id>EasyPost-Official</id>
         <title>EasyPost (Official)</title>
-        <version>2.8.1</version>
+        <version>2.8.2</version>
         <authors>EasyPost</authors>
         <owners>EasyPost</owners>
         <projectUrl>http://www.easypost.com</projectUrl>

--- a/EasyPost/Client.cs
+++ b/EasyPost/Client.cs
@@ -52,11 +52,11 @@ namespace EasyPost
             {
                 // ref Example 1: https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assemblyname.version?view=netframework-4.8#examples
                 _libraryVersion = typeof(Client).Assembly.GetName().Version.ToString();
-            } catch (Exception)
+            }
+            catch (Exception)
             {
                 _libraryVersion = "Unknown";
             }
-
 
             string dotNetVersion = Environment.Version.ToString();
             if (dotNetVersion == "4.0.30319.42000")

--- a/EasyPost/VersionInfo.cs
+++ b/EasyPost/VersionInfo.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection;
 
 // Version information for an assembly must follow semantic versioning
-[assembly: AssemblyVersion("2.8.1")]
-[assembly: AssemblyFileVersion("2.8.1")]
-[assembly: AssemblyInformationalVersion("2.8.1")]
+[assembly: AssemblyVersion("2.8.2")]
+[assembly: AssemblyFileVersion("2.8.2")]
+[assembly: AssemblyInformationalVersion("2.8.2")]


### PR DESCRIPTION
Prepares v2.8.2 for release (begins diverging from the `master` branch, using `v2` branch.