### PR TITLE
Add missing Refund class

### DIFF
--- a/EasyPost.Net/Refund.cs
+++ b/EasyPost.Net/Refund.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using RestSharp;
+
+namespace EasyPost
+{
+    public class Refund : Resource
+    {
+        [JsonProperty("id")]
+        public string id { get; set; }
+
+        [JsonProperty("tracking_code")]
+        public string tracking_code { get; set; }
+
+        [JsonProperty("confirmation_number")]
+        public string confirmation_number { get; set; }
+
+        [JsonProperty("status")]
+        public string status { get; set; }
+
+        [JsonProperty("carrier")]
+        public string carrier { get; set; }
+
+        [JsonProperty("shipment_id")]
+        public string shipment_id { get; set; }
+
+        /// <summary>
+        ///     Create a Refund.
+        /// </summary>
+        /// <param name="parameters">
+        ///     Dictionary containing parameters to create the refund with.
+        ///     All invalid keys will be ignored.
+        /// </param>
+        /// <returns>A list of EasyPost.Refund instances.</returns>
+        public static List<Refund> Create(Dictionary<string, object> parameters = null)
+        {
+            parameters = parameters ?? new Dictionary<string, object>();
+
+            Request request = new Request("refunds", Method.Post);
+            request.AddBody(new Dictionary<string, object>
+            {
+                {
+                    "refund", parameters
+                }
+            });
+
+            return request.Execute<List<Refund>>();
+        }
+
+        /// <summary>
+        ///     Retrieve a Refund from its id.
+        /// </summary>
+        /// <param name="id">String representing a Refund. Starts with "rfnd_".</param>
+        /// <returns>EasyPost.Refund instance.</returns>
+        public static Refund Retrieve(string id)
+        {
+            Request request = new Request("refunds/{id}");
+            request.AddUrlSegment("id", id);
+
+            return request.Execute<Refund>();
+        }
+
+        /// <summary>
+        ///     List all Refund objects.
+        /// </summary>
+        /// <param name="parameters">
+        ///     Optional dictionary containing parameters to filter the list with.
+        ///     All invalid keys will be ignored.
+        /// </param>
+        /// <returns>EasyPost.RefundCollection instance.</returns>
+        public static RefundCollection All(Dictionary<string, object> parameters = null)
+        {
+            parameters = parameters ?? new Dictionary<string, object>();
+
+            Request request = new Request("refunds");
+            request.AddQueryString(parameters);
+
+            return request.Execute<RefundCollection>();
+        }
+    }
+}

--- a/EasyPost.Net/RefundCollection.cs
+++ b/EasyPost.Net/RefundCollection.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace EasyPost
+{
+    public class RefundCollection : Resource
+    {
+        [JsonProperty("refunds")]
+        public List<Refund> refunds { get; set; }
+        [JsonProperty("has_more")]
+        public bool has_more { get; set; }
+    }
+}

--- a/EasyPost.NetFramework/EasyPost.NetFramework.csproj
+++ b/EasyPost.NetFramework/EasyPost.NetFramework.csproj
@@ -89,6 +89,8 @@
     <Compile Include="Options.cs" />
     <Compile Include="ClientConfiguration.cs" />
     <Compile Include="ClientManager.cs" />
+    <Compile Include="Refund.cs" />
+    <Compile Include="RefundCollection.cs" />
     <Compile Include="Report.cs" />
     <Compile Include="ReportList.cs" />
     <Compile Include="Resource.cs" />

--- a/EasyPost.NetFramework/Refund.cs
+++ b/EasyPost.NetFramework/Refund.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using RestSharp;
+
+namespace EasyPost
+{
+    public class Refund : Resource
+    {
+        [JsonProperty("id")]
+        public string id { get; set; }
+
+        [JsonProperty("tracking_code")]
+        public string tracking_code { get; set; }
+
+        [JsonProperty("confirmation_number")]
+        public string confirmation_number { get; set; }
+
+        [JsonProperty("status")]
+        public string status { get; set; }
+
+        [JsonProperty("carrier")]
+        public string carrier { get; set; }
+
+        [JsonProperty("shipment_id")]
+        public string shipment_id { get; set; }
+
+        /// <summary>
+        ///     Create a Refund.
+        /// </summary>
+        /// <param name="parameters">
+        ///     Dictionary containing parameters to create the refund with.
+        ///     All invalid keys will be ignored.
+        /// </param>
+        /// <returns>A list of EasyPost.Refund instances.</returns>
+        public static List<Refund> Create(Dictionary<string, object> parameters = null)
+        {
+            parameters = parameters ?? new Dictionary<string, object>();
+
+            Request request = new Request("refunds", Method.POST);
+            request.AddBody(new Dictionary<string, object>
+            {
+                {
+                    "refund", parameters
+                }
+            });
+
+            return request.Execute<List<Refund>>();
+        }
+
+        /// <summary>
+        ///     Retrieve a Refund from its id.
+        /// </summary>
+        /// <param name="id">String representing a Refund. Starts with "rfnd_".</param>
+        /// <returns>EasyPost.Refund instance.</returns>
+        public static Refund Retrieve(string id)
+        {
+            Request request = new Request("refunds/{id}");
+            request.AddUrlSegment("id", id);
+
+            return request.Execute<Refund>();
+        }
+
+        /// <summary>
+        ///     List all Refund objects.
+        /// </summary>
+        /// <param name="parameters">
+        ///     Optional dictionary containing parameters to filter the list with.
+        ///     All invalid keys will be ignored.
+        /// </param>
+        /// <returns>EasyPost.RefundCollection instance.</returns>
+        public static RefundCollection All(Dictionary<string, object> parameters = null)
+        {
+            parameters = parameters ?? new Dictionary<string, object>();
+
+            Request request = new Request("refunds");
+            request.AddQueryString(parameters);
+
+            return request.Execute<RefundCollection>();
+        }
+    }
+}

--- a/EasyPost.NetFramework/RefundCollection.cs
+++ b/EasyPost.NetFramework/RefundCollection.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace EasyPost
+{
+    public class RefundCollection : Resource
+    {
+        [JsonProperty("refunds")]
+        public List<Refund> refunds { get; set; }
+        [JsonProperty("has_more")]
+        public bool has_more { get; set; }
+    }
+}

--- a/EasyPost.Tests.Net/RefundTest.cs
+++ b/EasyPost.Tests.Net/RefundTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace EasyPost.Tests.Net
@@ -5,12 +6,88 @@ namespace EasyPost.Tests.Net
     [TestClass]
     public class RefundTest
     {
-        // TODO: C# does not have a Refund class
-
         [TestInitialize]
         public void Initialize()
         {
             VCR.SetUp(VCRApiKey.Test, "refund", true);
+        }
+
+        private static List<Refund> CreateBasicRefund()
+        {
+            Shipment shipment = Shipment.Create(Fixture.OneCallBuyShipment);
+            Shipment retrievedShipment = Shipment.Retrieve(shipment.id); // We need to retrieve the shipment so that the tracking_code has time to populate
+
+            return Refund.Create(new Dictionary<string, object>
+            {
+                {
+                    "carrier", Fixture.Usps
+                },
+                {
+                    "tracking_codes", new List<string>
+                    {
+                        retrievedShipment.tracking_code
+                    }
+                }
+            });
+        }
+
+        [TestMethod]
+        public void TestCreate()
+        {
+            VCR.Record("create");
+
+            List<Refund> refunds = CreateBasicRefund();
+
+            foreach (var item in refunds)
+            {
+                Assert.IsInstanceOfType(item, typeof(Refund));
+            }
+
+            Refund refund = refunds[0];
+            Assert.IsTrue(refund.id.StartsWith("rfnd_"));
+            Assert.AreEqual("submitted", refund.status);
+        }
+
+        [TestMethod]
+        public void TestAll()
+        {
+            VCR.Record("all");
+
+            RefundCollection refundCollection = Refund.All(new Dictionary<string, object>
+            {
+                {
+                    "page_size", Fixture.PageSize
+                }
+            });
+
+            List<Refund> refunds = refundCollection.refunds;
+
+            Assert.IsTrue(refunds.Count <= Fixture.PageSize);
+            Assert.IsNotNull(refundCollection.has_more);
+            foreach (var item in refunds)
+            {
+                Assert.IsInstanceOfType(item, typeof(Refund));
+            }
+        }
+
+        [TestMethod]
+        public void TestRetrieve()
+        {
+            VCR.Record("retrieve");
+
+            RefundCollection refundCollection = Refund.All(new Dictionary<string, object>
+            {
+                {
+                    "page_size", Fixture.PageSize
+                }
+            });
+
+            Refund refund = CreateBasicRefund()[0];
+
+            Refund retrievedRefund = Refund.Retrieve(refund.id);
+
+            Assert.IsInstanceOfType(retrievedRefund, typeof(Refund));
+            Assert.AreEqual(refund.id, retrievedRefund.id);
         }
     }
 }

--- a/EasyPost.Tests.Net/cassettes/refund/all.json
+++ b/EasyPost.Tests.Net/cassettes/refund/all.json
@@ -1,0 +1,49 @@
+[
+  {
+    "Request": {
+      "Method": "GET",
+      "URI": "https://api.easypost.com/v2/refunds?page_size=5",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "********",
+        "content_type": "application/json",
+        "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
+      },
+      "ContentHeaders": {},
+      "Body": ""
+    },
+    "Response": {
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      },
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "de40c280621e7da4f44cebf800386b89",
+        "Cache-Control": "no-store, no-cache",
+        "Pragma": "no-cache",
+        "ETag": "W/\"ab7e70e3fb9ba9bea5a3e379039b6950\"",
+        "X-Request-ID": "8e1eab11-c63e-4ed8-81e7-8ffdb4c39443",
+        "x-runtime": "0.075299",
+        "x-node": "bigweb9nuq",
+        "x-version-label": "easypost-202203011826-45d0115384-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb1nuq 88c34981dc,intlb2wdc 88c34981dc,extlb3wdc 88c34981dc",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "1508"
+      },
+      "Body": "{\"refunds\":[{\"id\":\"rfnd_a373f07735454c29bb38d2e20a3f7766\",\"object\":\"Refund\",\"created_at\":\"2022-03-01T20:10:11Z\",\"updated_at\":\"2022-03-01T20:10:11Z\",\"tracking_code\":\"9400100109361109561226\",\"confirmation_number\":null,\"status\":\"submitted\",\"carrier\":\"USPS\",\"shipment_id\":\"shp_ff5b75ac719e4312ac4b46812f2eb24e\"},{\"id\":\"rfnd_84c04dca76cb468f901e67f2b2e74526\",\"object\":\"Refund\",\"created_at\":\"2022-03-01T20:01:46Z\",\"updated_at\":\"2022-03-01T20:01:46Z\",\"tracking_code\":\"9400100109361109560502\",\"confirmation_number\":null,\"status\":\"submitted\",\"carrier\":\"USPS\",\"shipment_id\":\"shp_6625c2045ae5408a8cde50c63a9a0252\"},{\"id\":\"rfnd_3320250fcc6945b0818ee8a1c3962297\",\"object\":\"Refund\",\"created_at\":\"2022-03-01T20:00:40Z\",\"updated_at\":\"2022-03-01T20:00:40Z\",\"tracking_code\":\"9400100109361109560342\",\"confirmation_number\":null,\"status\":\"submitted\",\"carrier\":\"USPS\",\"shipment_id\":\"shp_bb29ab64c6c44d249ceecfd01edfd5e3\"},{\"id\":\"rfnd_1edd89a908004eacbce4fca4a0bb3ddd\",\"object\":\"Refund\",\"created_at\":\"2022-03-01T19:59:29Z\",\"updated_at\":\"2022-03-01T19:59:29Z\",\"tracking_code\":\"9400100109361109560038\",\"confirmation_number\":null,\"status\":\"submitted\",\"carrier\":\"USPS\",\"shipment_id\":\"shp_98b98f5f2edd4eb7b372b1720415a87d\"},{\"id\":\"rfnd_fd69ab9c7799443ab1dbb530d5e38cf2\",\"object\":\"Refund\",\"created_at\":\"2022-02-28T23:42:25Z\",\"updated_at\":\"2022-03-01T00:35:44Z\",\"tracking_code\":\"9400100897846109428529\",\"confirmation_number\":null,\"status\":\"rejected\",\"carrier\":\"USPS\",\"shipment_id\":\"shp_b6b14d193593409eb6f656a04469f96a\"}],\"has_more\":true}",
+      "HttpVersion": "1.1"
+    },
+    "RecordedAt": "2022-03-01T12:10:12.56541-08:00"
+  }
+]

--- a/EasyPost.Tests.Net/cassettes/refund/create.json
+++ b/EasyPost.Tests.Net/cassettes/refund/create.json
@@ -1,0 +1,291 @@
+[
+  {
+    "Request": {
+      "Method": "POST",
+      "URI": "https://api.easypost.com/v2/shipments",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "********",
+        "content_type": "application/json",
+        "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
+      },
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "558"
+      },
+      "Body": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":\"10\",\"width\":\"8\",\"height\":\"4\",\"weight\":\"15.4\"},\"service\":\"First\",\"carrier_accounts\":[\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"],\"carrier\":\"USPS\"}}"
+    },
+    "Response": {
+      "Status": {
+        "Code": 201,
+        "Message": "Created"
+      },
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "0a093059621e7da1f44c8710003cfdba",
+        "Cache-Control": "no-store, no-cache",
+        "Pragma": "no-cache",
+        "Location": "/api/v2/shipments/shp_ff5b75ac719e4312ac4b46812f2eb24e",
+        "ETag": "W/\"e668f4055dc24212035baa85bda27824\"",
+        "X-Request-ID": "e069630f-fd58-4a3b-ba8f-e2bfb9ac24c7",
+        "x-runtime": "1.031508",
+        "x-node": "bigweb9nuq",
+        "x-version-label": "easypost-202203011826-45d0115384-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb2nuq 88c34981dc,extlb2nuq 88c34981dc",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "6826"
+      },
+      "Body": "{\"created_at\":\"2022-03-01T20:10:09Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361109561226\",\"updated_at\":\"2022-03-01T20:10:10Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_9822cd9b999b11ec8704ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:10:09+00:00\",\"updated_at\":\"2022-03-01T20:10:09+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_6a3f9f240d4e4b518c8181f37e22591d\",\"object\":\"Parcel\",\"created_at\":\"2022-03-01T20:10:09Z\",\"updated_at\":\"2022-03-01T20:10:09Z\",\"length\":10.0,\"width\":8.0,\"height\":4.0,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_f86184f8a75a428094834645a4b9a772\",\"created_at\":\"2022-03-01T20:10:09Z\",\"updated_at\":\"2022-03-01T20:10:10Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-03-01T20:10:09Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220301/71d0e7cd10004b7a87982a0a75eebc52.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_73f251610e86489fb092aa4c048a94f5\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:09Z\",\"updated_at\":\"2022-03-01T20:10:09Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_ff5b75ac719e4312ac4b46812f2eb24e\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_69f87453897144a097291d343e2dbd75\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:09Z\",\"updated_at\":\"2022-03-01T20:10:09Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_ff5b75ac719e4312ac4b46812f2eb24e\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_ede48c1282344b2b9a5979fb538db645\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:09Z\",\"updated_at\":\"2022-03-01T20:10:09Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_ff5b75ac719e4312ac4b46812f2eb24e\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_a89d89dfbf474d7fa87953467723d411\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:09Z\",\"updated_at\":\"2022-03-01T20:10:09Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_ff5b75ac719e4312ac4b46812f2eb24e\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_69f87453897144a097291d343e2dbd75\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:09Z\",\"updated_at\":\"2022-03-01T20:10:09Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_ff5b75ac719e4312ac4b46812f2eb24e\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},\"tracker\":{\"id\":\"trk_f69d4a1495c34a35a30bb3247283951c\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361109561226\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-03-01T20:10:10Z\",\"updated_at\":\"2022-03-01T20:10:10Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_ff5b75ac719e4312ac4b46812f2eb24e\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrX2Y2OWQ0YTE0OTVjMzRhMzVhMzBiYjMyNDcyODM5NTFj\"},\"to_address\":{\"id\":\"adr_982133e7999b11ec9fd8ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:10:09+00:00\",\"updated_at\":\"2022-03-01T20:10:09+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_9822cd9b999b11ec8704ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:10:09+00:00\",\"updated_at\":\"2022-03-01T20:10:09+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_982133e7999b11ec9fd8ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:10:09+00:00\",\"updated_at\":\"2022-03-01T20:10:09+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.01000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_ff5b75ac719e4312ac4b46812f2eb24e\",\"object\":\"Shipment\"}",
+      "HttpVersion": "1.1"
+    },
+    "RecordedAt": "2022-03-01T12:10:10.181287-08:00"
+  },
+  {
+    "Request": {
+      "Method": "GET",
+      "URI": "https://api.easypost.com/v2/shipments/shp_98b98f5f2edd4eb7b372b1720415a87d",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "********",
+        "content_type": "application/json",
+        "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
+      },
+      "ContentHeaders": {},
+      "Body": ""
+    },
+    "Response": {
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      },
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "7a24fa5b621e7b09f44c81bf003848dc",
+        "Cache-Control": "no-store, no-cache",
+        "Pragma": "no-cache",
+        "ETag": "W/\"6c244814908159b2a9658b19c7fb6d88\"",
+        "X-Request-ID": "9e11205e-1296-4823-b90d-b937eff6934d",
+        "x-runtime": "0.122313",
+        "x-node": "bigweb5nuq",
+        "x-version-label": "easypost-202203011826-45d0115384-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb2nuq 88c34981dc,intlb1wdc 88c34981dc,extlb1wdc 88c34981dc",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "7960"
+      },
+      "Body": "{\"created_at\":\"2022-03-01T19:58:22Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361109560038\",\"updated_at\":\"2022-03-01T19:58:22Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_f2ac5099999911ec9fbdac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-03-01T19:58:22+00:00\",\"updated_at\":\"2022-03-01T19:58:22+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_d534d15264784c539f5e682bdffcdb48\",\"object\":\"Parcel\",\"created_at\":\"2022-03-01T19:58:22Z\",\"updated_at\":\"2022-03-01T19:58:22Z\",\"length\":10.0,\"width\":8.0,\"height\":4.0,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_93de287046e9417b8237d1deddb65403\",\"created_at\":\"2022-03-01T19:58:22Z\",\"updated_at\":\"2022-03-01T19:58:22Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-03-01T19:58:22Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220301/4ce53324035d44938bfd5ac639d64042.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_a4e42c01790248878a583b70942dc002\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T19:58:22Z\",\"updated_at\":\"2022-03-01T19:58:22Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_98b98f5f2edd4eb7b372b1720415a87d\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_2ba435c345b64c599bfd256f9c27a3b9\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T19:58:22Z\",\"updated_at\":\"2022-03-01T19:58:22Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_98b98f5f2edd4eb7b372b1720415a87d\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_f5bd8de6de674f32ab268382fda97f43\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T19:58:22Z\",\"updated_at\":\"2022-03-01T19:58:22Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_98b98f5f2edd4eb7b372b1720415a87d\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_12e2802ba33b489ca34b33f283db56e2\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T19:58:22Z\",\"updated_at\":\"2022-03-01T19:58:22Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_98b98f5f2edd4eb7b372b1720415a87d\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_12e2802ba33b489ca34b33f283db56e2\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T19:58:22Z\",\"updated_at\":\"2022-03-01T19:58:22Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_98b98f5f2edd4eb7b372b1720415a87d\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},\"tracker\":{\"id\":\"trk_780d1c2183064f49a1b108baa7a9d1d5\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361109560038\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-03-01T19:58:23Z\",\"updated_at\":\"2022-03-01T19:58:23Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-03-01T19:58:23Z\",\"shipment_id\":\"shp_98b98f5f2edd4eb7b372b1720415a87d\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-02-01T19:58:23Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-02-02T08:35:23Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"fees\":[],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"public_url\":\"https://track.easypost.com/djE6dHJrXzc4MGQxYzIxODMwNjRmNDlhMWIxMDhiYWE3YTlkMWQ1\"},\"to_address\":{\"id\":\"adr_f2aaa11e999911ec9fbcac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-03-01T19:58:22+00:00\",\"updated_at\":\"2022-03-01T19:58:22+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_f2ac5099999911ec9fbdac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-03-01T19:58:22+00:00\",\"updated_at\":\"2022-03-01T19:58:22+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_f2aaa11e999911ec9fbcac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-03-01T19:58:22+00:00\",\"updated_at\":\"2022-03-01T19:58:22+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.01000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_98b98f5f2edd4eb7b372b1720415a87d\",\"object\":\"Shipment\"}",
+      "HttpVersion": "1.1"
+    },
+    "RecordedAt": "2022-03-01T11:59:06.034993-08:00"
+  },
+  {
+    "Request": {
+      "Method": "POST",
+      "URI": "https://api.easypost.com/v2/refunds",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "********",
+        "content_type": "application/json",
+        "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
+      },
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "73"
+      },
+      "Body": "{\"refund\":{\"carrier\":\"USPS\",\"tracking_codes\":[\"9400100109361109561226\"]}}"
+    },
+    "Response": {
+      "Status": {
+        "Code": 201,
+        "Message": "Created"
+      },
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "8055d313621e7da3f44cebf7003d8055",
+        "Cache-Control": "no-store, no-cache",
+        "Pragma": "no-cache",
+        "ETag": "W/\"d639ebc5dd2c02e4c25fa05f81ae0af8\"",
+        "X-Request-ID": "3e428c6a-f127-4eea-85bc-2021e066eae0",
+        "x-runtime": "0.068284",
+        "x-node": "bigweb4nuq",
+        "x-version-label": "easypost-202203011826-45d0115384-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb1nuq 88c34981dc,extlb1nuq 88c34981dc",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "297"
+      },
+      "Body": "[{\"id\":\"rfnd_a373f07735454c29bb38d2e20a3f7766\",\"object\":\"Refund\",\"created_at\":\"2022-03-01T20:10:11Z\",\"updated_at\":\"2022-03-01T20:10:11Z\",\"tracking_code\":\"9400100109361109561226\",\"confirmation_number\":null,\"status\":\"submitted\",\"carrier\":\"USPS\",\"shipment_id\":\"shp_ff5b75ac719e4312ac4b46812f2eb24e\"}]",
+      "HttpVersion": "1.1"
+    },
+    "RecordedAt": "2022-03-01T12:10:11.583564-08:00"
+  },
+  {
+    "Request": {
+      "Method": "GET",
+      "URI": "https://api.easypost.com/v2/shipments/shp_bb29ab64c6c44d249ceecfd01edfd5e3",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "********",
+        "content_type": "application/json",
+        "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
+      },
+      "ContentHeaders": {},
+      "Body": ""
+    },
+    "Response": {
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      },
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "7a24fa5a621e7b5ff44c82220038604e",
+        "Cache-Control": "no-store, no-cache",
+        "Pragma": "no-cache",
+        "ETag": "W/\"d1e9f13864863eb8e7600f816e1f0d05\"",
+        "X-Request-ID": "a8a5cd73-eba6-4f8e-b7d1-aa74c3fde908",
+        "x-runtime": "0.126457",
+        "x-node": "bigweb4nuq",
+        "x-version-label": "easypost-202203011826-45d0115384-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb1nuq 88c34981dc,intlb2wdc 88c34981dc,extlb1wdc 88c34981dc",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "7960"
+      },
+      "Body": "{\"created_at\":\"2022-03-01T20:00:26Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361109560342\",\"updated_at\":\"2022-03-01T20:00:27Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_3d072892999a11ecb07eac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:00:26+00:00\",\"updated_at\":\"2022-03-01T20:00:26+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_a9b7a6ea7fb34d9388f33698716ebf67\",\"object\":\"Parcel\",\"created_at\":\"2022-03-01T20:00:26Z\",\"updated_at\":\"2022-03-01T20:00:26Z\",\"length\":10.0,\"width\":8.0,\"height\":4.0,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_03ecec7451c84ce08059f5875c242745\",\"created_at\":\"2022-03-01T20:00:27Z\",\"updated_at\":\"2022-03-01T20:00:27Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-03-01T20:00:27Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220301/840e429c52534ca4a6328f6be0b70414.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_31381f64de3d4652b5e15322377bdc6c\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:00:27Z\",\"updated_at\":\"2022-03-01T20:00:27Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_bb29ab64c6c44d249ceecfd01edfd5e3\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_82798c48382a422ea547a676b235e6c1\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:00:27Z\",\"updated_at\":\"2022-03-01T20:00:27Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_bb29ab64c6c44d249ceecfd01edfd5e3\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_42b869262bfa4ca28c1b41dff066f22b\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:00:27Z\",\"updated_at\":\"2022-03-01T20:00:27Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_bb29ab64c6c44d249ceecfd01edfd5e3\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_267a4c83960940ec9fed45d34c22a582\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:00:27Z\",\"updated_at\":\"2022-03-01T20:00:27Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_bb29ab64c6c44d249ceecfd01edfd5e3\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_267a4c83960940ec9fed45d34c22a582\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:00:27Z\",\"updated_at\":\"2022-03-01T20:00:27Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_bb29ab64c6c44d249ceecfd01edfd5e3\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},\"tracker\":{\"id\":\"trk_1b6de3d751384f218c8bea01b2a5134a\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361109560342\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-03-01T20:00:27Z\",\"updated_at\":\"2022-03-01T20:00:28Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-03-01T20:00:27Z\",\"shipment_id\":\"shp_bb29ab64c6c44d249ceecfd01edfd5e3\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-02-01T20:00:27Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-02-02T08:37:27Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"fees\":[],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"public_url\":\"https://track.easypost.com/djE6dHJrXzFiNmRlM2Q3NTEzODRmMjE4YzhiZWEwMWIyYTUxMzRh\"},\"to_address\":{\"id\":\"adr_3d0562d5999a11ecb7a6ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:00:26+00:00\",\"updated_at\":\"2022-03-01T20:00:27+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_3d072892999a11ecb07eac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:00:26+00:00\",\"updated_at\":\"2022-03-01T20:00:26+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_3d0562d5999a11ecb7a6ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:00:26+00:00\",\"updated_at\":\"2022-03-01T20:00:27+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.01000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_bb29ab64c6c44d249ceecfd01edfd5e3\",\"object\":\"Shipment\"}",
+      "HttpVersion": "1.1"
+    },
+    "RecordedAt": "2022-03-01T12:00:31.455292-08:00"
+  },
+  {
+    "Request": {
+      "Method": "GET",
+      "URI": "https://api.easypost.com/v2/shipments/shp_6625c2045ae5408a8cde50c63a9a0252",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "********",
+        "content_type": "application/json",
+        "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
+      },
+      "ContentHeaders": {},
+      "Body": ""
+    },
+    "Response": {
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      },
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "7a24fa5b621e7ba4f44c8266003878b0",
+        "Cache-Control": "no-store, no-cache",
+        "Pragma": "no-cache",
+        "ETag": "W/\"0f779a281af568f60b03f9a71612e944\"",
+        "X-Request-ID": "674274e6-d436-461e-96f2-150b9c42b626",
+        "x-runtime": "0.110085",
+        "x-node": "bigweb3nuq",
+        "x-version-label": "easypost-202203011826-45d0115384-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb2nuq 88c34981dc,intlb1wdc 88c34981dc,extlb1wdc 88c34981dc",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "7960"
+      },
+      "Body": "{\"created_at\":\"2022-03-01T20:01:36Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361109560502\",\"updated_at\":\"2022-03-01T20:01:37Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_66505f44999a11ec813fac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:01:36+00:00\",\"updated_at\":\"2022-03-01T20:01:36+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_21510221f7a44ffe9d7dccc1982bed90\",\"object\":\"Parcel\",\"created_at\":\"2022-03-01T20:01:36Z\",\"updated_at\":\"2022-03-01T20:01:36Z\",\"length\":10.0,\"width\":8.0,\"height\":4.0,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_1cbb76c366474a11898f9c81abd07ba5\",\"created_at\":\"2022-03-01T20:01:36Z\",\"updated_at\":\"2022-03-01T20:01:36Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-03-01T20:01:36Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220301/5bb9d9d915bf47a29bb304e291f8fd34.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_01807d9e8a4146a8bfa389a5c2d426f1\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:01:36Z\",\"updated_at\":\"2022-03-01T20:01:36Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_6625c2045ae5408a8cde50c63a9a0252\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_920a8f74624b43f19258ead370513040\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:01:36Z\",\"updated_at\":\"2022-03-01T20:01:36Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_6625c2045ae5408a8cde50c63a9a0252\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_a46931105c8c4dfe9b078dcd599b1ea0\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:01:36Z\",\"updated_at\":\"2022-03-01T20:01:36Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_6625c2045ae5408a8cde50c63a9a0252\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_a705af8520da49aeb1f213dbc633a96d\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:01:36Z\",\"updated_at\":\"2022-03-01T20:01:36Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_6625c2045ae5408a8cde50c63a9a0252\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_a705af8520da49aeb1f213dbc633a96d\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:01:36Z\",\"updated_at\":\"2022-03-01T20:01:36Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_6625c2045ae5408a8cde50c63a9a0252\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},\"tracker\":{\"id\":\"trk_0bfc946ce5684f9a96db5fe328d467dd\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361109560502\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-03-01T20:01:37Z\",\"updated_at\":\"2022-03-01T20:01:37Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-03-01T20:01:37Z\",\"shipment_id\":\"shp_6625c2045ae5408a8cde50c63a9a0252\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-02-01T20:01:37Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-02-02T08:38:37Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"fees\":[],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"public_url\":\"https://track.easypost.com/djE6dHJrXzBiZmM5NDZjZTU2ODRmOWE5NmRiNWZlMzI4ZDQ2N2Rk\"},\"to_address\":{\"id\":\"adr_664ec683999a11ecbd95ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:01:36+00:00\",\"updated_at\":\"2022-03-01T20:01:36+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_66505f44999a11ec813fac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:01:36+00:00\",\"updated_at\":\"2022-03-01T20:01:36+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_664ec683999a11ecbd95ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:01:36+00:00\",\"updated_at\":\"2022-03-01T20:01:36+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.01000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_6625c2045ae5408a8cde50c63a9a0252\",\"object\":\"Shipment\"}",
+      "HttpVersion": "1.1"
+    },
+    "RecordedAt": "2022-03-01T12:01:40.680684-08:00"
+  },
+  {
+    "Request": {
+      "Method": "GET",
+      "URI": "https://api.easypost.com/v2/shipments/shp_ff5b75ac719e4312ac4b46812f2eb24e",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "********",
+        "content_type": "application/json",
+        "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
+      },
+      "ContentHeaders": {},
+      "Body": ""
+    },
+    "Response": {
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      },
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "8055d311621e7da2f44c8711003d8018",
+        "Cache-Control": "no-store, no-cache",
+        "Pragma": "no-cache",
+        "ETag": "W/\"e5f0189e16592baabafc5a71a9ca6566\"",
+        "X-Request-ID": "238bb522-dc50-4139-b4c1-4635dfe36447",
+        "x-runtime": "0.201041",
+        "x-node": "bigweb1nuq",
+        "x-version-label": "easypost-202203011826-45d0115384-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb2nuq 88c34981dc,extlb1nuq 88c34981dc",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "7960"
+      },
+      "Body": "{\"created_at\":\"2022-03-01T20:10:09Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361109561226\",\"updated_at\":\"2022-03-01T20:10:10Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_9822cd9b999b11ec8704ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:10:09+00:00\",\"updated_at\":\"2022-03-01T20:10:09+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_6a3f9f240d4e4b518c8181f37e22591d\",\"object\":\"Parcel\",\"created_at\":\"2022-03-01T20:10:09Z\",\"updated_at\":\"2022-03-01T20:10:09Z\",\"length\":10.0,\"width\":8.0,\"height\":4.0,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_f86184f8a75a428094834645a4b9a772\",\"created_at\":\"2022-03-01T20:10:09Z\",\"updated_at\":\"2022-03-01T20:10:10Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-03-01T20:10:09Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220301/71d0e7cd10004b7a87982a0a75eebc52.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_73f251610e86489fb092aa4c048a94f5\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:09Z\",\"updated_at\":\"2022-03-01T20:10:09Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_ff5b75ac719e4312ac4b46812f2eb24e\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_69f87453897144a097291d343e2dbd75\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:09Z\",\"updated_at\":\"2022-03-01T20:10:09Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_ff5b75ac719e4312ac4b46812f2eb24e\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_ede48c1282344b2b9a5979fb538db645\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:09Z\",\"updated_at\":\"2022-03-01T20:10:09Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_ff5b75ac719e4312ac4b46812f2eb24e\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_a89d89dfbf474d7fa87953467723d411\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:09Z\",\"updated_at\":\"2022-03-01T20:10:09Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_ff5b75ac719e4312ac4b46812f2eb24e\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_69f87453897144a097291d343e2dbd75\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:09Z\",\"updated_at\":\"2022-03-01T20:10:09Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_ff5b75ac719e4312ac4b46812f2eb24e\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},\"tracker\":{\"id\":\"trk_f69d4a1495c34a35a30bb3247283951c\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361109561226\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-03-01T20:10:10Z\",\"updated_at\":\"2022-03-01T20:10:10Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-03-01T20:10:10Z\",\"shipment_id\":\"shp_ff5b75ac719e4312ac4b46812f2eb24e\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-02-01T20:10:10Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-02-02T08:47:10Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"fees\":[],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"public_url\":\"https://track.easypost.com/djE6dHJrX2Y2OWQ0YTE0OTVjMzRhMzVhMzBiYjMyNDcyODM5NTFj\"},\"to_address\":{\"id\":\"adr_982133e7999b11ec9fd8ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:10:09+00:00\",\"updated_at\":\"2022-03-01T20:10:09+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_9822cd9b999b11ec8704ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:10:09+00:00\",\"updated_at\":\"2022-03-01T20:10:09+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_982133e7999b11ec9fd8ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:10:09+00:00\",\"updated_at\":\"2022-03-01T20:10:09+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.01000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_ff5b75ac719e4312ac4b46812f2eb24e\",\"object\":\"Shipment\"}",
+      "HttpVersion": "1.1"
+    },
+    "RecordedAt": "2022-03-01T12:10:10.995936-08:00"
+  }
+]

--- a/EasyPost.Tests.Net/cassettes/refund/retrieve.json
+++ b/EasyPost.Tests.Net/cassettes/refund/retrieve.json
@@ -1,0 +1,244 @@
+[
+  {
+    "Request": {
+      "Method": "GET",
+      "URI": "https://api.easypost.com/v2/refunds?page_size=5",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "********",
+        "content_type": "application/json",
+        "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
+      },
+      "ContentHeaders": {},
+      "Body": ""
+    },
+    "Response": {
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      },
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "de40c284621e7da5f44cebf900386be9",
+        "Cache-Control": "no-store, no-cache",
+        "Pragma": "no-cache",
+        "ETag": "W/\"ab7e70e3fb9ba9bea5a3e379039b6950\"",
+        "X-Request-ID": "4b55fdc9-3222-43a5-ab1b-66a4bf9f6c47",
+        "x-runtime": "0.049280",
+        "x-node": "bigweb6nuq",
+        "x-version-label": "easypost-202203011826-45d0115384-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb2nuq 88c34981dc,intlb1wdc 88c34981dc,extlb3wdc 88c34981dc",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "1508"
+      },
+      "Body": "{\"refunds\":[{\"id\":\"rfnd_a373f07735454c29bb38d2e20a3f7766\",\"object\":\"Refund\",\"created_at\":\"2022-03-01T20:10:11Z\",\"updated_at\":\"2022-03-01T20:10:11Z\",\"tracking_code\":\"9400100109361109561226\",\"confirmation_number\":null,\"status\":\"submitted\",\"carrier\":\"USPS\",\"shipment_id\":\"shp_ff5b75ac719e4312ac4b46812f2eb24e\"},{\"id\":\"rfnd_84c04dca76cb468f901e67f2b2e74526\",\"object\":\"Refund\",\"created_at\":\"2022-03-01T20:01:46Z\",\"updated_at\":\"2022-03-01T20:01:46Z\",\"tracking_code\":\"9400100109361109560502\",\"confirmation_number\":null,\"status\":\"submitted\",\"carrier\":\"USPS\",\"shipment_id\":\"shp_6625c2045ae5408a8cde50c63a9a0252\"},{\"id\":\"rfnd_3320250fcc6945b0818ee8a1c3962297\",\"object\":\"Refund\",\"created_at\":\"2022-03-01T20:00:40Z\",\"updated_at\":\"2022-03-01T20:00:40Z\",\"tracking_code\":\"9400100109361109560342\",\"confirmation_number\":null,\"status\":\"submitted\",\"carrier\":\"USPS\",\"shipment_id\":\"shp_bb29ab64c6c44d249ceecfd01edfd5e3\"},{\"id\":\"rfnd_1edd89a908004eacbce4fca4a0bb3ddd\",\"object\":\"Refund\",\"created_at\":\"2022-03-01T19:59:29Z\",\"updated_at\":\"2022-03-01T19:59:29Z\",\"tracking_code\":\"9400100109361109560038\",\"confirmation_number\":null,\"status\":\"submitted\",\"carrier\":\"USPS\",\"shipment_id\":\"shp_98b98f5f2edd4eb7b372b1720415a87d\"},{\"id\":\"rfnd_fd69ab9c7799443ab1dbb530d5e38cf2\",\"object\":\"Refund\",\"created_at\":\"2022-02-28T23:42:25Z\",\"updated_at\":\"2022-03-01T00:35:44Z\",\"tracking_code\":\"9400100897846109428529\",\"confirmation_number\":null,\"status\":\"rejected\",\"carrier\":\"USPS\",\"shipment_id\":\"shp_b6b14d193593409eb6f656a04469f96a\"}],\"has_more\":true}",
+      "HttpVersion": "1.1"
+    },
+    "RecordedAt": "2022-03-01T12:10:13.469408-08:00"
+  },
+  {
+    "Request": {
+      "Method": "POST",
+      "URI": "https://api.easypost.com/v2/shipments",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "********",
+        "content_type": "application/json",
+        "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
+      },
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "558"
+      },
+      "Body": "{\"shipment\":{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":\"10\",\"width\":\"8\",\"height\":\"4\",\"weight\":\"15.4\"},\"service\":\"First\",\"carrier_accounts\":[\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"],\"carrier\":\"USPS\"}}"
+    },
+    "Response": {
+      "Status": {
+        "Code": 201,
+        "Message": "Created"
+      },
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "7a24fa5c621e7da6f44cebfa00391792",
+        "Cache-Control": "no-store, no-cache",
+        "Pragma": "no-cache",
+        "Location": "/api/v2/shipments/shp_90f7ba60462840fea5595a7240e660c9",
+        "ETag": "W/\"1510264cb09e3c52cd150476b9573832\"",
+        "X-Request-ID": "846d8977-f8ed-419d-88a1-5080b28b17be",
+        "x-runtime": "0.993103",
+        "x-node": "bigweb6nuq",
+        "x-version-label": "easypost-202203011826-45d0115384-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb2nuq 88c34981dc,intlb1wdc 88c34981dc,extlb1wdc 88c34981dc",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "6826"
+      },
+      "Body": "{\"created_at\":\"2022-03-01T20:10:14Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361109561240\",\"updated_at\":\"2022-03-01T20:10:15Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_9b3500db999b11ec9cb4ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:10:14+00:00\",\"updated_at\":\"2022-03-01T20:10:14+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_174da365c3854234993d8b44962a47ff\",\"object\":\"Parcel\",\"created_at\":\"2022-03-01T20:10:14Z\",\"updated_at\":\"2022-03-01T20:10:14Z\",\"length\":10.0,\"width\":8.0,\"height\":4.0,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_ca88a743083f45649ff3ed5fa313f7da\",\"created_at\":\"2022-03-01T20:10:14Z\",\"updated_at\":\"2022-03-01T20:10:15Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-03-01T20:10:14Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220301/8d3967a6bf2d42e293c4b88dcef79edf.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_d870b9ea100a464e98aae4ea7cc1ae33\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:14Z\",\"updated_at\":\"2022-03-01T20:10:14Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_90f7ba60462840fea5595a7240e660c9\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_7f48ad835a7d4e1dadbf037a2d25de92\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:14Z\",\"updated_at\":\"2022-03-01T20:10:14Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_90f7ba60462840fea5595a7240e660c9\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_06677ce5d68a41e58051e1964fdddc72\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:14Z\",\"updated_at\":\"2022-03-01T20:10:14Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_90f7ba60462840fea5595a7240e660c9\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_bf4e8be577be4753b0ab5943f7ed18ac\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:14Z\",\"updated_at\":\"2022-03-01T20:10:14Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_90f7ba60462840fea5595a7240e660c9\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_bf4e8be577be4753b0ab5943f7ed18ac\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:15Z\",\"updated_at\":\"2022-03-01T20:10:15Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_90f7ba60462840fea5595a7240e660c9\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},\"tracker\":{\"id\":\"trk_7715dc36ed214dd59159083479e6848c\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361109561240\",\"status\":\"unknown\",\"status_detail\":\"unknown\",\"created_at\":\"2022-03-01T20:10:15Z\",\"updated_at\":\"2022-03-01T20:10:15Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":null,\"shipment_id\":\"shp_90f7ba60462840fea5595a7240e660c9\",\"carrier\":\"USPS\",\"tracking_details\":[],\"fees\":[],\"carrier_detail\":null,\"public_url\":\"https://track.easypost.com/djE6dHJrXzc3MTVkYzM2ZWQyMTRkZDU5MTU5MDgzNDc5ZTY4NDhj\"},\"to_address\":{\"id\":\"adr_9b33206c999b11ec9cb3ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:10:14+00:00\",\"updated_at\":\"2022-03-01T20:10:14+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_9b3500db999b11ec9cb4ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:10:14+00:00\",\"updated_at\":\"2022-03-01T20:10:14+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_9b33206c999b11ec9cb3ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:10:14+00:00\",\"updated_at\":\"2022-03-01T20:10:14+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.01000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_90f7ba60462840fea5595a7240e660c9\",\"object\":\"Shipment\"}",
+      "HttpVersion": "1.1"
+    },
+    "RecordedAt": "2022-03-01T12:10:15.285825-08:00"
+  },
+  {
+    "Request": {
+      "Method": "GET",
+      "URI": "https://api.easypost.com/v2/shipments/shp_90f7ba60462840fea5595a7240e660c9",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "********",
+        "content_type": "application/json",
+        "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
+      },
+      "ContentHeaders": {},
+      "Body": ""
+    },
+    "Response": {
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      },
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "0a093057621e7da7f44cebfb003d00e8",
+        "Cache-Control": "no-store, no-cache",
+        "Pragma": "no-cache",
+        "ETag": "W/\"ef9a0fb222e8c7815d78502793cce998\"",
+        "X-Request-ID": "d8125a7a-9920-4d9b-ae22-5abca93b9f6b",
+        "x-runtime": "0.173739",
+        "x-node": "bigweb8nuq",
+        "x-version-label": "easypost-202203011826-45d0115384-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb2nuq 88c34981dc,extlb2nuq 88c34981dc",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "7960"
+      },
+      "Body": "{\"created_at\":\"2022-03-01T20:10:14Z\",\"is_return\":false,\"messages\":[],\"mode\":\"test\",\"options\":{\"currency\":\"USD\",\"payment\":{\"type\":\"SENDER\"},\"date_advance\":0},\"reference\":null,\"status\":\"unknown\",\"tracking_code\":\"9400100109361109561240\",\"updated_at\":\"2022-03-01T20:10:15Z\",\"batch_id\":null,\"batch_status\":null,\"batch_message\":null,\"customs_info\":null,\"from_address\":{\"id\":\"adr_9b3500db999b11ec9cb4ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:10:14+00:00\",\"updated_at\":\"2022-03-01T20:10:14+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"insurance\":null,\"order_id\":null,\"parcel\":{\"id\":\"prcl_174da365c3854234993d8b44962a47ff\",\"object\":\"Parcel\",\"created_at\":\"2022-03-01T20:10:14Z\",\"updated_at\":\"2022-03-01T20:10:14Z\",\"length\":10.0,\"width\":8.0,\"height\":4.0,\"predefined_package\":null,\"weight\":15.4,\"mode\":\"test\"},\"postage_label\":{\"object\":\"PostageLabel\",\"id\":\"pl_ca88a743083f45649ff3ed5fa313f7da\",\"created_at\":\"2022-03-01T20:10:14Z\",\"updated_at\":\"2022-03-01T20:10:15Z\",\"date_advance\":0,\"integrated_form\":\"none\",\"label_date\":\"2022-03-01T20:10:14Z\",\"label_resolution\":300,\"label_size\":\"4x6\",\"label_type\":\"default\",\"label_file_type\":\"image/png\",\"label_url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/postage_label/20220301/8d3967a6bf2d42e293c4b88dcef79edf.png\",\"label_pdf_url\":null,\"label_zpl_url\":null,\"label_epl2_url\":null,\"label_file\":null},\"rates\":[{\"id\":\"rate_d870b9ea100a464e98aae4ea7cc1ae33\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:14Z\",\"updated_at\":\"2022-03-01T20:10:14Z\",\"mode\":\"test\",\"service\":\"Express\",\"carrier\":\"USPS\",\"rate\":\"23.75\",\"currency\":\"USD\",\"retail_rate\":\"27.40\",\"retail_currency\":\"USD\",\"list_rate\":\"23.75\",\"list_currency\":\"USD\",\"delivery_days\":null,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":null,\"shipment_id\":\"shp_90f7ba60462840fea5595a7240e660c9\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_7f48ad835a7d4e1dadbf037a2d25de92\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:14Z\",\"updated_at\":\"2022-03-01T20:10:14Z\",\"mode\":\"test\",\"service\":\"ParcelSelect\",\"carrier\":\"USPS\",\"rate\":\"7.22\",\"currency\":\"USD\",\"retail_rate\":\"7.22\",\"retail_currency\":\"USD\",\"list_rate\":\"7.22\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_90f7ba60462840fea5595a7240e660c9\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_06677ce5d68a41e58051e1964fdddc72\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:14Z\",\"updated_at\":\"2022-03-01T20:10:14Z\",\"mode\":\"test\",\"service\":\"Priority\",\"carrier\":\"USPS\",\"rate\":\"7.37\",\"currency\":\"USD\",\"retail_rate\":\"8.70\",\"retail_currency\":\"USD\",\"list_rate\":\"7.37\",\"list_currency\":\"USD\",\"delivery_days\":1,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":1,\"shipment_id\":\"shp_90f7ba60462840fea5595a7240e660c9\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},{\"id\":\"rate_bf4e8be577be4753b0ab5943f7ed18ac\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:14Z\",\"updated_at\":\"2022-03-01T20:10:14Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_90f7ba60462840fea5595a7240e660c9\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"}],\"refund_status\":null,\"scan_form\":null,\"selected_rate\":{\"id\":\"rate_bf4e8be577be4753b0ab5943f7ed18ac\",\"object\":\"Rate\",\"created_at\":\"2022-03-01T20:10:15Z\",\"updated_at\":\"2022-03-01T20:10:15Z\",\"mode\":\"test\",\"service\":\"First\",\"carrier\":\"USPS\",\"rate\":\"5.49\",\"currency\":\"USD\",\"retail_rate\":\"5.49\",\"retail_currency\":\"USD\",\"list_rate\":\"5.49\",\"list_currency\":\"USD\",\"delivery_days\":2,\"delivery_date\":null,\"delivery_date_guaranteed\":false,\"est_delivery_days\":2,\"shipment_id\":\"shp_90f7ba60462840fea5595a7240e660c9\",\"carrier_account_id\":\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"},\"tracker\":{\"id\":\"trk_7715dc36ed214dd59159083479e6848c\",\"object\":\"Tracker\",\"mode\":\"test\",\"tracking_code\":\"9400100109361109561240\",\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"created_at\":\"2022-03-01T20:10:15Z\",\"updated_at\":\"2022-03-01T20:10:15Z\",\"signed_by\":null,\"weight\":null,\"est_delivery_date\":\"2022-03-01T20:10:15Z\",\"shipment_id\":\"shp_90f7ba60462840fea5595a7240e660c9\",\"carrier\":\"USPS\",\"tracking_details\":[{\"object\":\"TrackingDetail\",\"message\":\"Pre-Shipment Info Sent to USPS\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-02-01T20:10:15Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":null,\"state\":null,\"country\":null,\"zip\":null}},{\"object\":\"TrackingDetail\",\"message\":\"Shipping Label Created\",\"description\":null,\"status\":\"pre_transit\",\"status_detail\":\"status_update\",\"datetime\":\"2022-02-02T08:47:15Z\",\"source\":\"USPS\",\"carrier_code\":null,\"tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"}}],\"fees\":[],\"carrier_detail\":{\"object\":\"CarrierDetail\",\"service\":\"First-Class Package Service\",\"container_type\":null,\"est_delivery_date_local\":null,\"est_delivery_time_local\":null,\"origin_location\":\"HOUSTON TX, 77001\",\"origin_tracking_location\":{\"object\":\"TrackingLocation\",\"city\":\"HOUSTON\",\"state\":\"TX\",\"country\":null,\"zip\":\"77063\"},\"destination_location\":\"CHARLESTON SC, 29401\",\"destination_tracking_location\":null,\"guaranteed_delivery_date\":null,\"alternate_identifier\":null,\"initial_delivery_attempt\":null},\"public_url\":\"https://track.easypost.com/djE6dHJrXzc3MTVkYzM2ZWQyMTRkZDU5MTU5MDgzNDc5ZTY4NDhj\"},\"to_address\":{\"id\":\"adr_9b33206c999b11ec9cb3ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:10:14+00:00\",\"updated_at\":\"2022-03-01T20:10:14+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"usps_zone\":1,\"return_address\":{\"id\":\"adr_9b3500db999b11ec9cb4ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:10:14+00:00\",\"updated_at\":\"2022-03-01T20:10:14+00:00\",\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},\"buyer_address\":{\"id\":\"adr_9b33206c999b11ec9cb3ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-03-01T20:10:14+00:00\",\"updated_at\":\"2022-03-01T20:10:14+00:00\",\"name\":\"JACK SPARROW\",\"company\":\"EASYPOST\",\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"5555555555\",\"email\":null,\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},\"forms\":[],\"fees\":[{\"object\":\"Fee\",\"type\":\"LabelFee\",\"amount\":\"0.01000\",\"charged\":true,\"refunded\":false},{\"object\":\"Fee\",\"type\":\"PostageFee\",\"amount\":\"5.49000\",\"charged\":true,\"refunded\":false}],\"id\":\"shp_90f7ba60462840fea5595a7240e660c9\",\"object\":\"Shipment\"}",
+      "HttpVersion": "1.1"
+    },
+    "RecordedAt": "2022-03-01T12:10:15.957276-08:00"
+  },
+  {
+    "Request": {
+      "Method": "POST",
+      "URI": "https://api.easypost.com/v2/refunds",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "********",
+        "content_type": "application/json",
+        "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
+      },
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "73"
+      },
+      "Body": "{\"refund\":{\"carrier\":\"USPS\",\"tracking_codes\":[\"9400100109361109561240\"]}}"
+    },
+    "Response": {
+      "Status": {
+        "Code": 201,
+        "Message": "Created"
+      },
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "0a093052621e7da8f44cebfc003d012a",
+        "Cache-Control": "no-store, no-cache",
+        "Pragma": "no-cache",
+        "ETag": "W/\"bb00fe7dec4e6230890188c6a84a7f59\"",
+        "X-Request-ID": "38f5e9b1-d68c-41f9-8f2f-1253450dd5e4",
+        "x-runtime": "0.171209",
+        "x-node": "bigweb5nuq",
+        "x-version-label": "easypost-202203011826-45d0115384-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb1nuq 88c34981dc,extlb2nuq 88c34981dc",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "297"
+      },
+      "Body": "[{\"id\":\"rfnd_aa1253d0fdd6461eb838a9918935424d\",\"object\":\"Refund\",\"created_at\":\"2022-03-01T20:10:16Z\",\"updated_at\":\"2022-03-01T20:10:16Z\",\"tracking_code\":\"9400100109361109561240\",\"confirmation_number\":null,\"status\":\"submitted\",\"carrier\":\"USPS\",\"shipment_id\":\"shp_90f7ba60462840fea5595a7240e660c9\"}]",
+      "HttpVersion": "1.1"
+    },
+    "RecordedAt": "2022-03-01T12:10:16.549344-08:00"
+  },
+  {
+    "Request": {
+      "Method": "GET",
+      "URI": "https://api.easypost.com/v2/refunds/rfnd_aa1253d0fdd6461eb838a9918935424d",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "********",
+        "content_type": "application/json",
+        "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
+      },
+      "ContentHeaders": {},
+      "Body": ""
+    },
+    "Response": {
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      },
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "0a093055621e7da9f44cebfd003d016b",
+        "Cache-Control": "no-store, no-cache",
+        "Pragma": "no-cache",
+        "ETag": "W/\"579c53d125e26f343d05d4a09a41121d\"",
+        "X-Request-ID": "d6c1d457-4031-4e3c-ac49-37f581b9ec3b",
+        "x-runtime": "0.033577",
+        "x-node": "bigweb8nuq",
+        "x-version-label": "easypost-202203011826-45d0115384-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb2nuq 88c34981dc,extlb2nuq 88c34981dc",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "295"
+      },
+      "Body": "{\"id\":\"rfnd_aa1253d0fdd6461eb838a9918935424d\",\"object\":\"Refund\",\"created_at\":\"2022-03-01T20:10:16Z\",\"updated_at\":\"2022-03-01T20:10:16Z\",\"tracking_code\":\"9400100109361109561240\",\"confirmation_number\":null,\"status\":\"submitted\",\"carrier\":\"USPS\",\"shipment_id\":\"shp_90f7ba60462840fea5595a7240e660c9\"}",
+      "HttpVersion": "1.1"
+    },
+    "RecordedAt": "2022-03-01T12:10:17.003607-08:00"
+  }
+]

--- a/EasyPost.Tests.NetFramework/RefundTest.cs
+++ b/EasyPost.Tests.NetFramework/RefundTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace EasyPost.Tests.NetFramework
@@ -5,12 +6,82 @@ namespace EasyPost.Tests.NetFramework
     [TestClass]
     public class RefundTest
     {
-        // TODO: C# does not have a Refund class
-
         [TestInitialize]
         public void Initialize()
         {
             TestSuite.SetUp(TestSuiteApiKey.Test);
+        }
+
+        private static List<Refund> CreateBasicRefund()
+        {
+            Shipment shipment = Shipment.Create(Fixture.OneCallBuyShipment);
+            Shipment retrievedShipment = Shipment.Retrieve(shipment.id); // We need to retrieve the shipment so that the tracking_code has time to populate
+
+            return Refund.Create(new Dictionary<string, object>
+            {
+                {
+                    "carrier", Fixture.Usps
+                },
+                {
+                    "tracking_codes", new List<string>
+                    {
+                        retrievedShipment.tracking_code
+                    }
+                }
+            });
+        }
+
+        [TestMethod]
+        public void TestCreate()
+        {
+            List<Refund> refunds = CreateBasicRefund();
+
+            foreach (var item in refunds)
+            {
+                Assert.IsInstanceOfType(item, typeof(Refund));
+            }
+
+            Refund refund = refunds[0];
+            Assert.IsTrue(refund.id.StartsWith("rfnd_"));
+            Assert.AreEqual("submitted", refund.status);
+        }
+
+        [TestMethod]
+        public void TestAll()
+        {
+            RefundCollection refundCollection = Refund.All(new Dictionary<string, object>
+            {
+                {
+                    "page_size", Fixture.PageSize
+                }
+            });
+
+            List<Refund> refunds = refundCollection.refunds;
+
+            Assert.IsTrue(refunds.Count <= Fixture.PageSize);
+            Assert.IsNotNull(refundCollection.has_more);
+            foreach (var item in refunds)
+            {
+                Assert.IsInstanceOfType(item, typeof(Refund));
+            }
+        }
+
+        [TestMethod]
+        public void TestRetrieve()
+        {
+            RefundCollection refundCollection = Refund.All(new Dictionary<string, object>
+            {
+                {
+                    "page_size", Fixture.PageSize
+                }
+            });
+
+            Refund refund = CreateBasicRefund()[0];
+
+            Refund retrievedRefund = Refund.Retrieve(refund.id);
+
+            Assert.IsInstanceOfType(retrievedRefund, typeof(Refund));
+            Assert.AreEqual(refund.id, retrievedRefund.id);
         }
     }
 }


### PR DESCRIPTION
Our C# client library is missing a `Refund` class. Let's fix that.

This PR includes:
- A new `Refund` class, with `Create()`, `Retrieve()` and `All()` functions
- Refund tests for the .NET/.NET Core (VCR) and .NET Framework (live) versions in the respective test suites.

This branch is based on the `tests` branch, so please merge the `tests` branch first to avoid merge conflicts.