### PR TITLE
Consistent XList vs XCollection class naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * Adds option to pass in a custom `HttpClient` to the Client constructor (.NET/.NET Core only)
 * Fix Address creation respecting `verify` and `verify_strict` parameters
 * Add missing `id` property to `Brand` class
+* Clarify XList vs XCollection distinction:
+  * `ReportList`, `ScanFormList`, `ShipmentList` and `TrackerList` renamed to `ReportCollection`, `ScanFormCollection`, `ShipmentCollection` and `TrackerCollection`
 
 ## v2.8.1 (2022-02-17)
 

--- a/EasyPost.Net/Address.cs
+++ b/EasyPost.Net/Address.cs
@@ -222,7 +222,7 @@ namespace EasyPost
         ///     * {"page_size", int} Max size of list. Default to 20.
         ///     All invalid keys will be ignored.
         /// </param>
-        /// <returns>EasyPost.AddressCollection instance.</returns>
+        /// <returns>An EasyPost.AddressCollection instance.</returns>
         public static AddressCollection All(Dictionary<string, object> parameters = null)
         {
             parameters = parameters ?? new Dictionary<string, object>();

--- a/EasyPost.Net/Batch.cs
+++ b/EasyPost.Net/Batch.cs
@@ -194,7 +194,7 @@ namespace EasyPost
         ///     * {"page_size", int} Max size of list. Default to 20.
         ///     All invalid keys will be ignored.
         /// </param>
-        /// <returns>EasyPost.BatchCollection instance.</returns>
+        /// <returns>An EasyPost.BatchCollection instance.</returns>
         public static BatchCollection All(Dictionary<string, object> parameters = null)
         {
             parameters = parameters ?? new Dictionary<string, object>();

--- a/EasyPost.Net/Event.cs
+++ b/EasyPost.Net/Event.cs
@@ -70,7 +70,7 @@ namespace EasyPost
         ///     * {"page_size", int} Max size of list. Default to 20.
         ///     All invalid keys will be ignored.
         /// </param>
-        /// <returns>EasyPost.EventCollection instance.</returns>
+        /// <returns>An EasyPost.EventCollection instance.</returns>
         public static EventCollection All(Dictionary<string, object> parameters = null)
         {
             parameters = parameters ?? new Dictionary<string, object>();

--- a/EasyPost.Net/Insurance.cs
+++ b/EasyPost.Net/Insurance.cs
@@ -64,7 +64,7 @@ namespace EasyPost
         ///     * {"page_size", int} Max size of list. Default to 20.
         ///     All invalid keys will be ignored.
         /// </param>
-        /// <returns>EasyPost.InsuranceCollection instance.</returns>
+        /// <returns>An EasyPost.InsuranceCollection instance.</returns>
         public static InsuranceCollection All(Dictionary<string, object> parameters = null)
         {
             parameters = parameters ?? new Dictionary<string, object>();

--- a/EasyPost.Net/Refund.cs
+++ b/EasyPost.Net/Refund.cs
@@ -67,7 +67,7 @@ namespace EasyPost
         ///     Optional dictionary containing parameters to filter the list with.
         ///     All invalid keys will be ignored.
         /// </param>
-        /// <returns>EasyPost.RefundCollection instance.</returns>
+        /// <returns>An EasyPost.RefundCollection instance.</returns>
         public static RefundCollection All(Dictionary<string, object> parameters = null)
         {
             parameters = parameters ?? new Dictionary<string, object>();

--- a/EasyPost.Net/Report.cs
+++ b/EasyPost.Net/Report.cs
@@ -65,17 +65,17 @@ namespace EasyPost
         ///     All invalid keys will be ignored.
         /// </param>
         /// <param name="type">The type of report, e.g. "shipment", "tracker", "payment_log", etc.</param>
-        /// <returns>Instance of EasyPost.ScanForm.</returns>
-        public static ReportList All(string type, Dictionary<string, object> parameters = null)
+        /// <returns>An EasyPost.ReportCollection instance.</returns>
+        public static ReportCollection All(string type, Dictionary<string, object> parameters = null)
         {
             Request request = new Request("reports/{type}");
             request.AddUrlSegment("type", type);
             request.AddQueryString(parameters ?? new Dictionary<string, object>());
 
-            ReportList reportList = request.Execute<ReportList>();
-            reportList.filters = parameters;
-            reportList.type = type;
-            return reportList;
+            ReportCollection reportCollection = request.Execute<ReportCollection>();
+            reportCollection.filters = parameters;
+            reportCollection.type = type;
+            return reportCollection;
         }
 
 

--- a/EasyPost.Net/ReportCollection.cs
+++ b/EasyPost.Net/ReportCollection.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace EasyPost
 {
-    public class ReportList
+    public class ReportCollection : Resource
     {
         [JsonProperty("filters")]
         public Dictionary<string, object> filters { get; set; }
@@ -18,8 +18,8 @@ namespace EasyPost
         /// <summary>
         ///     Get the next page of reports based on the original parameters passed to ReportList.All().
         /// </summary>
-        /// <returns>A new EasyPost.ScanFormList instance.</returns>
-        public ReportList Next()
+        /// <returns>An EasyPost.ReportCollection instance.</returns>
+        public ReportCollection Next()
         {
             filters = filters ?? new Dictionary<string, object>();
             filters["before_id"] = reports.Last().id;

--- a/EasyPost.Net/ScanForm.cs
+++ b/EasyPost.Net/ScanForm.cs
@@ -70,15 +70,15 @@ namespace EasyPost
         ///     * {"page_size", int} Max size of list. Default to 20.
         ///     All invalid keys will be ignored.
         /// </param>
-        /// <returns>Instance of EasyPost.ScanForm.</returns>
-        public static ScanFormList All(Dictionary<string, object> parameters = null)
+        /// <returns>An EasyPost.ScanFormCollection instance.</returns>
+        public static ScanFormCollection All(Dictionary<string, object> parameters = null)
         {
             Request request = new Request("scan_forms");
             request.AddQueryString(parameters ?? new Dictionary<string, object>());
 
-            ScanFormList scanFormList = request.Execute<ScanFormList>();
-            scanFormList.filters = parameters;
-            return scanFormList;
+            ScanFormCollection scanFormCollection = request.Execute<ScanFormCollection>();
+            scanFormCollection.filters = parameters;
+            return scanFormCollection;
         }
 
         /// <summary>

--- a/EasyPost.Net/ScanFormCollection.cs
+++ b/EasyPost.Net/ScanFormCollection.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace EasyPost
 {
-    public class ScanFormList : Resource
+    public class ScanFormCollection : Resource
     {
         [JsonProperty("filters")]
         public Dictionary<string, object> filters { get; set; }
@@ -16,8 +16,8 @@ namespace EasyPost
         /// <summary>
         ///     Get the next page of scan forms based on the original parameters passed to ScanForm.All().
         /// </summary>
-        /// <returns>A new EasyPost.ScanFormList instance.</returns>
-        public ScanFormList Next()
+        /// <returns>An EasyPost.ScanFormCollection instance.</returns>
+        public ScanFormCollection Next()
         {
             filters = filters ?? new Dictionary<string, object>();
             filters["before_id"] = scan_forms.Last().id;

--- a/EasyPost.Net/Shipment.cs
+++ b/EasyPost.Net/Shipment.cs
@@ -299,15 +299,15 @@ namespace EasyPost
         ///     * {"purchased", bool} If true only display purchased shipments.
         ///     All invalid keys will be ignored.
         /// </param>
-        /// <returns>Instance of EasyPost.ShipmentList.</returns>
-        public static ShipmentList All(Dictionary<string, object> parameters = null)
+        /// <returns>An EasyPost.ShipmentCollection instance.</returns>
+        public static ShipmentCollection All(Dictionary<string, object> parameters = null)
         {
             Request request = new Request("shipments");
             request.AddQueryString(parameters ?? new Dictionary<string, object>());
 
-            ShipmentList shipmentList = request.Execute<ShipmentList>();
-            shipmentList.filters = parameters;
-            return shipmentList;
+            ShipmentCollection shipmentCollection = request.Execute<ShipmentCollection>();
+            shipmentCollection.filters = parameters;
+            return shipmentCollection;
         }
 
         /// <summary>

--- a/EasyPost.Net/ShipmentCollection.cs
+++ b/EasyPost.Net/ShipmentCollection.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace EasyPost
 {
-    public class ShipmentList : Resource
+    public class ShipmentCollection : Resource
     {
         [JsonProperty("filters")]
         public Dictionary<string, object> filters { get; set; }
@@ -16,8 +16,8 @@ namespace EasyPost
         /// <summary>
         ///     Get the next page of shipments based on the original parameters passed to Shipment.All().
         /// </summary>
-        /// <returns>A new EasyPost.ShipmentList instance.</returns>
-        public ShipmentList Next()
+        /// <returns>An EasyPost.ShipmentCollection instance.</returns>
+        public ShipmentCollection Next()
         {
             filters = filters ?? new Dictionary<string, object>();
             filters["before_id"] = shipments.Last().id;

--- a/EasyPost.Net/Tracker.cs
+++ b/EasyPost.Net/Tracker.cs
@@ -86,15 +86,15 @@ namespace EasyPost
         ///     * {"page_size", int} Size of page. Default to 30.
         ///     All invalid keys will be ignored.
         /// </param>
-        /// <returns>Instance of EasyPost.ShipmentList.</returns>
-        public static TrackerList All(Dictionary<string, object> parameters = null)
+        /// <returns>A EasyPost.TrackerCollection instance.</returns>
+        public static TrackerCollection All(Dictionary<string, object> parameters = null)
         {
             Request request = new Request("trackers");
             request.AddQueryString(parameters ?? new Dictionary<string, object>());
 
-            TrackerList trackerList = request.Execute<TrackerList>();
-            trackerList.filters = parameters;
-            return trackerList;
+            TrackerCollection trackerCollection = request.Execute<TrackerCollection>();
+            trackerCollection.filters = parameters;
+            return trackerCollection;
         }
 
         /// <summary>

--- a/EasyPost.Net/TrackerCollection.cs
+++ b/EasyPost.Net/TrackerCollection.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace EasyPost
 {
-    public class TrackerList
+    public class TrackerCollection
     {
         [JsonProperty("filters")]
         public Dictionary<string, object> filters { get; set; }
@@ -14,10 +14,10 @@ namespace EasyPost
         public List<Tracker> trackers { get; set; }
 
         /// <summary>
-        ///     Get the next page of shipments based on the original parameters passed to Shipment.All().
+        ///     Get the next page of trackers based on the original parameters passed to Tracker.All().
         /// </summary>
-        /// <returns>A new EasyPost.ShipmentList instance.</returns>
-        public TrackerList Next()
+        /// <returns>An EasyPost.TrackerCollection instance.</returns>
+        public TrackerCollection Next()
         {
             filters = filters ?? new Dictionary<string, object>();
             filters["before_id"] = trackers.Last().id;

--- a/EasyPost.NetFramework/Address.cs
+++ b/EasyPost.NetFramework/Address.cs
@@ -222,7 +222,7 @@ namespace EasyPost
         ///     * {"page_size", int} Max size of list. Default to 20.
         ///     All invalid keys will be ignored.
         /// </param>
-        /// <returns>EasyPost.AddressCollection instance.</returns>
+        /// <returns>An EasyPost.AddressCollection instance.</returns>
         public static AddressCollection All(Dictionary<string, object> parameters = null)
         {
             parameters = parameters ?? new Dictionary<string, object>();

--- a/EasyPost.NetFramework/Batch.cs
+++ b/EasyPost.NetFramework/Batch.cs
@@ -195,7 +195,7 @@ namespace EasyPost
         ///     * {"page_size", int} Max size of list. Default to 20.
         ///     All invalid keys will be ignored.
         /// </param>
-        /// <returns>EasyPost.BatchCollection instance.</returns>
+        /// <returns>An EasyPost.BatchCollection instance.</returns>
         public static BatchCollection All(Dictionary<string, object> parameters = null)
         {
             parameters = parameters ?? new Dictionary<string, object>();

--- a/EasyPost.NetFramework/EasyPost.NetFramework.csproj
+++ b/EasyPost.NetFramework/EasyPost.NetFramework.csproj
@@ -92,12 +92,12 @@
     <Compile Include="Refund.cs" />
     <Compile Include="RefundCollection.cs" />
     <Compile Include="Report.cs" />
-    <Compile Include="ReportList.cs" />
+    <Compile Include="ReportCollection.cs" />
     <Compile Include="Resource.cs" />
     <Compile Include="Smartrate.cs" />
     <Compile Include="TimeInTransit.cs" />
-    <Compile Include="TrackerList.cs" />
-    <Compile Include="ScanFormList.cs" />
+    <Compile Include="TrackerCollection.cs" />
+    <Compile Include="ScanFormCollection.cs" />
     <Compile Include="Exception.cs" />
     <Compile Include="Fee.cs" />
     <Compile Include="Form.cs" />
@@ -114,7 +114,7 @@
     <Compile Include="ScanForm.cs" />
     <Compile Include="Security.cs" />
     <Compile Include="Shipment.cs" />
-    <Compile Include="ShipmentList.cs" />
+    <Compile Include="ShipmentCollection.cs" />
     <Compile Include="TaxIdentifier.cs" />
     <Compile Include="Tracker.cs" />
     <Compile Include="TrackingDetail.cs" />

--- a/EasyPost.NetFramework/Event.cs
+++ b/EasyPost.NetFramework/Event.cs
@@ -70,7 +70,7 @@ namespace EasyPost
         ///     * {"page_size", int} Max size of list. Default to 20.
         ///     All invalid keys will be ignored.
         /// </param>
-        /// <returns>EasyPost.EventCollection instance.</returns>
+        /// <returns>An EasyPost.EventCollection instance.</returns>
         public static EventCollection All(Dictionary<string, object> parameters = null)
         {
             parameters = parameters ?? new Dictionary<string, object>();

--- a/EasyPost.NetFramework/Insurance.cs
+++ b/EasyPost.NetFramework/Insurance.cs
@@ -64,7 +64,7 @@ namespace EasyPost
         ///     * {"page_size", int} Max size of list. Default to 20.
         ///     All invalid keys will be ignored.
         /// </param>
-        /// <returns>EasyPost.InsuranceCollection instance.</returns>
+        /// <returns>An EasyPost.InsuranceCollection instance.</returns>
         public static InsuranceCollection All(Dictionary<string, object> parameters = null)
         {
             parameters = parameters ?? new Dictionary<string, object>();

--- a/EasyPost.NetFramework/Refund.cs
+++ b/EasyPost.NetFramework/Refund.cs
@@ -67,7 +67,7 @@ namespace EasyPost
         ///     Optional dictionary containing parameters to filter the list with.
         ///     All invalid keys will be ignored.
         /// </param>
-        /// <returns>EasyPost.RefundCollection instance.</returns>
+        /// <returns>An EasyPost.RefundCollection instance.</returns>
         public static RefundCollection All(Dictionary<string, object> parameters = null)
         {
             parameters = parameters ?? new Dictionary<string, object>();

--- a/EasyPost.NetFramework/Report.cs
+++ b/EasyPost.NetFramework/Report.cs
@@ -65,17 +65,17 @@ namespace EasyPost
         ///     All invalid keys will be ignored.
         /// </param>
         /// <param name="type">The type of report, e.g. "shipment", "tracker", "payment_log", etc.</param>
-        /// <returns>Instance of EasyPost.ScanForm.</returns>
-        public static ReportList All(string type, Dictionary<string, object> parameters = null)
+        /// <returns>An EasyPost.ReportCollection instance.</returns>
+        public static ReportCollection All(string type, Dictionary<string, object> parameters = null)
         {
             Request request = new Request("reports/{type}");
             request.AddUrlSegment("type", type);
             request.AddQueryString(parameters ?? new Dictionary<string, object>());
 
-            ReportList reportList = request.Execute<ReportList>();
-            reportList.filters = parameters;
-            reportList.type = type;
-            return reportList;
+            ReportCollection reportCollection = request.Execute<ReportCollection>();
+            reportCollection.filters = parameters;
+            reportCollection.type = type;
+            return reportCollection;
         }
 
 

--- a/EasyPost.NetFramework/ReportCollection.cs
+++ b/EasyPost.NetFramework/ReportCollection.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace EasyPost
 {
-    public class ReportList
+    public class ReportCollection : Resource
     {
         [JsonProperty("filters")]
         public Dictionary<string, object> filters { get; set; }
@@ -18,8 +18,8 @@ namespace EasyPost
         /// <summary>
         ///     Get the next page of reports based on the original parameters passed to ReportList.All().
         /// </summary>
-        /// <returns>A new EasyPost.ScanFormList instance.</returns>
-        public ReportList Next()
+        /// <returns>An EasyPost.ReportCollection instance.</returns>
+        public ReportCollection Next()
         {
             filters = filters ?? new Dictionary<string, object>();
             filters["before_id"] = reports.Last().id;

--- a/EasyPost.NetFramework/ScanForm.cs
+++ b/EasyPost.NetFramework/ScanForm.cs
@@ -70,15 +70,15 @@ namespace EasyPost
         ///     * {"page_size", int} Max size of list. Default to 20.
         ///     All invalid keys will be ignored.
         /// </param>
-        /// <returns>Instance of EasyPost.ScanForm.</returns>
-        public static ScanFormList All(Dictionary<string, object> parameters = null)
+        /// <returns>An EasyPost.ScanFormCollection instance.</returns>
+        public static ScanFormCollection All(Dictionary<string, object> parameters = null)
         {
             Request request = new Request("scan_forms");
             request.AddQueryString(parameters ?? new Dictionary<string, object>());
 
-            ScanFormList scanFormList = request.Execute<ScanFormList>();
-            scanFormList.filters = parameters;
-            return scanFormList;
+            ScanFormCollection scanFormCollection = request.Execute<ScanFormCollection>();
+            scanFormCollection.filters = parameters;
+            return scanFormCollection;
         }
 
         /// <summary>

--- a/EasyPost.NetFramework/ScanFormCollection.cs
+++ b/EasyPost.NetFramework/ScanFormCollection.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace EasyPost
 {
-    public class ScanFormList : Resource
+    public class ScanFormCollection : Resource
     {
         [JsonProperty("filters")]
         public Dictionary<string, object> filters { get; set; }
@@ -16,8 +16,8 @@ namespace EasyPost
         /// <summary>
         ///     Get the next page of scan forms based on the original parameters passed to ScanForm.All().
         /// </summary>
-        /// <returns>A new EasyPost.ScanFormList instance.</returns>
-        public ScanFormList Next()
+        /// <returns>An EasyPost.ScanFormCollection instance.</returns>
+        public ScanFormCollection Next()
         {
             filters = filters ?? new Dictionary<string, object>();
             filters["before_id"] = scan_forms.Last().id;

--- a/EasyPost.NetFramework/Shipment.cs
+++ b/EasyPost.NetFramework/Shipment.cs
@@ -299,15 +299,15 @@ namespace EasyPost
         ///     * {"purchased", bool} If true only display purchased shipments.
         ///     All invalid keys will be ignored.
         /// </param>
-        /// <returns>Instance of EasyPost.ShipmentList.</returns>
-        public static ShipmentList All(Dictionary<string, object> parameters = null)
+        /// <returns>An EasyPost.ShipmentCollection instance.</returns>
+        public static ShipmentCollection All(Dictionary<string, object> parameters = null)
         {
             Request request = new Request("shipments");
             request.AddQueryString(parameters ?? new Dictionary<string, object>());
 
-            ShipmentList shipmentList = request.Execute<ShipmentList>();
-            shipmentList.filters = parameters;
-            return shipmentList;
+            ShipmentCollection shipmentCollection = request.Execute<ShipmentCollection>();
+            shipmentCollection.filters = parameters;
+            return shipmentCollection;
         }
 
         /// <summary>

--- a/EasyPost.NetFramework/ShipmentCollection.cs
+++ b/EasyPost.NetFramework/ShipmentCollection.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace EasyPost
 {
-    public class ShipmentList : Resource
+    public class ShipmentCollection : Resource
     {
         [JsonProperty("filters")]
         public Dictionary<string, object> filters { get; set; }
@@ -16,8 +16,8 @@ namespace EasyPost
         /// <summary>
         ///     Get the next page of shipments based on the original parameters passed to Shipment.All().
         /// </summary>
-        /// <returns>A new EasyPost.ShipmentList instance.</returns>
-        public ShipmentList Next()
+        /// <returns>An EasyPost.ShipmentCollection instance.</returns>
+        public ShipmentCollection Next()
         {
             filters = filters ?? new Dictionary<string, object>();
             filters["before_id"] = shipments.Last().id;

--- a/EasyPost.NetFramework/Tracker.cs
+++ b/EasyPost.NetFramework/Tracker.cs
@@ -86,15 +86,15 @@ namespace EasyPost
         ///     * {"page_size", int} Size of page. Default to 30.
         ///     All invalid keys will be ignored.
         /// </param>
-        /// <returns>Instance of EasyPost.ShipmentList.</returns>
-        public static TrackerList All(Dictionary<string, object> parameters = null)
+        /// <returns>An EasyPost.TrackerCollection instance.</returns>
+        public static TrackerCollection All(Dictionary<string, object> parameters = null)
         {
             Request request = new Request("trackers");
             request.AddQueryString(parameters ?? new Dictionary<string, object>());
 
-            TrackerList trackerList = request.Execute<TrackerList>();
-            trackerList.filters = parameters;
-            return trackerList;
+            TrackerCollection trackerCollection = request.Execute<TrackerCollection>();
+            trackerCollection.filters = parameters;
+            return trackerCollection;
         }
 
         /// <summary>

--- a/EasyPost.NetFramework/TrackerCollection.cs
+++ b/EasyPost.NetFramework/TrackerCollection.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json;
 
 namespace EasyPost
 {
-    public class TrackerList
+    public class TrackerCollection : Resource
     {
         [JsonProperty("filters")]
         public Dictionary<string, object> filters { get; set; }
@@ -14,10 +14,10 @@ namespace EasyPost
         public List<Tracker> trackers { get; set; }
 
         /// <summary>
-        ///     Get the next page of shipments based on the original parameters passed to Shipment.All().
+        ///     Get the next page of trackers based on the original parameters passed to Tracker.All().
         /// </summary>
-        /// <returns>A new EasyPost.ShipmentList instance.</returns>
-        public TrackerList Next()
+        /// <returns>An EasyPost.TrackerCollection instance.</returns>
+        public TrackerCollection Next()
         {
             filters = filters ?? new Dictionary<string, object>();
             filters["before_id"] = trackers.Last().id;

--- a/EasyPost.Tests.Net/ReportTest.cs
+++ b/EasyPost.Tests.Net/ReportTest.cs
@@ -115,17 +115,17 @@ namespace EasyPost.Tests.Net
         {
             VCR.Replay("all");
 
-            ReportList reportList = Report.All("shipment", new Dictionary<string, object>
+            ReportCollection reportCollection = Report.All("shipment", new Dictionary<string, object>
             {
                 {
                     "page_size", Fixture.PageSize
                 }
             });
 
-            List<Report> reports = reportList.reports;
+            List<Report> reports = reportCollection.reports;
 
             Assert.IsTrue(reports.Count <= Fixture.PageSize);
-            Assert.IsNotNull(reportList.has_more);
+            Assert.IsNotNull(reportCollection.has_more);
             foreach (var report in reports)
             {
                 Assert.IsInstanceOfType(report, typeof(Report));

--- a/EasyPost.Tests.Net/ScanFormTest.cs
+++ b/EasyPost.Tests.Net/ScanFormTest.cs
@@ -51,17 +51,17 @@ namespace EasyPost.Tests.Net
         {
             VCR.Replay("all");
 
-            ScanFormList scanFormList = ScanForm.All(new Dictionary<string, object>
+            ScanFormCollection scanFormCollection = ScanForm.All(new Dictionary<string, object>
             {
                 {
                     "page_size", Fixture.PageSize
                 }
             });
 
-            List<ScanForm> scanForms = scanFormList.scan_forms;
+            List<ScanForm> scanForms = scanFormCollection.scan_forms;
 
             Assert.IsTrue(scanForms.Count <= Fixture.PageSize);
-            Assert.IsNotNull(scanFormList.has_more);
+            Assert.IsNotNull(scanFormCollection.has_more);
             foreach (var scanForm in scanForms)
             {
                 Assert.IsInstanceOfType(scanForm, typeof(ScanForm));

--- a/EasyPost.Tests.Net/ShipmentTest.cs
+++ b/EasyPost.Tests.Net/ShipmentTest.cs
@@ -47,17 +47,17 @@ namespace EasyPost.Tests.Net
         {
             VCR.Replay("all");
 
-            ShipmentList shipmentList = Shipment.All(new Dictionary<string, object>
+            ShipmentCollection shipmentCollection = Shipment.All(new Dictionary<string, object>
             {
                 {
                     "page_size", Fixture.PageSize
                 }
             });
 
-            List<Shipment> shipments = shipmentList.shipments;
+            List<Shipment> shipments = shipmentCollection.shipments;
 
             Assert.IsTrue(shipments.Count <= Fixture.PageSize);
-            Assert.IsNotNull(shipmentList.has_more);
+            Assert.IsNotNull(shipmentCollection.has_more);
             foreach (var shipment in shipments)
             {
                 Assert.IsInstanceOfType(shipment, typeof(Shipment));

--- a/EasyPost.Tests.Net/TrackerTest.cs
+++ b/EasyPost.Tests.Net/TrackerTest.cs
@@ -49,17 +49,17 @@ namespace EasyPost.Tests.Net
         {
             VCR.Replay("all");
 
-            TrackerList trackerList = Tracker.All(new Dictionary<string, object>
+            TrackerCollection trackerCollection = Tracker.All(new Dictionary<string, object>
             {
                 {
                     "page_size", Fixture.PageSize
                 }
             });
 
-            List<Tracker> trackers = trackerList.trackers;
+            List<Tracker> trackers = trackerCollection.trackers;
 
             Assert.IsTrue(trackers.Count <= Fixture.PageSize);
-            Assert.IsNotNull(trackerList.has_more);
+            Assert.IsNotNull(trackerCollection.has_more);
             foreach (var tracker in trackers)
             {
                 Assert.IsInstanceOfType(tracker, typeof(Tracker));

--- a/EasyPost.Tests.NetFramework/ReportTest.cs
+++ b/EasyPost.Tests.NetFramework/ReportTest.cs
@@ -108,17 +108,17 @@ namespace EasyPost.Tests.NetFramework
         [TestMethod]
         public void TestAll()
         {
-            ReportList reportList = Report.All("shipment", new Dictionary<string, object>
+            ReportCollection reportCollection = Report.All("shipment", new Dictionary<string, object>
             {
                 {
                     "page_size", Fixture.PageSize
                 }
             });
 
-            List<Report> reports = reportList.reports;
+            List<Report> reports = reportCollection.reports;
 
             Assert.IsTrue(reports.Count <= Fixture.PageSize);
-            Assert.IsNotNull(reportList.has_more);
+            Assert.IsNotNull(reportCollection.has_more);
             foreach (var report in reports)
             {
                 Assert.IsInstanceOfType(report, typeof(Report));

--- a/EasyPost.Tests.NetFramework/ScanFormTest.cs
+++ b/EasyPost.Tests.NetFramework/ScanFormTest.cs
@@ -44,17 +44,17 @@ namespace EasyPost.Tests.NetFramework
         [TestMethod]
         public void TestAll()
         {
-            ScanFormList scanFormList = ScanForm.All(new Dictionary<string, object>
+            ScanFormCollection scanFormCollection = ScanForm.All(new Dictionary<string, object>
             {
                 {
                     "page_size", Fixture.PageSize
                 }
             });
 
-            List<ScanForm> scanForms = scanFormList.scan_forms;
+            List<ScanForm> scanForms = scanFormCollection.scan_forms;
 
             Assert.IsTrue(scanForms.Count <= Fixture.PageSize);
-            Assert.IsNotNull(scanFormList.has_more);
+            Assert.IsNotNull(scanFormCollection.has_more);
             foreach (var scanForm in scanForms)
             {
                 Assert.IsInstanceOfType(scanForm, typeof(ScanForm));

--- a/EasyPost.Tests.NetFramework/ShipmentTest.cs
+++ b/EasyPost.Tests.NetFramework/ShipmentTest.cs
@@ -40,17 +40,17 @@ namespace EasyPost.Tests.NetFramework
         [TestMethod]
         public void TestAll()
         {
-            ShipmentList shipmentList = Shipment.All(new Dictionary<string, object>
+            ShipmentCollection shipmentCollection = Shipment.All(new Dictionary<string, object>
             {
                 {
                     "page_size", Fixture.PageSize
                 }
             });
 
-            List<Shipment> shipments = shipmentList.shipments;
+            List<Shipment> shipments = shipmentCollection.shipments;
 
             Assert.IsTrue(shipments.Count <= Fixture.PageSize);
-            Assert.IsNotNull(shipmentList.has_more);
+            Assert.IsNotNull(shipmentCollection.has_more);
             foreach (var shipment in shipments)
             {
                 Assert.IsInstanceOfType(shipment, typeof(Shipment));

--- a/EasyPost.Tests.NetFramework/TrackerTest.cs
+++ b/EasyPost.Tests.NetFramework/TrackerTest.cs
@@ -42,17 +42,17 @@ namespace EasyPost.Tests.NetFramework
         [TestMethod]
         public void TestAll()
         {
-            TrackerList trackerList = Tracker.All(new Dictionary<string, object>
+            TrackerCollection trackerCollection = Tracker.All(new Dictionary<string, object>
             {
                 {
                     "page_size", Fixture.PageSize
                 }
             });
 
-            List<Tracker> trackers = trackerList.trackers;
+            List<Tracker> trackers = trackerCollection.trackers;
 
             Assert.IsTrue(trackers.Count <= Fixture.PageSize);
-            Assert.IsNotNull(trackerList.has_more);
+            Assert.IsNotNull(trackerCollection.has_more);
             foreach (var tracker in trackers)
             {
                 Assert.IsInstanceOfType(tracker, typeof(Tracker));


### PR DESCRIPTION
We have several classes that are essentially wrappers around a list of individual items + a `has_more` boolean. Half of these classes are called XList (i.e. `ShipmentList`) while the other half are called XCollection (i.e. `AddressCollection`). This PR makes the naming structure consistent.

This PR:
- Renames all __public__ XList classes to XCollection (`WebhookList` has not be renamed, as that is an internal class that operates differently than the traditional list wrappers)

This is a breaking change, introducing several renames:
 - `ReportList` -> `ReportCollection`
 - `ScanFormList` -> `ScanFormCollection`
 - `ShipmentList`  -> `ShipmentCollection`
 - `TrackerList` -> `TrackerCollection`