### PR TITLE
Add missing ID property to Brand class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix bug where AddressCollection was storing Batch objects rather than Address objects
 * Adds option to pass in a custom `HttpClient` to the Client constructor (.NET/.NET Core only)
 * Fix Address creation respecting `verify` and `verify_strict` parameters
+* Add missing `id` property to `Brand` class
 
 ## v2.8.1 (2022-02-17)
 

--- a/EasyPost.Net/Brand.cs
+++ b/EasyPost.Net/Brand.cs
@@ -12,6 +12,8 @@ namespace EasyPost
         public string background_color { get; set; }
         [JsonProperty("color")]
         public string color { get; set; }
+        [JsonProperty("id")]
+        public string id { get; set; }
         [JsonProperty("logo")]
         public string logo { get; set; }
         [JsonProperty("logo_href")]

--- a/EasyPost.Tests.Net/UserTest.cs
+++ b/EasyPost.Tests.Net/UserTest.cs
@@ -145,7 +145,7 @@ namespace EasyPost.Tests.Net
             });
 
             Assert.IsInstanceOfType(brand, typeof(Brand));
-            // TODO: Brand doesn't have an ID
+            Assert.IsTrue(brand.id.StartsWith("brd_"));
             Assert.AreEqual(color, brand.color);
         }
     }


### PR DESCRIPTION
Our Brand class hasn't had a proper `id` property. This PR fixes that.

- Adds missing `id` for Brand class
- Adds test for checking Brand ID