### PR TITLE
Rename `Destroy` functions to `Delete`

### DIFF
--- a/EasyPost.Net/CarrierAccount.cs
+++ b/EasyPost.Net/CarrierAccount.cs
@@ -30,7 +30,7 @@ namespace EasyPost
         ///     Remove this CarrierAccount from your account.
         /// </summary>
         /// <returns>Whether the request was successful or not.</returns>
-        public bool Destroy()
+        public bool Delete()
         {
             Request request = new Request("carrier_accounts/{id}", Method.Delete);
             request.AddUrlSegment("id", id);

--- a/EasyPost.Net/User.cs
+++ b/EasyPost.Net/User.cs
@@ -44,7 +44,7 @@ namespace EasyPost
         ///     Delete the user.
         /// </summary>
         /// <returns>Whether the request was successful or not.</returns>
-        public bool Destroy()
+        public bool Delete()
         {
             Request request = new Request("users/{id}", Method.Delete);
             request.AddUrlSegment("id", id);

--- a/EasyPost.Net/Webhook.cs
+++ b/EasyPost.Net/Webhook.cs
@@ -20,7 +20,7 @@ namespace EasyPost
         ///     Delete this webhook.
         /// </summary>
         /// <returns>Whether the request was successful or not.</returns>
-        public bool Destroy()
+        public bool Delete()
         {
             Request request = new Request("webhooks/{id}", Method.Delete);
             request.AddUrlSegment("id", id);

--- a/EasyPost.NetFramework/CarrierAccount.cs
+++ b/EasyPost.NetFramework/CarrierAccount.cs
@@ -30,7 +30,7 @@ namespace EasyPost
         ///     Remove this CarrierAccount from your account.
         /// </summary>
         /// <returns>Whether the request was successful or not.</returns>
-        public bool Destroy()
+        public bool Delete()
         {
             Request request = new Request("carrier_accounts/{id}", Method.DELETE);
             request.AddUrlSegment("id", id);

--- a/EasyPost.NetFramework/User.cs
+++ b/EasyPost.NetFramework/User.cs
@@ -44,7 +44,7 @@ namespace EasyPost
         ///     Delete the user.
         /// </summary>
         /// <returns>Whether the request was successful or not.</returns>
-        public bool Destroy()
+        public bool Delete()
         {
             Request request = new Request("users/{id}", Method.DELETE);
             request.AddUrlSegment("id", id);

--- a/EasyPost.NetFramework/Webhook.cs
+++ b/EasyPost.NetFramework/Webhook.cs
@@ -20,7 +20,7 @@ namespace EasyPost
         ///     Delete this webhook.
         /// </summary>
         /// <returns>Whether the request was successful or not.</returns>
-        public bool Destroy()
+        public bool Delete()
         {
             Request request = new Request("webhooks/{id}", Method.DELETE);
             request.AddUrlSegment("id", id);

--- a/EasyPost.Tests.Net/CarrierAccountTest.cs
+++ b/EasyPost.Tests.Net/CarrierAccountTest.cs
@@ -86,7 +86,7 @@ namespace EasyPost.Tests.Net
 
             CarrierAccount carrierAccount = CreateBasicCarrierAccount();
 
-            bool success = carrierAccount.Destroy();
+            bool success = carrierAccount.Delete();
 
             Assert.IsTrue(success);
         }

--- a/EasyPost.Tests.Net/UserTest.cs
+++ b/EasyPost.Tests.Net/UserTest.cs
@@ -98,7 +98,7 @@ namespace EasyPost.Tests.Net
 
             User user = CreateUser();
 
-            user.Destroy();
+            user.Delete();
         }
 
         // API keys are returned as plaintext, do not run this test.

--- a/EasyPost.Tests.Net/WebhookTest.cs
+++ b/EasyPost.Tests.Net/WebhookTest.cs
@@ -28,7 +28,7 @@ namespace EasyPost.Tests.Net
                 try
                 {
                     Webhook retrievedWebhook = Webhook.Retrieve(webhookId);
-                    retrievedWebhook.Destroy();
+                    retrievedWebhook.Delete();
                     webhookId = null;
                 }
                 catch
@@ -113,7 +113,7 @@ namespace EasyPost.Tests.Net
             Webhook webhook = CreateBasicWebhook(url);
             Webhook retrievedWebhook = Webhook.Retrieve(webhook.id);
 
-            bool success = retrievedWebhook.Destroy();
+            bool success = retrievedWebhook.Delete();
 
             // This endpoint/method does not return anything, just make sure the request doesn't fail
             Assert.IsTrue(success);

--- a/EasyPost.Tests.NetFramework/CarrierAccountTest.cs
+++ b/EasyPost.Tests.NetFramework/CarrierAccountTest.cs
@@ -73,7 +73,7 @@ namespace EasyPost.Tests.NetFramework
         {
             CarrierAccount carrierAccount = CreateBasicCarrierAccount();
 
-            bool success = carrierAccount.Destroy();
+            bool success = carrierAccount.Delete();
 
             Assert.IsTrue(success);
         }

--- a/EasyPost.Tests.NetFramework/UserTest.cs
+++ b/EasyPost.Tests.NetFramework/UserTest.cs
@@ -86,7 +86,7 @@ namespace EasyPost.Tests.NetFramework
         {
             User user = CreateUser();
 
-            user.Destroy();
+            user.Delete();
         }
 
         // API keys are returned as plaintext, do not run this test.

--- a/EasyPost.Tests.NetFramework/WebhookTest.cs
+++ b/EasyPost.Tests.NetFramework/WebhookTest.cs
@@ -28,7 +28,7 @@ namespace EasyPost.Tests.NetFramework
                 try
                 {
                     Webhook retrievedWebhook = Webhook.Retrieve(webhookId);
-                    retrievedWebhook.Destroy();
+                    retrievedWebhook.Delete();
                     webhookId = null;
                 }
                 catch
@@ -104,7 +104,7 @@ namespace EasyPost.Tests.NetFramework
             Webhook webhook = CreateBasicWebhook(url);
             Webhook retrievedWebhook = Webhook.Retrieve(webhook.id);
 
-            bool success = retrievedWebhook.Destroy();
+            bool success = retrievedWebhook.Delete();
 
             // This endpoint/method does not return anything, just make sure the request doesn't fail
             Assert.IsTrue(success);


### PR DESCRIPTION
Our functions to delete a `User`, `CarrierAccount` or `Webhook` are called `Destroy()`. This could get confused with the programmatic concept of destroying a local object vs. deleting a server-side element. Renaming them to `Delete()` makes it more clear what these functions do.

This PR:
- Renames `Destroy` functions to `Delete`