### PR TITLE
Add CreateAndBuy function to Batch class

### DIFF
--- a/EasyPost.Net/Batch.cs
+++ b/EasyPost.Net/Batch.cs
@@ -166,6 +166,30 @@ namespace EasyPost
             return request.Execute<Batch>();
         }
 
+        /// <summary>
+        ///     Create and buy a Batch in one step.
+        /// </summary>
+        /// <param name="parameters">
+        ///     Optional dictionary containing parameters to create the batch with. Valid pairs:
+        ///     * {"shipments", List&lt;Dictionary&lt;string, object&gt;&gt;} See Shipment.Create for a list of valid keys.
+        ///     * {"reference", string}
+        ///     All invalid keys will be ignored.
+        /// </param>
+        /// <returns>EasyPost.Batch instance.</returns>
+        public static Batch CreateAndBuy(Dictionary<string, object> parameters = null)
+        {
+            parameters = parameters ?? new Dictionary<string, object>();
+
+            Request request = new Request("batches/create_and_buy", Method.Post);
+            request.AddBody(new Dictionary<string, object>
+            {
+                {
+                    "batch", parameters
+                }
+            });
+
+            return request.Execute<Batch>();
+        }
 
         /// <summary>
         ///     Retrieve a Batch from its id.

--- a/EasyPost.NetFramework/Batch.cs
+++ b/EasyPost.NetFramework/Batch.cs
@@ -167,6 +167,31 @@ namespace EasyPost
             return request.Execute<Batch>();
         }
 
+        /// <summary>
+        ///     Create and buy a Batch in one step.
+        /// </summary>
+        /// <param name="parameters">
+        ///     Optional dictionary containing parameters to create the batch with. Valid pairs:
+        ///     * {"shipments", List&lt;Dictionary&lt;string, object&gt;&gt;} See Shipment.Create for a list of valid keys.
+        ///     * {"reference", string}
+        ///     All invalid keys will be ignored.
+        /// </param>
+        /// <returns>EasyPost.Batch instance.</returns>
+        public static Batch CreateAndBuy(Dictionary<string, object> parameters = null)
+        {
+            parameters = parameters ?? new Dictionary<string, object>();
+
+            Request request = new Request("batches/create_and_buy", Method.POST);
+            request.AddBody(new Dictionary<string, object>
+            {
+                {
+                    "batch", parameters
+                }
+            });
+
+            return request.Execute<Batch>();
+        }
+
 
         /// <summary>
         ///     Retrieve a Batch from its id.

--- a/EasyPost.Tests.Net/BatchTest.cs
+++ b/EasyPost.Tests.Net/BatchTest.cs
@@ -87,20 +87,30 @@ namespace EasyPost.Tests.Net
             }
         }
 
-        // TODO: C# doesn't have a CreateAndBuy method for Batch
-        [Ignore]
         [TestMethod]
         public void TestCreateAndBuy()
         {
             VCR.Replay("create_and_buy");
+
+            Batch batch = Batch.CreateAndBuy(new Dictionary<string, object>
+            {
+                {
+                    "shipments", new List<Dictionary<string, object>>
+                    {
+                        Fixture.OneCallBuyShipment
+                    }
+                }
+            });
+
+            Assert.IsInstanceOfType(batch, typeof(Batch));
+            Assert.IsTrue(batch.id.StartsWith("batch_"));
+            Assert.AreEqual(1, batch.num_shipments);
         }
 
         [TestMethod]
         public void TestBuy()
         {
             VCR.Replay("buy");
-
-            var data = Fixture.OneCallBuyShipment;
 
             Batch batch = CreateOneCallBuyBatch();
 

--- a/EasyPost.Tests.Net/cassettes/batch/create_and_buy.json
+++ b/EasyPost.Tests.Net/cassettes/batch/create_and_buy.json
@@ -1,0 +1,52 @@
+[
+  {
+    "Request": {
+      "Method": "POST",
+      "URI": "https://api.easypost.com/v2/batches/create_and_buy",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "********",
+        "content_type": "application/json",
+        "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
+      },
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "571"
+      },
+      "Body": "{\"batch\":{\"shipments\":[{\"to_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\"},\"from_address\":{\"name\":\"Jack Sparrow\",\"company\":\"EasyPost\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"5555555555\"},\"parcel\":{\"length\":\"10\",\"width\":\"8\",\"height\":\"4\",\"weight\":\"15.4\"},\"service\":\"First\",\"carrier_accounts\":[\"ca_7642d249fdcf47bcb5da9ea34c96dfcf\"],\"carrier\":\"USPS\"}]}}"
+    },
+    "Response": {
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      },
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "1cbfe2c46227ab9fe016796f001e8683",
+        "Cache-Control": "no-store, no-cache",
+        "Pragma": "no-cache",
+        "ETag": "W/\"06516c97df5543185683db9567e4a484\"",
+        "X-Request-ID": "bd2c6548-1c3c-4deb-9d6c-c4bae623e653",
+        "x-runtime": "0.041979",
+        "x-node": "bigweb3nuq",
+        "x-version-label": "easypost-202203042109-ebc16e3e74-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb2nuq 88c34981dc,intlb2wdc 88c34981dc,extlb1wdc 88c34981dc",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "384"
+      },
+      "Body": "{\"id\":\"batch_ed1ae6e5f6794c7283a0b05304eb8674\",\"object\":\"Batch\",\"mode\":\"test\",\"state\":\"creating\",\"num_shipments\":1,\"reference\":null,\"created_at\":\"2022-03-08T19:16:47Z\",\"updated_at\":\"2022-03-08T19:16:47Z\",\"scan_form\":null,\"shipments\":[],\"status\":{\"created\":0,\"queued_for_purchase\":0,\"creation_failed\":0,\"postage_purchased\":0,\"postage_purchase_failed\":0},\"pickup\":null,\"label_url\":null}",
+      "HttpVersion": "1.1"
+    },
+    "RecordedAt": "2022-03-08T12:16:47.3362-07:00"
+  }
+]

--- a/EasyPost.Tests.NetFramework/BatchTest.cs
+++ b/EasyPost.Tests.NetFramework/BatchTest.cs
@@ -80,11 +80,22 @@ namespace EasyPost.Tests.NetFramework
             }
         }
 
-        // TODO: C# doesn't have a CreateAndBuy method for Batch
-        [Ignore]
         [TestMethod]
         public void TestCreateAndBuy()
         {
+            Batch batch = Batch.CreateAndBuy(new Dictionary<string, object>
+            {
+                {
+                    "shipments", new List<Dictionary<string, object>>
+                    {
+                        Fixture.OneCallBuyShipment
+                    }
+                }
+            });
+
+            Assert.IsInstanceOfType(batch, typeof(Batch));
+            Assert.IsTrue(batch.id.StartsWith("batch_"));
+            Assert.AreEqual(1, batch.num_shipments);
         }
 
         // hard to test because the sleep time is hit-or-miss
@@ -92,8 +103,6 @@ namespace EasyPost.Tests.NetFramework
         [TestMethod]
         public void TestBuy()
         {
-            var data = Fixture.OneCallBuyShipment;
-
             Batch batch = CreateOneCallBuyBatch();
 
             batch.Buy();


### PR DESCRIPTION
Our C# library is missing the CreateAndBuy one-step function for batches that is present in other client libraries.

This PR:
- Adds `CreateAndBuy` function to `Batch`
- Adds unit tests and required VCR cassettes