### PR TITLE
WIP: Thread Manager

### DIFF
--- a/EasyPost.Net/ThreadManager.cs
+++ b/EasyPost.Net/ThreadManager.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace EasyPost
+{
+    public static class ThreadManager
+    {
+        private static Dictionary<int, string> ThreadApiKeyPairs = new Dictionary<int, string>();
+
+        public static void RegisterThread(int threadId, string apiKey)
+        {
+            ThreadApiKeyPairs.Add(threadId, apiKey);
+        }
+
+        public static void RegisterThread(Thread thread, string apiKey)
+        {
+            RegisterThread(thread.ManagedThreadId, apiKey);
+        }
+
+        internal static string GetApiKeyForThread(int threadId)
+        {
+            try
+            {
+                return ThreadApiKeyPairs[threadId];
+            }
+            catch (KeyNotFoundException)
+            {
+                throw new Exception("No API key registered for this thread.");
+            }
+        }
+
+        internal static string GetApiKeyForThread(Thread thread)
+        {
+            return GetApiKeyForThread(thread.ManagedThreadId);
+        }
+
+        internal static string GetApiKeyForCurrentThread()
+        {
+            return GetApiKeyForThread(Thread.CurrentThread);
+        }
+
+        public static void DeregisterThread(int threadId)
+        {
+            try
+            {
+                ThreadApiKeyPairs.Remove(threadId);
+            }
+            catch (KeyNotFoundException)
+            {
+                // Do nothing
+            }
+        }
+
+        public static void DeregisterThread(Thread thread)
+        {
+            DeregisterThread(thread.ManagedThreadId);
+        }
+
+        public static void DeregisterAllThreads()
+        {
+            ThreadApiKeyPairs.Clear();
+        }
+    }
+}


### PR DESCRIPTION
In response to #98 , one proposed solution is to track the different API keys for different threads in a multi-threaded environment.

This is a proof of concept, implementing a ThreadManager, which stores and tracks thread-API key pairs.

To use it, users would first enable multithreading support by `ClientManager.IsMultithreaded = true`, and then register a thread with `ThreadManager.RegisterThread(thread/threadId, apiKey)`. When loading a `Client` for a request, if multithreading is enabled, the `ClientManager` will poll the `ThreadManager` for the API key corresponding to the currently running thread.