### PR TITLE
WIP: Removing non-static `Create` methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
       EASYPOST_PROD_API_KEY: ${{ secrets.EASYPOST_PROD_API_KEY }}
     strategy:
       matrix:
-        dotnet-version: [ 'NetFramework35', 'NetCore31', 'Net50', 'Net60' ]
+        platform: [ 'NetFramework35', 'NetCore31', 'Net50', 'Net60' ]
     steps:
       - uses: actions/checkout@v2
-        # Set the project name, based on .NET version currently selected
+        # Set the project name, based on platform version currently selected
       - name: Set up variables
         id: test_project
-        run: echo "::set-output name=test_file::EasyPost.Tests.${{ matrix.dotnet-version }}"
+        run: echo "::set-output name=test_file::EasyPost.Tests.${{ matrix.platform }}"
         # install MSBuild, used to build the test project
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.1
@@ -47,3 +47,34 @@ jobs:
         # Run the tests
       - name: Run Tests
         run: vstest.console.exe ${{ steps.test_project.outputs.test_file }}\bin\Test\${{ steps.test_project.outputs.test_file }}.dll
+  Compatibility_Tests:
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        platform: [ 'VB', 'FSharp' ]
+        include:
+          - platform: VB
+            ext: vbproj
+          - platform: FSharp
+            ext: fsproj
+    steps:
+      - uses: actions/checkout@v2
+        # Set the project name, based on platform version currently selected
+      - name: Set up variables
+        id: test_project
+        run: echo "::set-output name=test_file::EasyPost.Tests.${{ matrix.platform }}"
+        # install MSBuild, used to build the test project
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.1
+        # install NuGet.exe to restore required NuGet packages
+      - name: Setup Nuget
+        uses: NuGet/setup-nuget@v1.0.5
+        # install Visual Studio's console test application, to execute tests
+      - name: Setup VSTest
+        uses: darenm/Setup-VSTest@v1
+        # Restore required NuGet packages
+      - name: Restore NuGet Packages
+        run: nuget restore EasyPost.sln
+        # Build the test project
+      - name: Build Solution
+        run: msbuild ${{ steps.test_project.outputs.test_file }}\${{ steps.test_project.outputs.test_file }}.${{ matrix.ext }} /p:platform="Any CPU" /p:configuration="Debug" /p:outputPath="bin/Test" /p:target="Rebuild" -restore

--- a/EasyPost.Net/Address.cs
+++ b/EasyPost.Net/Address.cs
@@ -55,45 +55,11 @@ namespace EasyPost
         public string zip { get; set; }
 
         /// <summary>
-        ///     Create this Address.
-        /// </summary>
-        /// <exception cref="ResourceAlreadyCreated">Address already has an id.</exception>
-        public void Create() => Create(verify, verify_strict);
-
-        /// <summary>
-        ///     Create this Address.
-        /// </summary>
-        /// <param name="verifications">
-        ///     A list of verifications to perform on the address.
-        ///     Possible items are "delivery" and "zip4".
-        /// </param>
-        /// <param name="strictVerifications">
-        ///     A list of verifications to perform on the address.
-        ///     Will cause an HttpException to be raised if unsuccessful.
-        ///     Possible items are "delivery" and "zip4".
-        /// </param>
-        /// <exception cref="ResourceAlreadyCreated">Address already has an id.</exception>
-        public void Create(List<string> verifications = null, List<string> strictVerifications = null)
-        {
-            if (id != null)
-            {
-                throw new ResourceAlreadyCreated();
-            }
-
-            Merge(SendCreate(AsDictionary(), verifications, strictVerifications));
-        }
-
-        /// <summary>
         ///     Verify an address.
         /// </summary>
         /// <returns>EasyPost.Address instance. Check message for verification failures.</returns>
         public void Verify(string carrier = null)
         {
-            if (id == null)
-            {
-                Create();
-            }
-
             Request request = new Request("addresses/{id}/verify")
             {
                 RootElement = "address"

--- a/EasyPost.Net/Address.cs
+++ b/EasyPost.Net/Address.cs
@@ -60,6 +60,11 @@ namespace EasyPost
         /// <returns>EasyPost.Address instance. Check message for verification failures.</returns>
         public void Verify(string carrier = null)
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("addresses/{id}/verify")
             {
                 RootElement = "address"

--- a/EasyPost.Net/Exception.cs
+++ b/EasyPost.Net/Exception.cs
@@ -49,6 +49,22 @@ namespace EasyPost
     }
 
     [Serializable]
+    public class PropertyMissing : Exception
+    {
+        private readonly string _property;
+
+        public PropertyMissing(string property)
+        {
+            _property = property;
+        }
+
+        public override string Message
+        {
+            get { return $"Missing {_property}"; }
+        }
+    }
+
+    [Serializable]
     public class ClientNotConfigured : Exception
     {
     }

--- a/EasyPost.Net/Order.cs
+++ b/EasyPost.Net/Order.cs
@@ -69,29 +69,10 @@ namespace EasyPost
         public void Buy(Rate rate) => Buy(rate.carrier, rate.service);
 
         /// <summary>
-        ///     Create this Order.
-        /// </summary>
-        /// <exception cref="ResourceAlreadyCreated">Order already has an id.</exception>
-        public void Create()
-        {
-            if (id != null)
-            {
-                throw new ResourceAlreadyCreated();
-            }
-
-            Merge(SendCreate(AsDictionary()));
-        }
-
-        /// <summary>
         ///     Populate the rates property for this Order.
         /// </summary>
         public void GetRates()
         {
-            if (id == null)
-            {
-                Create();
-            }
-
             Request request = new Request("orders/{id}/rates");
             request.AddUrlSegment("id", id);
 

--- a/EasyPost.Net/Order.cs
+++ b/EasyPost.Net/Order.cs
@@ -47,6 +47,11 @@ namespace EasyPost
         /// <param name="service">The service to purchase.</param>
         public void Buy(string carrier, string service)
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("orders/{id}/buy", Method.Post);
             request.AddUrlSegment("id", id);
             request.AddQueryString(new Dictionary<string, object>
@@ -73,6 +78,11 @@ namespace EasyPost
         /// </summary>
         public void GetRates()
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("orders/{id}/rates");
             request.AddUrlSegment("id", id);
 

--- a/EasyPost.Net/Pickup.cs
+++ b/EasyPost.Net/Pickup.cs
@@ -74,20 +74,6 @@ namespace EasyPost
         }
 
         /// <summary>
-        ///     Create this Pickup.
-        /// </summary>
-        /// <exception cref="ResourceAlreadyCreated">Pickup already has an id.</exception>
-        public void Create()
-        {
-            if (id != null)
-            {
-                throw new ResourceAlreadyCreated();
-            }
-
-            Merge(SendCreate(AsDictionary()));
-        }
-
-        /// <summary>
         ///     Create a Pickup.
         /// </summary>
         /// <param name="parameters">

--- a/EasyPost.Net/Pickup.cs
+++ b/EasyPost.Net/Pickup.cs
@@ -47,6 +47,11 @@ namespace EasyPost
         /// <param name="service">The name of the service to purchase.</param>
         public void Buy(string carrier, string service)
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("pickups/{id}/buy", Method.Post);
             request.AddUrlSegment("id", id);
             request.AddQueryString(new Dictionary<string, object>
@@ -67,6 +72,11 @@ namespace EasyPost
         /// </summary>
         public void Cancel()
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("pickups/{id}/cancel", Method.Post);
             request.AddUrlSegment("id", id);
 

--- a/EasyPost.Net/Shipment.cs
+++ b/EasyPost.Net/Shipment.cs
@@ -125,20 +125,6 @@ namespace EasyPost
         public void Buy(Rate rate, string insuranceValue = null) => Buy(rate.id, insuranceValue);
 
         /// <summary>
-        ///     Create this Shipment.
-        /// </summary>
-        /// <exception cref="ResourceAlreadyCreated">Shipment already has an id.</exception>
-        public void Create()
-        {
-            if (id != null)
-            {
-                throw new ResourceAlreadyCreated();
-            }
-
-            Merge(SendCreate(AsDictionary()));
-        }
-
-        /// <summary>
         ///     Generate a postage label for this shipment.
         /// </summary>
         /// <param name="fileFormat">Format to generate the label in. Valid formats: "pdf", "zpl" and "epl2".</param>
@@ -158,11 +144,6 @@ namespace EasyPost
         /// <returns>A list of EasyPost.Smartrate instances.</returns>
         public List<Smartrate> GetSmartrates()
         {
-            if (id == null)
-            {
-                Create();
-            }
-
             Request request = new Request("shipments/{id}/smartrate");
             request.AddUrlSegment("id", id);
             request.RootElement = "result";
@@ -235,11 +216,6 @@ namespace EasyPost
         /// <param name="parameters">Optional dictionary of parameters for the API request.</param>
         public void RegenerateRates(Dictionary<string, object> parameters = null)
         {
-            if (id == null)
-            {
-                Create();
-            }
-
             Request request = new Request("shipments/{id}/rerate", Method.Post);
             request.AddUrlSegment("id", id);
             if (parameters != null)

--- a/EasyPost.Net/Shipment.cs
+++ b/EasyPost.Net/Shipment.cs
@@ -82,6 +82,11 @@ namespace EasyPost
         /// <param name="insuranceValue">The value to insure the shipment for.</param>
         public void Buy(string rateId, string insuranceValue = null)
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("shipments/{id}/buy", Method.Post);
             request.AddUrlSegment("id", id);
 
@@ -130,6 +135,11 @@ namespace EasyPost
         /// <param name="fileFormat">Format to generate the label in. Valid formats: "pdf", "zpl" and "epl2".</param>
         public void GenerateLabel(string fileFormat)
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("shipments/{id}/label");
             request.AddUrlSegment("id", id);
             // This is a GET, but uses the request body, so use ParameterType.GetOrPost instead.
@@ -144,6 +154,11 @@ namespace EasyPost
         /// <returns>A list of EasyPost.Smartrate instances.</returns>
         public List<Smartrate> GetSmartrates()
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("shipments/{id}/smartrate");
             request.AddUrlSegment("id", id);
             request.RootElement = "result";
@@ -157,6 +172,11 @@ namespace EasyPost
         /// <param name="amount">The amount to insure the shipment for. Currency is provided when creating a shipment.</param>
         public void Insure(double amount)
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("shipments/{id}/insure", Method.Post);
             request.AddUrlSegment("id", id);
             request.AddQueryString(new Dictionary<string, object>
@@ -216,6 +236,11 @@ namespace EasyPost
         /// <param name="parameters">Optional dictionary of parameters for the API request.</param>
         public void RegenerateRates(Dictionary<string, object> parameters = null)
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("shipments/{id}/rerate", Method.Post);
             request.AddUrlSegment("id", id);
             if (parameters != null)
@@ -231,6 +256,11 @@ namespace EasyPost
         /// </summary>
         public void Refund()
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("shipments/{id}/refund");
             request.AddUrlSegment("id", id);
 

--- a/EasyPost.NetFramework/Address.cs
+++ b/EasyPost.NetFramework/Address.cs
@@ -55,45 +55,11 @@ namespace EasyPost
         public string zip { get; set; }
 
         /// <summary>
-        ///     Create this Address.
-        /// </summary>
-        /// <exception cref="ResourceAlreadyCreated">Address already has an id.</exception>
-        public void Create() => Create(verify, verify_strict);
-
-        /// <summary>
-        ///     Create this Address.
-        /// </summary>
-        /// <param name="verifications">
-        ///     A list of verifications to perform on the address.
-        ///     Possible items are "delivery" and "zip4".
-        /// </param>
-        /// <param name="strictVerifications">
-        ///     A list of verifications to perform on the address.
-        ///     Will cause an HttpException to be raised if unsuccessful.
-        ///     Possible items are "delivery" and "zip4".
-        /// </param>
-        /// <exception cref="ResourceAlreadyCreated">Address already has an id.</exception>
-        public void Create(List<string> verifications = null, List<string> strictVerifications = null)
-        {
-            if (id != null)
-            {
-                throw new ResourceAlreadyCreated();
-            }
-
-            Merge(SendCreate(AsDictionary(), verifications, strictVerifications));
-        }
-
-        /// <summary>
         ///     Verify an address.
         /// </summary>
         /// <returns>EasyPost.Address instance. Check message for verification failures.</returns>
         public void Verify(string carrier = null)
         {
-            if (id == null)
-            {
-                Create();
-            }
-
             Request request = new Request("addresses/{id}/verify")
             {
                 RootElement = "address"

--- a/EasyPost.NetFramework/Address.cs
+++ b/EasyPost.NetFramework/Address.cs
@@ -60,6 +60,11 @@ namespace EasyPost
         /// <returns>EasyPost.Address instance. Check message for verification failures.</returns>
         public void Verify(string carrier = null)
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("addresses/{id}/verify")
             {
                 RootElement = "address"

--- a/EasyPost.NetFramework/Exception.cs
+++ b/EasyPost.NetFramework/Exception.cs
@@ -49,6 +49,22 @@ namespace EasyPost
     }
 
     [Serializable]
+    public class PropertyMissing : Exception
+    {
+        private readonly string _property;
+
+        public PropertyMissing(string property)
+        {
+            _property = property;
+        }
+
+        public override string Message
+        {
+            get { return $"Missing {_property}"; }
+        }
+    }
+
+    [Serializable]
     public class ClientNotConfigured : Exception
     {
     }

--- a/EasyPost.NetFramework/Order.cs
+++ b/EasyPost.NetFramework/Order.cs
@@ -69,29 +69,10 @@ namespace EasyPost
         public void Buy(Rate rate) => Buy(rate.carrier, rate.service);
 
         /// <summary>
-        ///     Create this Order.
-        /// </summary>
-        /// <exception cref="ResourceAlreadyCreated">Order already has an id.</exception>
-        public void Create()
-        {
-            if (id != null)
-            {
-                throw new ResourceAlreadyCreated();
-            }
-
-            Merge(SendCreate(AsDictionary()));
-        }
-
-        /// <summary>
         ///     Populate the rates property for this Order.
         /// </summary>
         public void GetRates()
         {
-            if (id == null)
-            {
-                Create();
-            }
-
             Request request = new Request("orders/{id}/rates");
             request.AddUrlSegment("id", id);
 

--- a/EasyPost.NetFramework/Order.cs
+++ b/EasyPost.NetFramework/Order.cs
@@ -47,6 +47,11 @@ namespace EasyPost
         /// <param name="service">The service to purchase.</param>
         public void Buy(string carrier, string service)
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("orders/{id}/buy", Method.POST);
             request.AddUrlSegment("id", id);
             request.AddQueryString(new Dictionary<string, object>
@@ -73,6 +78,11 @@ namespace EasyPost
         /// </summary>
         public void GetRates()
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("orders/{id}/rates");
             request.AddUrlSegment("id", id);
 

--- a/EasyPost.NetFramework/Pickup.cs
+++ b/EasyPost.NetFramework/Pickup.cs
@@ -47,6 +47,11 @@ namespace EasyPost
         /// <param name="service">The name of the service to purchase.</param>
         public void Buy(string carrier, string service)
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("pickups/{id}/buy", Method.POST);
             request.AddUrlSegment("id", id);
             request.AddQueryString(new Dictionary<string, object>
@@ -67,6 +72,11 @@ namespace EasyPost
         /// </summary>
         public void Cancel()
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("pickups/{id}/cancel", Method.POST);
             request.AddUrlSegment("id", id);
 

--- a/EasyPost.NetFramework/Pickup.cs
+++ b/EasyPost.NetFramework/Pickup.cs
@@ -74,20 +74,6 @@ namespace EasyPost
         }
 
         /// <summary>
-        ///     Create this Pickup.
-        /// </summary>
-        /// <exception cref="ResourceAlreadyCreated">Pickup already has an id.</exception>
-        public void Create()
-        {
-            if (id != null)
-            {
-                throw new ResourceAlreadyCreated();
-            }
-
-            Merge(SendCreate(AsDictionary()));
-        }
-
-        /// <summary>
         ///     Create a Pickup.
         /// </summary>
         /// <param name="parameters">

--- a/EasyPost.NetFramework/Shipment.cs
+++ b/EasyPost.NetFramework/Shipment.cs
@@ -125,20 +125,6 @@ namespace EasyPost
         public void Buy(Rate rate, string insuranceValue = null) => Buy(rate.id, insuranceValue);
 
         /// <summary>
-        ///     Create this Shipment.
-        /// </summary>
-        /// <exception cref="ResourceAlreadyCreated">Shipment already has an id.</exception>
-        public void Create()
-        {
-            if (id != null)
-            {
-                throw new ResourceAlreadyCreated();
-            }
-
-            Merge(SendCreate(AsDictionary()));
-        }
-
-        /// <summary>
         ///     Generate a postage label for this shipment.
         /// </summary>
         /// <param name="fileFormat">Format to generate the label in. Valid formats: "pdf", "zpl" and "epl2".</param>
@@ -158,11 +144,6 @@ namespace EasyPost
         /// <returns>A list of EasyPost.Smartrate instances.</returns>
         public List<Smartrate> GetSmartrates()
         {
-            if (id == null)
-            {
-                Create();
-            }
-
             Request request = new Request("shipments/{id}/smartrate");
             request.AddUrlSegment("id", id);
             request.RootElement = "result";
@@ -235,11 +216,6 @@ namespace EasyPost
         /// <param name="parameters">Optional dictionary of parameters for the API request.</param>
         public void RegenerateRates(Dictionary<string, object> parameters = null)
         {
-            if (id == null)
-            {
-                Create();
-            }
-
             Request request = new Request("shipments/{id}/rerate", Method.POST);
             request.AddUrlSegment("id", id);
             if (parameters != null)

--- a/EasyPost.NetFramework/Shipment.cs
+++ b/EasyPost.NetFramework/Shipment.cs
@@ -82,6 +82,11 @@ namespace EasyPost
         /// <param name="insuranceValue">The value to insure the shipment for.</param>
         public void Buy(string rateId, string insuranceValue = null)
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("shipments/{id}/buy", Method.POST);
             request.AddUrlSegment("id", id);
 
@@ -130,6 +135,11 @@ namespace EasyPost
         /// <param name="fileFormat">Format to generate the label in. Valid formats: "pdf", "zpl" and "epl2".</param>
         public void GenerateLabel(string fileFormat)
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("shipments/{id}/label");
             request.AddUrlSegment("id", id);
             // This is a GET, but uses the request body, so use ParameterType.GetOrPost instead.
@@ -144,6 +154,11 @@ namespace EasyPost
         /// <returns>A list of EasyPost.Smartrate instances.</returns>
         public List<Smartrate> GetSmartrates()
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("shipments/{id}/smartrate");
             request.AddUrlSegment("id", id);
             request.RootElement = "result";
@@ -157,6 +172,11 @@ namespace EasyPost
         /// <param name="amount">The amount to insure the shipment for. Currency is provided when creating a shipment.</param>
         public void Insure(double amount)
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("shipments/{id}/insure", Method.POST);
             request.AddUrlSegment("id", id);
             request.AddQueryString(new Dictionary<string, object>
@@ -216,6 +236,11 @@ namespace EasyPost
         /// <param name="parameters">Optional dictionary of parameters for the API request.</param>
         public void RegenerateRates(Dictionary<string, object> parameters = null)
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("shipments/{id}/rerate", Method.POST);
             request.AddUrlSegment("id", id);
             if (parameters != null)
@@ -231,6 +256,11 @@ namespace EasyPost
         /// </summary>
         public void Refund()
         {
+            if (id == null)
+            {
+                throw new PropertyMissing("id");
+            }
+
             Request request = new Request("shipments/{id}/refund");
             request.AddUrlSegment("id", id);
 

--- a/EasyPost.Tests.FSharp/EasyPost.Tests.FSharp.fsproj
+++ b/EasyPost.Tests.FSharp/EasyPost.Tests.FSharp.fsproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="FSharpCompileTest.fs" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\EasyPost.Net\EasyPost.Net.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+      <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+      <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    </ItemGroup>
+
+</Project>

--- a/EasyPost.Tests.FSharp/FSharpCompileTest.fs
+++ b/EasyPost.Tests.FSharp/FSharpCompileTest.fs
@@ -1,0 +1,16 @@
+﻿// This test checks that EasyPost C# code can be used in F#.
+// This test project is running on .NET 6.0, although a success here should mean a success in all versions of .NET.'
+
+namespace EasyPost.Tests.FSharp
+
+open System
+open EasyPost
+open Microsoft.VisualStudio.TestTools.UnitTesting
+
+[<TestClass>]
+type FSharpCompileTest () =
+    [<TestMethod>]
+    member this.TestCompile() =
+        // The assert doesn't really do anything, but as long as this test can run, then the code is compiling correctly.
+        let result = Assert.ThrowsException<ClientNotConfigured>(fun() -> Console.Write(CarrierType.All()); new obj())
+        Assert.IsNotNull(result)

--- a/EasyPost.Tests.VB/EasyPost.Tests.VB.vbproj
+++ b/EasyPost.Tests.VB/EasyPost.Tests.VB.vbproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <RootNamespace>EasyPost.Tests.VB</RootNamespace>
+        <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\EasyPost.Net\EasyPost.Net.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+      <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+      <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    </ItemGroup>
+
+</Project>

--- a/EasyPost.Tests.VB/VbCompileTest.vb
+++ b/EasyPost.Tests.VB/VbCompileTest.vb
@@ -1,0 +1,13 @@
+' This test checks that EasyPost C# code can be used in Visual Basic.
+' This test project is running on .NET 6.0, although a success here should mean a success in all versions of .NET.
+Imports Microsoft.VisualStudio.TestTools.UnitTesting
+
+<TestClass>
+Public Class VbCompileTest
+    <TestMethod>
+    Public Sub Test()
+        ' API key is not set, so calling CarrierType.All() will produce an error.
+        ' But if this runs, then the code compiled properly.
+        Assert.ThrowsException(Of ClientNotConfigured)(Function() CarrierType.All())
+    End Sub
+End Class

--- a/EasyPost.Tests.VB/VbCompileTest.vb
+++ b/EasyPost.Tests.VB/VbCompileTest.vb
@@ -1,13 +1,27 @@
-' This test checks that EasyPost C# code can be used in Visual Basic.
-' This test project is running on .NET 6.0, although a success here should mean a success in all versions of .NET.
+'This test checks that EasyPost C# code can be used in Visual Basic.
+'This test project is running on .NET 6.0, although a success here should mean a success in all versions of .NET.
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 
 <TestClass>
 Public Class VbCompileTest
     <TestMethod>
-    Public Sub Test()
-        ' API key is not set, so calling CarrierType.All() will produce an error.
-        ' But if this runs, then the code compiled properly.
+    Public Sub TestCompile()
+        'API key is not set, so calling CarrierType.All() will produce an error. But if this runs, then the code compiled properly.
         Assert.ThrowsException(Of ClientNotConfigured)(Function() CarrierType.All())
+    End Sub
+
+    <TestMethod>
+    Public Sub TestAddress()
+        Dim addressData As New Dictionary(Of String, Object)()
+
+        addressData.Add("name", "John Smith")
+        addressData.Add("street1", "123 Main St")
+        addressData.Add("city", "San Francisco")
+        addressData.Add("state", "CA")
+        addressData.Add("zip", "94107")
+        addressData.Add("country", "US")
+
+        'Without an API key, this will throw an error. But as long as it's a ClientNotConfigured exception, it's a success.
+        Assert.ThrowsException(Of ClientNotConfigured)(Function() Address.Create(addressData))
     End Sub
 End Class

--- a/EasyPost.sln
+++ b/EasyPost.sln
@@ -21,6 +21,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyPost.Tests.Net60", "Eas
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Scotch", "Scotch\Scotch.csproj", "{0760BEC5-5629-4B1D-9B1F-BF84AC34D0F9}"
 EndProject
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "EasyPost.Tests.VB", "EasyPost.Tests.VB\EasyPost.Tests.VB.vbproj", "{E4E916C4-A35B-4EA4-90D7-5418978C0F34}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "EasyPost.Tests.FSharp", "EasyPost.Tests.FSharp\EasyPost.Tests.FSharp.fsproj", "{D264E3CC-396C-43B5-AFEA-02E50E61E2E4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +61,14 @@ Global
 		{0760BEC5-5629-4B1D-9B1F-BF84AC34D0F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0760BEC5-5629-4B1D-9B1F-BF84AC34D0F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0760BEC5-5629-4B1D-9B1F-BF84AC34D0F9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E4E916C4-A35B-4EA4-90D7-5418978C0F34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4E916C4-A35B-4EA4-90D7-5418978C0F34}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4E916C4-A35B-4EA4-90D7-5418978C0F34}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4E916C4-A35B-4EA4-90D7-5418978C0F34}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D264E3CC-396C-43B5-AFEA-02E50E61E2E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D264E3CC-396C-43B5-AFEA-02E50E61E2E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D264E3CC-396C-43B5-AFEA-02E50E61E2E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D264E3CC-396C-43B5-AFEA-02E50E61E2E4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Per #151 , Visual Basic cannot tell the difference between a static and non-static version of the same method signature. This is an issue because we have both static and non-static `Create` methods in a handful of our classes.

The non-static methods, however, are for creating/recreating an object in case its `id` is blank, which logically does not make much sense. Why are we checking, i.e. when calling `myOrder.Buy()` whether `myOrder` exists? Of course it does.

The methods were likely implemented for a single-altered structure, accounting for if the `id` was somehow blank/not returned by the API. There are better ways to handle this. For now, I have removed the `id` check, but if it is truly necessary, we should have an exception thrown, rather have the library attempt to regenerate the object. In that case, we can rollback part of these changes and add a new `ResourceNotCreated` expection.

By removing these non-static `Create` methods, there should be no more ambiguity for Visual Basic.