### PR TITLE
Fix issues with the port to v107. Need singleton RestClient and cannot use GetAwaiter().GetResult()!

### DIFF
--- a/EasyPost.Net/AsyncHelpers.cs
+++ b/EasyPost.Net/AsyncHelpers.cs
@@ -1,0 +1,136 @@
+﻿/*
+ * Taken from Rebus
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EasyPost
+{
+    public static class AsyncHelpers
+    {
+        /// <summary>
+        /// Executes a task synchronously on the calling thread by installing a temporary synchronization context that queues continuations
+        /// </summary>
+        /// <param name="task">Callback for asynchronous task to run</param>
+        public static void RunSync(
+            Func<Task> task)
+        {
+            var currentContext = SynchronizationContext.Current;
+            var customContext = new CustomSynchronizationContext(task);
+            try {
+                SynchronizationContext.SetSynchronizationContext(customContext);
+                customContext.Run();
+            } finally {
+                SynchronizationContext.SetSynchronizationContext(currentContext);
+            }
+        }
+
+        /// <summary>
+        /// Executes a task synchronously on the calling thread by installing a temporary synchronization context that queues continuations
+        /// </summary>
+        /// <param name="task">Callback for asynchronous task to run</param>
+        /// <typeparam name="T">Return type for the task</typeparam>
+        /// <returns>Return value from the task</returns>
+        public static T RunSync<T>(
+            Func<Task<T>> task)
+        {
+            T result = default;
+            RunSync(async () => {
+                result = await task();
+            });
+            return result;
+        }
+
+        /// <summary>
+        /// Synchronization context that can be "pumped" in order to have it execute continuations posted back to it
+        /// </summary>
+        private class CustomSynchronizationContext : SynchronizationContext
+        {
+            private readonly ConcurrentQueue<Tuple<SendOrPostCallback, object>> _items = new ConcurrentQueue<Tuple<SendOrPostCallback, object>>();
+            private readonly AutoResetEvent _workItemsWaiting = new AutoResetEvent(false);
+            private readonly Func<Task> _task;
+            private ExceptionDispatchInfo _caughtException;
+            private bool _done;
+
+            /// <summary>
+            /// Constructor for the custom context
+            /// </summary>
+            /// <param name="task"></param>
+            /// <exception cref="ArgumentNullException"></exception>
+            public CustomSynchronizationContext(
+                Func<Task> task)
+            {
+                _task = task ?? throw new ArgumentNullException(nameof(task), "Please remember to pass a Task to be executed");
+            }
+
+            /// <summary>
+            /// When overridden in a derived class, dispatches an asynchronous message to a synchronization context.
+            /// </summary>
+            /// <param name="function">Callback function</param>
+            /// <param name="state">Callback state</param>
+            public override void Post(
+                SendOrPostCallback function,
+                object state)
+            {
+                _items.Enqueue(Tuple.Create(function, state));
+                _workItemsWaiting.Set();
+            }
+
+            /// <summary>
+            /// Enqueues the function to be executed and executes all resulting continuations until it is completely done
+            /// </summary>
+            public void Run()
+            {
+                Post(async _ => {
+                        try {
+                            await _task().ConfigureAwait(false);
+                        } catch (Exception exception) {
+                            _caughtException = ExceptionDispatchInfo.Capture(exception);
+                            throw;
+                        } finally {
+                            Post(state => _done = true, null);
+                        }
+                    },
+                    null);
+
+                while (!_done) {
+                    if (_items.TryDequeue(out var task)) {
+                        task.Item1(task.Item2);
+                        if (_caughtException == null) {
+                            continue;
+                        }
+                        _caughtException.Throw();
+                    } else {
+                        _workItemsWaiting.WaitOne();
+                    }
+                }
+            }
+
+            /// <summary>
+            /// When overridden in a derived class, dispatches a synchronous message to a synchronization context.
+            /// </summary>
+            /// <param name="function">Callback function</param>
+            /// <param name="state">Callback state</param>
+            public override void Send(
+                SendOrPostCallback function,
+                object state)
+            {
+                throw new NotSupportedException("Cannot send to same thread");
+            }
+
+            /// <summary>
+            /// When overridden in a derived class, creates a copy of the synchronization context.
+            /// </summary>
+            /// <returns>Copy of the context</returns>
+            public override SynchronizationContext CreateCopy()
+            {
+                // Not needed, so just return ourselves
+                return this;
+            }
+        }
+    }
+}

--- a/EasyPost.Net/AsyncHelpers.cs
+++ b/EasyPost.Net/AsyncHelpers.cs
@@ -21,10 +21,13 @@ namespace EasyPost
         {
             var currentContext = SynchronizationContext.Current;
             var customContext = new CustomSynchronizationContext(task);
-            try {
+            try
+            {
                 SynchronizationContext.SetSynchronizationContext(customContext);
                 customContext.Run();
-            } finally {
+            }
+            finally
+            {
                 SynchronizationContext.SetSynchronizationContext(currentContext);
             }
         }
@@ -39,9 +42,7 @@ namespace EasyPost
             Func<Task<T>> task)
         {
             T result = default;
-            RunSync(async () => {
-                result = await task();
-            });
+            RunSync(async () => { result = await task(); });
             return result;
         }
 
@@ -85,26 +86,38 @@ namespace EasyPost
             /// </summary>
             public void Run()
             {
-                Post(async _ => {
-                        try {
+                Post(async _ =>
+                    {
+                        try
+                        {
                             await _task().ConfigureAwait(false);
-                        } catch (Exception exception) {
+                        }
+                        catch (Exception exception)
+                        {
                             _caughtException = ExceptionDispatchInfo.Capture(exception);
                             throw;
-                        } finally {
+                        }
+                        finally
+                        {
                             Post(state => _done = true, null);
                         }
                     },
                     null);
 
-                while (!_done) {
-                    if (_items.TryDequeue(out var task)) {
+                while (!_done)
+                {
+                    if (_items.TryDequeue(out var task))
+                    {
                         task.Item1(task.Item2);
-                        if (_caughtException == null) {
+                        if (_caughtException == null)
+                        {
                             continue;
                         }
+
                         _caughtException.Throw();
-                    } else {
+                    }
+                    else
+                    {
                         _workItemsWaiting.WaitOne();
                     }
                 }

--- a/EasyPost.Net/RestClientFactory.cs
+++ b/EasyPost.Net/RestClientFactory.cs
@@ -17,14 +17,17 @@ namespace EasyPost
             string cacheKey = options.BaseUrl!.ToString();
 
             // If we have an existing instance of this client, return it outside of the lock
-            if (_clients.TryGetValue(cacheKey, out var client)) {
+            if (_clients.TryGetValue(cacheKey, out var client))
+            {
                 return client;
             }
 
             // Create a new instance, but make sure only one thread can create it
-            lock (_clients) {
+            lock (_clients)
+            {
                 // Try again to get it, as it might have just been created by another thread
-                if (_clients.TryGetValue(cacheKey, out client)) {
+                if (_clients.TryGetValue(cacheKey, out client))
+                {
                     return client;
                 }
 

--- a/EasyPost.Net/RestClientFactory.cs
+++ b/EasyPost.Net/RestClientFactory.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Concurrent;
+using RestSharp;
+
+namespace EasyPost
+{
+    public static class RestClientFactory
+    {
+        /// <summary>
+        /// Dictionary of all static client instances based on the client API base URL
+        /// </summary>
+        private static readonly ConcurrentDictionary<string, RestClient> _clients = new ConcurrentDictionary<string, RestClient>();
+
+        public static RestClient GetClient(
+            RestClientOptions options)
+        {
+            // Build a key to cache the client against which is the base URL we are connecting to
+            string cacheKey = options.BaseUrl!.ToString();
+
+            // If we have an existing instance of this client, return it outside of the lock
+            if (_clients.TryGetValue(cacheKey, out var client)) {
+                return client;
+            }
+
+            // Create a new instance, but make sure only one thread can create it
+            lock (_clients) {
+                // Try again to get it, as it might have just been created by another thread
+                if (_clients.TryGetValue(cacheKey, out client)) {
+                    return client;
+                }
+
+                client = new RestClient(cacheKey);
+                _clients.TryAdd(cacheKey, client);
+                return client;
+            }
+        }
+    }
+}

--- a/EasyPost.Tests.NetFramework/TestSuite.cs
+++ b/EasyPost.Tests.NetFramework/TestSuite.cs
@@ -30,6 +30,9 @@ namespace EasyPost.Tests.NetFramework
         public static void SetUp(string apiKey)
         {
             ClientManager.SetCurrent(GetClientFunction(apiKey));
+
+            // Allow TLS 1.2 for the tests to work
+            System.Net.ServicePointManager.SecurityProtocol |= System.Net.SecurityProtocolType.Tls12;
         }
 
         public static void SetUp(TestSuiteApiKey apiKey)


### PR DESCRIPTION
Fix issues with the port to v107. As mentioned here:

https://restsharp.dev/v107/#restclient-lifecycle

The RestClient needs to be a singleton instance now, not an instance per request so we introduce a RestClient cache to cache them per API endpoint. 

Also since RestSharp v107 removed all the Sync functions from the API, it is incorrect to call an AsyncFunction and return the result using GetAwaiter().GetResult() as that WILL deadlock at some point. To do this correctly, you need to use a wrapper to run the functions Async and wait for the result. The wrapper in question is derived from the code in Rebus:

https://github.com/rebus-org/Rebus