### PR TITLE
[feat] Support for `columns` and `additional_columns` on Report creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Add missing `id` property to `Brand` class
 * Clarify XList vs XCollection distinction:
   * `ReportList`, `ScanFormList`, `ShipmentList` and `TrackerList` renamed to `ReportCollection`, `ScanFormCollection`, `ShipmentCollection` and `TrackerCollection`
+* Add support for `columns` and `additional_columns` on Report creation
 
 ## v2.8.1 (2022-02-17)
 

--- a/EasyPost.Tests.NetStandard20/EasyPost.Tests.NetStandard20.csproj
+++ b/EasyPost.Tests.NetStandard20/EasyPost.Tests.NetStandard20.csproj
@@ -9,6 +9,8 @@
     <Platforms>AnyCPU</Platforms>
 
     <RootNamespace>EasyPost.Tests.NetStandard20;</RootNamespace>
+
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EasyPost.Tests/VCR.cs
+++ b/EasyPost.Tests/VCR.cs
@@ -86,6 +86,7 @@ namespace EasyPost.Tests.Net
                 }
 
                 Record(cassetteName, apiKey, hideCredentials);
+                return;
             }
 
             ClientManager.SetCurrent(GetReplayingClientFunction(apiKey ?? GlobalApiKey, cassetteName, hideCredentials.GetValueOrDefault(_HideCredentials)));

--- a/EasyPost.Tests/cassettes/report/all.json
+++ b/EasyPost.Tests/cassettes/report/all.json
@@ -1,22 +1,26 @@
 [
   {
+    "RecordedAt": "2022-03-23T14:55:29.680188-06:00",
     "Request": {
+      "Body": "",
+      "ContentHeaders": {},
       "Method": "GET",
-      "URI": "https://api.easypost.com/v2/reports/shipment?page_size=5",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "********",
         "content_type": "application/json",
         "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
       },
-      "ContentHeaders": {},
-      "Body": ""
+      "Uri": "https://api.easypost.com/v2/reports/shipment?page_size=5"
     },
     "Response": {
-      "Status": {
-        "Code": 200,
-        "Message": "OK"
+      "Body": "{\"reports\":[{\"id\":\"shprep_b866faae8a2c46a9ae38300616337b74\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-03-23T20:55:28Z\",\"updated_at\":\"2022-03-23T20:55:28Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false},{\"id\":\"shprep_bb6834277b834786901f26b8efbbdeb7\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-03-23T20:55:26Z\",\"updated_at\":\"2022-03-23T20:55:28Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220323/6b12ebbe42294c808c26e7fa399ed430.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220323%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220323T205529Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=16e420af935086095f5f0a0574042981840a935a0101cf71e32130b94a381d2d\",\"url_expires_at\":\"2022-03-23T20:55:59Z\",\"include_children\":false},{\"id\":\"shprep_097ef86bc80b443282781143331c09cb\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-03-23T20:55:26Z\",\"updated_at\":\"2022-03-23T20:55:28Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220323/043883b06efa4d95a2fefa5eeb127bbb.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220323%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220323T205529Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=25d1fd2f62fa95de7532852f82365b693670fd7226721a0b7f6d23979e83c21a\",\"url_expires_at\":\"2022-03-23T20:55:59Z\",\"include_children\":false},{\"id\":\"shprep_bcdb62c90c6b447e9f1d17ea7848cf08\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-03-23T20:55:25Z\",\"updated_at\":\"2022-03-23T20:55:28Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220323/f1cfc113281b43ba96b659ab9484b90b.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220323%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220323T205529Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=2c3c3bdce7634bfa70a7ecf507b756d3ad14dd403ea309993be94b37f752395a\",\"url_expires_at\":\"2022-03-23T20:55:59Z\",\"include_children\":false},{\"id\":\"shprep_84b95d72d58c43469fe5ce5923d8f0cc\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-03-23T20:36:36Z\",\"updated_at\":\"2022-03-23T20:36:38Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220323/bc53b401f7294bc7b50bddec657eccda.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220323%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220323T205529Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=190e531a723cdf6f4d3ecd19036970ca5da8a8675897605d3e0c15bf32701c15\",\"url_expires_at\":\"2022-03-23T20:55:59Z\",\"include_children\":false}],\"has_more\":true}",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "3065"
       },
+      "HttpVersion": "1.1",
       "ResponseHeaders": {
         "X-Frame-Options": "SAMEORIGIN",
         "X-XSS-Protection": "1; mode=block",
@@ -24,27 +28,21 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "5f596082621d5dcce4d1746200a40aa6",
+        "x-ep-request-uuid": "4aee9dd4623b8941e78b9f24000bcdfd",
         "Cache-Control": "no-store, no-cache",
         "Pragma": "no-cache",
-        "ETag": "W/\"f84127be28184f380d0fa61b12e0e5c9\"",
-        "X-Request-ID": "4d10bc74-09d0-4d01-ac87-d0d118fb7b6b",
-        "x-runtime": "0.037708",
-        "x-node": "bigweb4nuq",
-        "x-version-label": "easypost-202202282222-e6cd2b4eed-master",
+        "ETag": "W/\"b201539d5b230fd6a2543de451b2b575\"",
+        "x-runtime": "0.037296",
+        "x-node": "bigweb1nuq",
+        "x-version-label": "easypost-202203231943-61a988cd70-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb2nuq 88c34981dc,extlb2nuq 88c34981dc",
+        "x-proxied": "intlb2nuq 3e97db20d4,extlb1nuq 3e97db20d4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
-      "ContentHeaders": {
-        "Expires": "0",
-        "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "3065"
-      },
-      "Body": "{\"reports\":[{\"id\":\"shprep_a25c8b6292f249ad90916c893b5feb26\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-02-28T23:42:02Z\",\"updated_at\":\"2022-02-28T23:42:02Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false},{\"id\":\"shprep_e3d2743eab8e4650a22bed5e3a9db944\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-02-28T23:41:59Z\",\"updated_at\":\"2022-02-28T23:42:01Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220228/52c8c9ebc3994e9ebdcbb6ed618eee28.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20220228%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220228T234204Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=10340c6063e9bfcc3485080203ef04ec4f6e07919addcd8ce2a99d384790dd7a\",\"url_expires_at\":\"2022-02-28T23:42:34Z\",\"include_children\":false},{\"id\":\"shprep_17e53e0baf874b379448e47558547ff9\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-02-28T22:01:07Z\",\"updated_at\":\"2022-02-28T22:01:09Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220228/e90fcba2ad41478881b6ead40119617d.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20220228%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220228T234204Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=d9ad155f4d21f910d44652235c27124457591ce3e39d2a606a546494475b57db\",\"url_expires_at\":\"2022-02-28T23:42:34Z\",\"include_children\":false},{\"id\":\"shprep_bcd09fdf1a2741a99c415e6ff49543e9\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-02-28T22:01:03Z\",\"updated_at\":\"2022-02-28T22:01:06Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220228/d501b5dfd89a48d39fada869f759aff7.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20220228%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220228T234204Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=06a3ef49d734171d72c307650e1b3d389e60f404c67c1908812eb2853da24c20\",\"url_expires_at\":\"2022-02-28T23:42:34Z\",\"include_children\":false},{\"id\":\"shprep_7f331778be0e40718920a5b7a029a5fa\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-02-28T19:42:03Z\",\"updated_at\":\"2022-02-28T19:42:05Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/shipment_report/20220228/ec37c0dd0a30403e89eb612030328763.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20220228%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220228T234204Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=b8649a2bb18e8682aaf361cdc15534ff923818e43152149c71f8a2a9bcfc5162\",\"url_expires_at\":\"2022-02-28T23:42:34Z\",\"include_children\":false}],\"has_more\":true}",
-      "RequestMessage": null,
-      "HttpVersion": "1.1"
-    },
-    "RecordedAt": "2022-02-28T15:42:04.608147-08:00"
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      }
+    }
   }
 ]

--- a/EasyPost.Tests/cassettes/report/create_payment_log_report.json
+++ b/EasyPost.Tests/cassettes/report/create_payment_log_report.json
@@ -1,22 +1,29 @@
 [
   {
+    "RecordedAt": "2022-03-23T14:55:25.084273-06:00",
     "Request": {
+      "Body": "{\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\"}",
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "51"
+      },
       "Method": "POST",
-      "URI": "https://api.easypost.com/v2/reports/payment_log?start_date=2022-02-01&end_date=2022-02-03",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "********",
         "content_type": "application/json",
         "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
       },
-      "ContentHeaders": {},
-      "Body": ""
+      "Uri": "https://api.easypost.com/v2/reports/payment_log"
     },
     "Response": {
-      "Status": {
-        "Code": 201,
-        "Message": "Created"
+      "Body": "{\"id\":\"plrep_68bdbd442caf47fba4b356c592f56632\",\"object\":\"PaymentLogReport\",\"created_at\":\"2022-03-23T20:55:25Z\",\"updated_at\":\"2022-03-23T20:55:25Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null}",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "259"
       },
+      "HttpVersion": "1.1",
       "ResponseHeaders": {
         "X-Frame-Options": "SAMEORIGIN",
         "X-XSS-Protection": "1; mode=block",
@@ -24,27 +31,21 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "5f596087621d5dc6e4d1742400a40949",
+        "x-ep-request-uuid": "4aee9dd5623b893de78b9ee4000bccb2",
         "Cache-Control": "no-store, no-cache",
         "Pragma": "no-cache",
-        "ETag": "W/\"4811ef014e2a11c186d107e58e2759c3\"",
-        "X-Request-ID": "3747fc57-ea29-4ac5-a9b2-8ec1b5d85942",
-        "x-runtime": "0.043317",
-        "x-node": "bigweb3nuq",
-        "x-version-label": "easypost-202202282222-e6cd2b4eed-master",
+        "ETag": "W/\"8595a1619c55b50a6fa4718982e5a5e9\"",
+        "x-runtime": "0.040805",
+        "x-node": "bigweb1nuq",
+        "x-version-label": "easypost-202203231943-61a988cd70-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb2nuq 88c34981dc,extlb2nuq 88c34981dc",
+        "x-proxied": "intlb2nuq 3e97db20d4,extlb1nuq 3e97db20d4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
-      "ContentHeaders": {
-        "Expires": "0",
-        "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "259"
-      },
-      "Body": "{\"id\":\"plrep_1a42ae5e8ecf490d9c6155bbc7beb93f\",\"object\":\"PaymentLogReport\",\"created_at\":\"2022-02-28T23:41:58Z\",\"updated_at\":\"2022-02-28T23:41:58Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null}",
-      "RequestMessage": null,
-      "HttpVersion": "1.1"
-    },
-    "RecordedAt": "2022-02-28T15:41:58.333714-08:00"
+      "Status": {
+        "Code": 201,
+        "Message": "Created"
+      }
+    }
   }
 ]

--- a/EasyPost.Tests/cassettes/report/create_report_with_additional_columns.json
+++ b/EasyPost.Tests/cassettes/report/create_report_with_additional_columns.json
@@ -1,27 +1,27 @@
 [
   {
-    "RecordedAt": "2022-03-23T14:55:25.493677-06:00",
+    "RecordedAt": "2022-03-23T16:50:39.102844-06:00",
     "Request": {
-      "Body": "{\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\"}",
+      "Body": "{\"additional_columns\":[\"from_name\",\"from_company\"],\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\"}",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "51"
+        "Content-Length": "101"
       },
       "Method": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "********",
         "content_type": "application/json",
-        "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
+        "User-Agent": "EasyPost/v2,CSharpClient/2.8.2,.NET/5.0.13"
       },
-      "Uri": "https://api.easypost.com/v2/reports/refund"
+      "Uri": "https://api.easypost.com/v2/reports/shipment"
     },
     "Response": {
-      "Body": "{\"id\":\"refrep_31ee82cedc794a778feb884cb1596741\",\"object\":\"RefundReport\",\"created_at\":\"2022-03-23T20:55:25Z\",\"updated_at\":\"2022-03-23T20:55:25Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null}",
+      "Body": "{\"id\":\"shprep_855197d39a7345759d0a15f105762122\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-03-23T22:50:39Z\",\"updated_at\":\"2022-03-23T22:50:39Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "256"
+        "Content-Length": "283"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -31,15 +31,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "4aee9dd6623b893de78b9ee6000bccd0",
+        "x-ep-request-uuid": "449abfc4623ba43ef1ee3d060012ae7e",
         "Cache-Control": "no-store, no-cache",
         "Pragma": "no-cache",
-        "ETag": "W/\"b357eea72a970471b6183758a5818b63\"",
-        "x-runtime": "0.037303",
-        "x-node": "bigweb2nuq",
-        "x-version-label": "easypost-202203231943-61a988cd70-master",
+        "ETag": "W/\"29dfabb9bc8c01d1d56bd1c86f8f0f23\"",
+        "x-runtime": "0.039409",
+        "x-node": "bigweb5nuq",
+        "x-version-label": "easypost-202203232220-83a361b07a-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq 3e97db20d4,extlb1nuq 3e97db20d4",
+        "x-proxied": "intlb1nuq 3e97db20d4,intlb1wdc 3e97db20d4,extlb3wdc 3e97db20d4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/report/create_report_with_columns.json
+++ b/EasyPost.Tests/cassettes/report/create_report_with_columns.json
@@ -1,27 +1,27 @@
 [
   {
-    "RecordedAt": "2022-03-23T14:55:25.493677-06:00",
+    "RecordedAt": "2022-03-23T16:51:16.705472-06:00",
     "Request": {
-      "Body": "{\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\"}",
+      "Body": "{\"columns\":[\"usps_zone\"],\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\"}",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "51"
+        "Content-Length": "75"
       },
       "Method": "POST",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "********",
         "content_type": "application/json",
-        "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
+        "User-Agent": "EasyPost/v2,CSharpClient/2.8.2,.NET/5.0.13"
       },
-      "Uri": "https://api.easypost.com/v2/reports/refund"
+      "Uri": "https://api.easypost.com/v2/reports/shipment"
     },
     "Response": {
-      "Body": "{\"id\":\"refrep_31ee82cedc794a778feb884cb1596741\",\"object\":\"RefundReport\",\"created_at\":\"2022-03-23T20:55:25Z\",\"updated_at\":\"2022-03-23T20:55:25Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null}",
+      "Body": "{\"id\":\"shprep_2d534f4ded974e17bc6258e3516810fe\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-03-23T22:51:16Z\",\"updated_at\":\"2022-03-23T22:51:16Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "256"
+        "Content-Length": "283"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -31,15 +31,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "4aee9dd6623b893de78b9ee6000bccd0",
+        "x-ep-request-uuid": "449abfbf623ba464f9c0cd240012bcca",
         "Cache-Control": "no-store, no-cache",
         "Pragma": "no-cache",
-        "ETag": "W/\"b357eea72a970471b6183758a5818b63\"",
-        "x-runtime": "0.037303",
-        "x-node": "bigweb2nuq",
-        "x-version-label": "easypost-202203231943-61a988cd70-master",
+        "ETag": "W/\"717c8902836abd65ae7abf22f9a7254c\"",
+        "x-runtime": "0.035780",
+        "x-node": "bigweb6nuq",
+        "x-version-label": "easypost-202203232220-83a361b07a-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq 3e97db20d4,extlb1nuq 3e97db20d4",
+        "x-proxied": "intlb2nuq 3e97db20d4,intlb1wdc 3e97db20d4,extlb3wdc 3e97db20d4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/report/create_shipment_invoice_report.json
+++ b/EasyPost.Tests/cassettes/report/create_shipment_invoice_report.json
@@ -1,22 +1,29 @@
 [
   {
+    "RecordedAt": "2022-03-23T14:55:26.016123-06:00",
     "Request": {
+      "Body": "{\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\"}",
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "51"
+      },
       "Method": "POST",
-      "URI": "https://api.easypost.com/v2/reports/shipment_invoice?start_date=2022-02-01&end_date=2022-02-03",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "********",
         "content_type": "application/json",
         "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
       },
-      "ContentHeaders": {},
-      "Body": ""
+      "Uri": "https://api.easypost.com/v2/reports/shipment_invoice"
     },
     "Response": {
-      "Status": {
-        "Code": 201,
-        "Message": "Created"
+      "Body": "{\"id\":\"shpinvrep_ad9cadbe3a4c43018266489c2e42612f\",\"object\":\"ShipmentInvoiceReport\",\"created_at\":\"2022-03-23T20:55:26Z\",\"updated_at\":\"2022-03-23T20:55:26Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "293"
       },
+      "HttpVersion": "1.1",
       "ResponseHeaders": {
         "X-Frame-Options": "SAMEORIGIN",
         "X-XSS-Protection": "1; mode=block",
@@ -24,27 +31,21 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "5f596080621d5dc7e4d1742700a40992",
+        "x-ep-request-uuid": "4aee9dd0623b893ee78b9ee8000bcced",
         "Cache-Control": "no-store, no-cache",
         "Pragma": "no-cache",
-        "ETag": "W/\"2358b4753765272b9ad2b99147b52e44\"",
-        "X-Request-ID": "3bdd3e11-d7e4-4357-91b0-f4a42a9a657c",
-        "x-runtime": "0.036418",
-        "x-node": "bigweb8nuq",
-        "x-version-label": "easypost-202202282222-e6cd2b4eed-master",
+        "ETag": "W/\"53aa1c8e9681791dc222be81438d18be\"",
+        "x-runtime": "0.035022",
+        "x-node": "bigweb6nuq",
+        "x-version-label": "easypost-202203231943-61a988cd70-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb2nuq 88c34981dc,extlb2nuq 88c34981dc",
+        "x-proxied": "intlb2nuq 3e97db20d4,extlb1nuq 3e97db20d4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
-      "ContentHeaders": {
-        "Expires": "0",
-        "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "293"
-      },
-      "Body": "{\"id\":\"shpinvrep_07bb830737054dcf829b7d84ddafc348\",\"object\":\"ShipmentInvoiceReport\",\"created_at\":\"2022-02-28T23:41:59Z\",\"updated_at\":\"2022-02-28T23:41:59Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}",
-      "RequestMessage": null,
-      "HttpVersion": "1.1"
-    },
-    "RecordedAt": "2022-02-28T15:41:59.559424-08:00"
+      "Status": {
+        "Code": 201,
+        "Message": "Created"
+      }
+    }
   }
 ]

--- a/EasyPost.Tests/cassettes/report/create_shipment_report.json
+++ b/EasyPost.Tests/cassettes/report/create_shipment_report.json
@@ -1,22 +1,29 @@
 [
   {
+    "RecordedAt": "2022-03-23T14:55:25.759795-06:00",
     "Request": {
+      "Body": "{\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\"}",
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "51"
+      },
       "Method": "POST",
-      "URI": "https://api.easypost.com/v2/reports/shipment?start_date=2022-02-01&end_date=2022-02-03",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "********",
         "content_type": "application/json",
         "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
       },
-      "ContentHeaders": {},
-      "Body": ""
+      "Uri": "https://api.easypost.com/v2/reports/shipment"
     },
     "Response": {
-      "Status": {
-        "Code": 201,
-        "Message": "Created"
+      "Body": "{\"id\":\"shprep_bcdb62c90c6b447e9f1d17ea7848cf08\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-03-23T20:55:25Z\",\"updated_at\":\"2022-03-23T20:55:25Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "283"
       },
+      "HttpVersion": "1.1",
       "ResponseHeaders": {
         "X-Frame-Options": "SAMEORIGIN",
         "X-XSS-Protection": "1; mode=block",
@@ -24,27 +31,22 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "5f596084621d5dc7e4d1742600a40979",
+        "x-ep-request-uuid": "4aee9dd4623b893de78b9ee7000bccdd",
         "Cache-Control": "no-store, no-cache",
         "Pragma": "no-cache",
-        "ETag": "W/\"3488826a3645a20490bce40f0bb3b821\"",
-        "X-Request-ID": "ad2a75e2-e4d1-46d2-b903-170928efc3a8",
-        "x-runtime": "0.040114",
-        "x-node": "bigweb3nuq",
-        "x-version-label": "easypost-202202282222-e6cd2b4eed-master",
+        "ETag": "W/\"b61513fe9b66e53a89ec281422583446\"",
+        "x-runtime": "0.047864",
+        "x-node": "bigweb7nuq",
+        "x-version-label": "easypost-202203231943-61a988cd70-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq 88c34981dc,extlb2nuq 88c34981dc",
+        "x-canary": "direct",
+        "x-proxied": "intlb2nuq 3e97db20d4,extlb1nuq 3e97db20d4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
-      "ContentHeaders": {
-        "Expires": "0",
-        "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "283"
-      },
-      "Body": "{\"id\":\"shprep_e3d2743eab8e4650a22bed5e3a9db944\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-02-28T23:41:59Z\",\"updated_at\":\"2022-02-28T23:41:59Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}",
-      "RequestMessage": null,
-      "HttpVersion": "1.1"
-    },
-    "RecordedAt": "2022-02-28T15:41:59.14567-08:00"
+      "Status": {
+        "Code": 201,
+        "Message": "Created"
+      }
+    }
   }
 ]

--- a/EasyPost.Tests/cassettes/report/create_tracker_report.json
+++ b/EasyPost.Tests/cassettes/report/create_tracker_report.json
@@ -1,22 +1,29 @@
 [
   {
+    "RecordedAt": "2022-03-23T14:55:26.286472-06:00",
     "Request": {
+      "Body": "{\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\"}",
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "51"
+      },
       "Method": "POST",
-      "URI": "https://api.easypost.com/v2/reports/tracker?start_date=2022-02-01&end_date=2022-02-03",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "********",
         "content_type": "application/json",
         "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
       },
-      "ContentHeaders": {},
-      "Body": ""
+      "Uri": "https://api.easypost.com/v2/reports/tracker"
     },
     "Response": {
-      "Status": {
-        "Code": 201,
-        "Message": "Created"
+      "Body": "{\"id\":\"trkrep_391a27d3e52c4eb9bf150830dce0759a\",\"object\":\"TrackerReport\",\"created_at\":\"2022-02-25T19:32:58Z\",\"updated_at\":\"2022-03-23T18:29:51Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/tracker_report/20220323/a74587592fac437b99ef1bb8a27684ea.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220323%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220323T205526Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=4f275336d3453434bd52ce016a78a7fdebc52873ba863fa91a5269fe55aa67f4\",\"url_expires_at\":\"2022-03-23T20:55:56Z\",\"include_children\":false}",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "685"
       },
+      "HttpVersion": "1.1",
       "ResponseHeaders": {
         "X-Frame-Options": "SAMEORIGIN",
         "X-XSS-Protection": "1; mode=block",
@@ -24,27 +31,21 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "5f596080621d5dc8e4d1744000a409a9",
+        "x-ep-request-uuid": "4aee9dd1623b893ee78b9f00000bccff",
         "Cache-Control": "no-store, no-cache",
         "Pragma": "no-cache",
-        "ETag": "W/\"ea6b85038538c7bd45ca2d3a8535e72f\"",
-        "X-Request-ID": "b60d4fec-a03a-4e4c-b2cb-371ec2b91412",
-        "x-runtime": "0.048293",
-        "x-node": "bigweb6nuq",
-        "x-version-label": "easypost-202202282222-e6cd2b4eed-master",
+        "ETag": "W/\"614f3163128a3590bdf0af04f3ec55e4\"",
+        "x-runtime": "0.057424",
+        "x-node": "bigweb1nuq",
+        "x-version-label": "easypost-202203231943-61a988cd70-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb2nuq 88c34981dc,extlb2nuq 88c34981dc",
+        "x-proxied": "intlb1nuq 3e97db20d4,extlb1nuq 3e97db20d4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
-      "ContentHeaders": {
-        "Expires": "0",
-        "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "685"
-      },
-      "Body": "{\"id\":\"trkrep_391a27d3e52c4eb9bf150830dce0759a\",\"object\":\"TrackerReport\",\"created_at\":\"2022-02-25T19:32:58Z\",\"updated_at\":\"2022-02-28T22:01:13Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/tracker_report/20220228/978946e53f5146c89ffa64224827c679.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20220228%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220228T234200Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=9a57c43eca7f267c2ce58a458a49f7b58cd5e88700a1b979c3184e8176c10cbb\",\"url_expires_at\":\"2022-02-28T23:42:30Z\",\"include_children\":false}",
-      "RequestMessage": null,
-      "HttpVersion": "1.1"
-    },
-    "RecordedAt": "2022-02-28T15:41:59.982273-08:00"
+      "Status": {
+        "Code": 201,
+        "Message": "Created"
+      }
+    }
   }
 ]

--- a/EasyPost.Tests/cassettes/report/retrieve_payment_log_report.json
+++ b/EasyPost.Tests/cassettes/report/retrieve_payment_log_report.json
@@ -1,70 +1,29 @@
 [
   {
+    "RecordedAt": "2022-03-23T14:55:27.062957-06:00",
     "Request": {
+      "Body": "{\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\"}",
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "51"
+      },
       "Method": "POST",
-      "URI": "https://api.easypost.com/v2/reports/payment_log?start_date=2022-02-01&end_date=2022-02-03",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "********",
         "content_type": "application/json",
         "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
       },
-      "ContentHeaders": {},
-      "Body": ""
+      "Uri": "https://api.easypost.com/v2/reports/payment_log"
     },
     "Response": {
-      "Status": {
-        "Code": 201,
-        "Message": "Created"
-      },
-      "ResponseHeaders": {
-        "X-Frame-Options": "SAMEORIGIN",
-        "X-XSS-Protection": "1; mode=block",
-        "X-Content-Type-Options": "nosniff",
-        "x-download-options": "noopen",
-        "x-permitted-cross-domain-policies": "none",
-        "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "5f596082621d5dc8e4d1744100a409ba",
-        "Cache-Control": "no-store, no-cache",
-        "Pragma": "no-cache",
-        "ETag": "W/\"26b0618a772e4c87c989a7a21cc809d7\"",
-        "X-Request-ID": "ca5eb674-4865-4d6e-905f-c599c585e75a",
-        "x-runtime": "0.040045",
-        "x-node": "bigweb4nuq",
-        "x-version-label": "easypost-202202282222-e6cd2b4eed-master",
-        "x-backend": "easypost",
-        "x-proxied": "intlb1nuq 88c34981dc,extlb2nuq 88c34981dc",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
-      },
+      "Body": "{\"id\":\"plrep_c1aa5fa561234376b2e3a28405bde6da\",\"object\":\"PaymentLogReport\",\"created_at\":\"2022-03-23T20:55:27Z\",\"updated_at\":\"2022-03-23T20:55:27Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null}",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
         "Content-Length": "259"
       },
-      "Body": "{\"id\":\"plrep_c722371abc714356a218aebfffe162af\",\"object\":\"PaymentLogReport\",\"created_at\":\"2022-02-28T23:42:00Z\",\"updated_at\":\"2022-02-28T23:42:00Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null}",
-      "RequestMessage": null,
-      "HttpVersion": "1.1"
-    },
-    "RecordedAt": "2022-02-28T15:42:00.393621-08:00"
-  },
-  {
-    "Request": {
-      "Method": "GET",
-      "URI": "https://api.easypost.com/v2/reports/plrep_c722371abc714356a218aebfffe162af",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "********",
-        "content_type": "application/json",
-        "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
-      },
-      "ContentHeaders": {},
-      "Body": ""
-    },
-    "Response": {
-      "Status": {
-        "Code": 200,
-        "Message": "OK"
-      },
+      "HttpVersion": "1.1",
       "ResponseHeaders": {
         "X-Frame-Options": "SAMEORIGIN",
         "X-XSS-Protection": "1; mode=block",
@@ -72,27 +31,67 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "5f596086621d5dc8e4d1744200a409cd",
+        "x-ep-request-uuid": "4aee9dd0623b893fe78b9f03000bcd5a",
         "Cache-Control": "no-store, no-cache",
         "Pragma": "no-cache",
-        "ETag": "W/\"455868b1390157d29dea235276328bd5\"",
-        "X-Request-ID": "054ea6b2-5349-45c7-b3b6-39d16c36b267",
-        "x-runtime": "0.033075",
-        "x-node": "bigweb8nuq",
-        "x-version-label": "easypost-202202282222-e6cd2b4eed-master",
+        "ETag": "W/\"56d4e2a1e1f24fb0a31bbe1cdc04ee39\"",
+        "x-runtime": "0.036932",
+        "x-node": "bigweb6nuq",
+        "x-version-label": "easypost-202203231943-61a988cd70-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb2nuq 88c34981dc,extlb2nuq 88c34981dc",
+        "x-proxied": "intlb2nuq 3e97db20d4,extlb1nuq 3e97db20d4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
+      "Status": {
+        "Code": 201,
+        "Message": "Created"
+      }
+    }
+  },
+  {
+    "RecordedAt": "2022-03-23T14:55:27.302595-06:00",
+    "Request": {
+      "Body": "",
+      "ContentHeaders": {},
+      "Method": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "********",
+        "content_type": "application/json",
+        "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
+      },
+      "Uri": "https://api.easypost.com/v2/reports/plrep_c1aa5fa561234376b2e3a28405bde6da"
+    },
+    "Response": {
+      "Body": "{\"id\":\"plrep_c1aa5fa561234376b2e3a28405bde6da\",\"object\":\"PaymentLogReport\",\"created_at\":\"2022-03-23T20:55:27Z\",\"updated_at\":\"2022-03-23T20:55:27Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null}",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "261"
+        "Content-Length": "259"
       },
-      "Body": "{\"id\":\"plrep_c722371abc714356a218aebfffe162af\",\"object\":\"PaymentLogReport\",\"created_at\":\"2022-02-28T23:42:00Z\",\"updated_at\":\"2022-02-28T23:42:00Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"empty\",\"url\":null,\"url_expires_at\":null}",
-      "RequestMessage": null,
-      "HttpVersion": "1.1"
-    },
-    "RecordedAt": "2022-02-28T15:42:00.813107-08:00"
+      "HttpVersion": "1.1",
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "4aee9dd4623b893fe78b9f04000bcd63",
+        "Cache-Control": "no-store, no-cache",
+        "Pragma": "no-cache",
+        "ETag": "W/\"56d4e2a1e1f24fb0a31bbe1cdc04ee39\"",
+        "x-runtime": "0.027019",
+        "x-node": "bigweb2nuq",
+        "x-version-label": "easypost-202203231943-61a988cd70-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb2nuq 3e97db20d4,extlb1nuq 3e97db20d4",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      }
+    }
   }
 ]

--- a/EasyPost.Tests/cassettes/report/retrieve_refund_report.json
+++ b/EasyPost.Tests/cassettes/report/retrieve_refund_report.json
@@ -1,70 +1,75 @@
 [
   {
+    "RecordedAt": "2022-03-23T14:55:27.57885-06:00",
     "Request": {
+      "Body": "{\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\"}",
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "51"
+      },
       "Method": "POST",
-      "URI": "https://api.easypost.com/v2/reports/refund?start_date=2022-02-01&end_date=2022-02-03",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "********",
         "content_type": "application/json",
         "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
       },
-      "ContentHeaders": {},
-      "Body": ""
+      "Uri": "https://api.easypost.com/v2/reports/refund"
     },
     "Response": {
+      "Body": "{\"id\":\"refrep_886600bb8dec4d27a33cfdee380d6232\",\"object\":\"RefundReport\",\"created_at\":\"2022-03-23T20:55:27Z\",\"updated_at\":\"2022-03-23T20:55:27Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null}",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "256"
+      },
+      "HttpVersion": "1.1",
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "4aee9dcf623b893fe78b9f05000bcd6d",
+        "Cache-Control": "no-store, no-cache",
+        "Pragma": "no-cache",
+        "ETag": "W/\"dd8590472ab36dabe4ea8c6e51ddaa05\"",
+        "x-runtime": "0.039156",
+        "x-node": "bigweb6nuq",
+        "x-version-label": "easypost-202203231943-61a988cd70-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb2nuq 3e97db20d4,extlb1nuq 3e97db20d4",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
       "Status": {
         "Code": 201,
         "Message": "Created"
-      },
-      "ResponseHeaders": {
-        "X-Frame-Options": "SAMEORIGIN",
-        "X-XSS-Protection": "1; mode=block",
-        "X-Content-Type-Options": "nosniff",
-        "x-download-options": "noopen",
-        "x-permitted-cross-domain-policies": "none",
-        "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "5f596084621d5dc9e4d1744300a409e1",
-        "Cache-Control": "no-store, no-cache",
-        "Pragma": "no-cache",
-        "ETag": "W/\"107f117b2ed736583e49dadb8441f26b\"",
-        "X-Request-ID": "a66edee9-3afb-43a9-852f-5f263bea3cac",
-        "x-runtime": "0.043398",
-        "x-node": "bigweb4nuq",
-        "x-version-label": "easypost-202202282222-e6cd2b4eed-master",
-        "x-backend": "easypost",
-        "x-proxied": "intlb2nuq 88c34981dc,extlb2nuq 88c34981dc",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
-      },
-      "ContentHeaders": {
-        "Expires": "0",
-        "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "256"
-      },
-      "Body": "{\"id\":\"refrep_d72c976ea61347dca9c9ceec8af22947\",\"object\":\"RefundReport\",\"created_at\":\"2022-02-28T23:42:01Z\",\"updated_at\":\"2022-02-28T23:42:01Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null}",
-      "RequestMessage": null,
-      "HttpVersion": "1.1"
-    },
-    "RecordedAt": "2022-02-28T15:42:01.223926-08:00"
+      }
+    }
   },
   {
+    "RecordedAt": "2022-03-23T14:55:27.910881-06:00",
     "Request": {
+      "Body": "",
+      "ContentHeaders": {},
       "Method": "GET",
-      "URI": "https://api.easypost.com/v2/reports/refrep_d72c976ea61347dca9c9ceec8af22947",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "********",
         "content_type": "application/json",
         "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
       },
-      "ContentHeaders": {},
-      "Body": ""
+      "Uri": "https://api.easypost.com/v2/reports/refrep_886600bb8dec4d27a33cfdee380d6232"
     },
     "Response": {
-      "Status": {
-        "Code": 200,
-        "Message": "OK"
+      "Body": "{\"id\":\"refrep_886600bb8dec4d27a33cfdee380d6232\",\"object\":\"RefundReport\",\"created_at\":\"2022-03-23T20:55:27Z\",\"updated_at\":\"2022-03-23T20:55:27Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null}",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "256"
       },
+      "HttpVersion": "1.1",
       "ResponseHeaders": {
         "X-Frame-Options": "SAMEORIGIN",
         "X-XSS-Protection": "1; mode=block",
@@ -72,27 +77,21 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "5f596081621d5dc9e4d1744400a409ea",
+        "x-ep-request-uuid": "4aee9dd2623b893fe78b9f06000bcd7f",
         "Cache-Control": "no-store, no-cache",
         "Pragma": "no-cache",
-        "ETag": "W/\"107f117b2ed736583e49dadb8441f26b\"",
-        "X-Request-ID": "13de1519-191f-437c-84ce-7cae07ab318b",
-        "x-runtime": "0.036613",
-        "x-node": "bigweb8nuq",
-        "x-version-label": "easypost-202202282222-e6cd2b4eed-master",
+        "ETag": "W/\"dd8590472ab36dabe4ea8c6e51ddaa05\"",
+        "x-runtime": "0.109255",
+        "x-node": "bigweb1nuq",
+        "x-version-label": "easypost-202203231943-61a988cd70-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq 88c34981dc,extlb2nuq 88c34981dc",
+        "x-proxied": "intlb2nuq 3e97db20d4,extlb1nuq 3e97db20d4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
-      "ContentHeaders": {
-        "Expires": "0",
-        "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "256"
-      },
-      "Body": "{\"id\":\"refrep_d72c976ea61347dca9c9ceec8af22947\",\"object\":\"RefundReport\",\"created_at\":\"2022-02-28T23:42:01Z\",\"updated_at\":\"2022-02-28T23:42:01Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null}",
-      "RequestMessage": null,
-      "HttpVersion": "1.1"
-    },
-    "RecordedAt": "2022-02-28T15:42:01.636266-08:00"
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      }
+    }
   }
 ]

--- a/EasyPost.Tests/cassettes/report/retrieve_shipment_invoice_report.json
+++ b/EasyPost.Tests/cassettes/report/retrieve_shipment_invoice_report.json
@@ -1,70 +1,29 @@
 [
   {
+    "RecordedAt": "2022-03-23T14:55:28.660518-06:00",
     "Request": {
+      "Body": "{\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\"}",
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "51"
+      },
       "Method": "POST",
-      "URI": "https://api.easypost.com/v2/reports/shipment_invoice?start_date=2022-02-01&end_date=2022-02-03",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "********",
         "content_type": "application/json",
         "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
       },
-      "ContentHeaders": {},
-      "Body": ""
+      "Uri": "https://api.easypost.com/v2/reports/shipment_invoice"
     },
     "Response": {
-      "Status": {
-        "Code": 201,
-        "Message": "Created"
-      },
-      "ResponseHeaders": {
-        "X-Frame-Options": "SAMEORIGIN",
-        "X-XSS-Protection": "1; mode=block",
-        "X-Content-Type-Options": "nosniff",
-        "x-download-options": "noopen",
-        "x-permitted-cross-domain-policies": "none",
-        "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "5f596087621d5dcae4d1744700a40a45",
-        "Cache-Control": "no-store, no-cache",
-        "Pragma": "no-cache",
-        "ETag": "W/\"7a24c82aea5da8472c632cde5f76a395\"",
-        "X-Request-ID": "c8c9944f-cc1a-4238-b5d4-853cf9799633",
-        "x-runtime": "0.043587",
-        "x-node": "bigweb6nuq",
-        "x-version-label": "easypost-202202282222-e6cd2b4eed-master",
-        "x-backend": "easypost",
-        "x-proxied": "intlb1nuq 88c34981dc,extlb2nuq 88c34981dc",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
-      },
+      "Body": "{\"id\":\"shpinvrep_b886fa294be4497e907af02d273cb348\",\"object\":\"ShipmentInvoiceReport\",\"created_at\":\"2022-03-23T20:55:28Z\",\"updated_at\":\"2022-03-23T20:55:28Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
         "Content-Length": "293"
       },
-      "Body": "{\"id\":\"shpinvrep_1d64156c063a47bbbd4545c52e5fde2e\",\"object\":\"ShipmentInvoiceReport\",\"created_at\":\"2022-02-28T23:42:02Z\",\"updated_at\":\"2022-02-28T23:42:02Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}",
-      "RequestMessage": null,
-      "HttpVersion": "1.1"
-    },
-    "RecordedAt": "2022-02-28T15:42:02.847576-08:00"
-  },
-  {
-    "Request": {
-      "Method": "GET",
-      "URI": "https://api.easypost.com/v2/reports/shpinvrep_1d64156c063a47bbbd4545c52e5fde2e",
-      "RequestHeaders": {
-        "Accept": "application/json",
-        "Authorization": "********",
-        "content_type": "application/json",
-        "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
-      },
-      "ContentHeaders": {},
-      "Body": ""
-    },
-    "Response": {
-      "Status": {
-        "Code": 200,
-        "Message": "OK"
-      },
+      "HttpVersion": "1.1",
       "ResponseHeaders": {
         "X-Frame-Options": "SAMEORIGIN",
         "X-XSS-Protection": "1; mode=block",
@@ -72,27 +31,68 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "5f596087621d5dcbe4d1744800a40a5f",
+        "x-ep-request-uuid": "4aee9dd6623b8940e78b9f09000bcdb8",
         "Cache-Control": "no-store, no-cache",
         "Pragma": "no-cache",
-        "ETag": "W/\"8de62d716486b8a0a72e50db85ad228a\"",
-        "X-Request-ID": "6e134fab-135f-4544-ba91-e299e653c76c",
-        "x-runtime": "0.030823",
+        "ETag": "W/\"b383947985932cd871ef0fb091225598\"",
+        "x-runtime": "0.033662",
         "x-node": "bigweb5nuq",
-        "x-version-label": "easypost-202202282222-e6cd2b4eed-master",
+        "x-version-label": "easypost-202203231943-61a988cd70-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb2nuq 88c34981dc,extlb2nuq 88c34981dc",
+        "x-proxied": "intlb1nuq 3e97db20d4,extlb1nuq 3e97db20d4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
+      "Status": {
+        "Code": 201,
+        "Message": "Created"
+      }
+    }
+  },
+  {
+    "RecordedAt": "2022-03-23T14:55:28.910949-06:00",
+    "Request": {
+      "Body": "",
+      "ContentHeaders": {},
+      "Method": "GET",
+      "RequestHeaders": {
+        "Accept": "application/json",
+        "Authorization": "********",
+        "content_type": "application/json",
+        "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
+      },
+      "Uri": "https://api.easypost.com/v2/reports/shpinvrep_b886fa294be4497e907af02d273cb348"
+    },
+    "Response": {
+      "Body": "{\"id\":\"shpinvrep_b886fa294be4497e907af02d273cb348\",\"object\":\"ShipmentInvoiceReport\",\"created_at\":\"2022-03-23T20:55:28Z\",\"updated_at\":\"2022-03-23T20:55:28Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"empty\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
         "Content-Length": "295"
       },
-      "Body": "{\"id\":\"shpinvrep_1d64156c063a47bbbd4545c52e5fde2e\",\"object\":\"ShipmentInvoiceReport\",\"created_at\":\"2022-02-28T23:42:02Z\",\"updated_at\":\"2022-02-28T23:42:02Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"empty\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}",
-      "RequestMessage": null,
-      "HttpVersion": "1.1"
-    },
-    "RecordedAt": "2022-02-28T15:42:03.26105-08:00"
+      "HttpVersion": "1.1",
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "4aee9dd6623b8940e78b9f21000bcdca",
+        "Cache-Control": "no-store, no-cache",
+        "Pragma": "no-cache",
+        "ETag": "W/\"8aa770981095fd4607ae4d4e451368c3\"",
+        "x-runtime": "0.034606",
+        "x-node": "bigweb7nuq",
+        "x-version-label": "easypost-202203231943-61a988cd70-master",
+        "x-backend": "easypost",
+        "x-canary": "direct",
+        "x-proxied": "intlb1nuq 3e97db20d4,extlb1nuq 3e97db20d4",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      }
+    }
   }
 ]

--- a/EasyPost.Tests/cassettes/report/retrieve_shipment_report.json
+++ b/EasyPost.Tests/cassettes/report/retrieve_shipment_report.json
@@ -1,70 +1,75 @@
 [
   {
+    "RecordedAt": "2022-03-23T14:55:28.167005-06:00",
     "Request": {
+      "Body": "{\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\"}",
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "51"
+      },
       "Method": "POST",
-      "URI": "https://api.easypost.com/v2/reports/shipment?start_date=2022-02-01&end_date=2022-02-03",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "********",
         "content_type": "application/json",
         "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
       },
-      "ContentHeaders": {},
-      "Body": ""
+      "Uri": "https://api.easypost.com/v2/reports/shipment"
     },
     "Response": {
+      "Body": "{\"id\":\"shprep_b866faae8a2c46a9ae38300616337b74\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-03-23T20:55:28Z\",\"updated_at\":\"2022-03-23T20:55:28Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "283"
+      },
+      "HttpVersion": "1.1",
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "4aee9dd3623b8940e78b9f07000bcd98",
+        "Cache-Control": "no-store, no-cache",
+        "Pragma": "no-cache",
+        "ETag": "W/\"8169da503b1704c23c1dbd0a5906a763\"",
+        "x-runtime": "0.037734",
+        "x-node": "bigweb1nuq",
+        "x-version-label": "easypost-202203231943-61a988cd70-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb1nuq 3e97db20d4,extlb1nuq 3e97db20d4",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
       "Status": {
         "Code": 201,
         "Message": "Created"
-      },
-      "ResponseHeaders": {
-        "X-Frame-Options": "SAMEORIGIN",
-        "X-XSS-Protection": "1; mode=block",
-        "X-Content-Type-Options": "nosniff",
-        "x-download-options": "noopen",
-        "x-permitted-cross-domain-policies": "none",
-        "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "5f596081621d5dcae4d1744500a40a09",
-        "Cache-Control": "no-store, no-cache",
-        "Pragma": "no-cache",
-        "ETag": "W/\"96d4be68a01a1b941f9e00a2da8c25ed\"",
-        "X-Request-ID": "cf33785f-a8b7-4a41-8fe8-3bc0dafdb1a1",
-        "x-runtime": "0.043593",
-        "x-node": "bigweb8nuq",
-        "x-version-label": "easypost-202202282222-e6cd2b4eed-master",
-        "x-backend": "easypost",
-        "x-proxied": "intlb1nuq 88c34981dc,extlb2nuq 88c34981dc",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
-      },
-      "ContentHeaders": {
-        "Expires": "0",
-        "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "283"
-      },
-      "Body": "{\"id\":\"shprep_a25c8b6292f249ad90916c893b5feb26\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-02-28T23:42:02Z\",\"updated_at\":\"2022-02-28T23:42:02Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}",
-      "RequestMessage": null,
-      "HttpVersion": "1.1"
-    },
-    "RecordedAt": "2022-02-28T15:42:02.051569-08:00"
+      }
+    }
   },
   {
+    "RecordedAt": "2022-03-23T14:55:28.413394-06:00",
     "Request": {
+      "Body": "",
+      "ContentHeaders": {},
       "Method": "GET",
-      "URI": "https://api.easypost.com/v2/reports/shprep_a25c8b6292f249ad90916c893b5feb26",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "********",
         "content_type": "application/json",
         "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
       },
-      "ContentHeaders": {},
-      "Body": ""
+      "Uri": "https://api.easypost.com/v2/reports/shprep_b866faae8a2c46a9ae38300616337b74"
     },
     "Response": {
-      "Status": {
-        "Code": 200,
-        "Message": "OK"
+      "Body": "{\"id\":\"shprep_b866faae8a2c46a9ae38300616337b74\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-03-23T20:55:28Z\",\"updated_at\":\"2022-03-23T20:55:28Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "283"
       },
+      "HttpVersion": "1.1",
       "ResponseHeaders": {
         "X-Frame-Options": "SAMEORIGIN",
         "X-XSS-Protection": "1; mode=block",
@@ -72,27 +77,21 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "5f596084621d5dcae4d1744600a40a2d",
+        "x-ep-request-uuid": "4aee9dd6623b8940e78b9f08000bcda8",
         "Cache-Control": "no-store, no-cache",
         "Pragma": "no-cache",
-        "ETag": "W/\"96d4be68a01a1b941f9e00a2da8c25ed\"",
-        "X-Request-ID": "f8b95578-ce22-4cf7-adb0-8a03babce0d9",
-        "x-runtime": "0.032870",
+        "ETag": "W/\"8169da503b1704c23c1dbd0a5906a763\"",
+        "x-runtime": "0.029242",
         "x-node": "bigweb1nuq",
-        "x-version-label": "easypost-202202282222-e6cd2b4eed-master",
+        "x-version-label": "easypost-202203231943-61a988cd70-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb2nuq 88c34981dc,extlb2nuq 88c34981dc",
+        "x-proxied": "intlb1nuq 3e97db20d4,extlb1nuq 3e97db20d4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
-      "ContentHeaders": {
-        "Expires": "0",
-        "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "283"
-      },
-      "Body": "{\"id\":\"shprep_a25c8b6292f249ad90916c893b5feb26\",\"object\":\"ShipmentReport\",\"created_at\":\"2022-02-28T23:42:02Z\",\"updated_at\":\"2022-02-28T23:42:02Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"new\",\"url\":null,\"url_expires_at\":null,\"include_children\":false}",
-      "RequestMessage": null,
-      "HttpVersion": "1.1"
-    },
-    "RecordedAt": "2022-02-28T15:42:02.443965-08:00"
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      }
+    }
   }
 ]

--- a/EasyPost.Tests/cassettes/report/retrieve_tracker_report.json
+++ b/EasyPost.Tests/cassettes/report/retrieve_tracker_report.json
@@ -1,70 +1,75 @@
 [
   {
+    "RecordedAt": "2022-03-23T14:55:29.168987-06:00",
     "Request": {
+      "Body": "{\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\"}",
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "51"
+      },
       "Method": "POST",
-      "URI": "https://api.easypost.com/v2/reports/tracker?start_date=2022-02-01&end_date=2022-02-03",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "********",
         "content_type": "application/json",
         "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
       },
-      "ContentHeaders": {},
-      "Body": ""
+      "Uri": "https://api.easypost.com/v2/reports/tracker"
     },
     "Response": {
+      "Body": "{\"id\":\"trkrep_391a27d3e52c4eb9bf150830dce0759a\",\"object\":\"TrackerReport\",\"created_at\":\"2022-02-25T19:32:58Z\",\"updated_at\":\"2022-03-23T18:29:51Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/tracker_report/20220323/a74587592fac437b99ef1bb8a27684ea.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220323%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220323T205529Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=58cb81dc9b61353e8fe98a2d6472a830f3d72ceff8110a8fec38b02090654863\",\"url_expires_at\":\"2022-03-23T20:55:59Z\",\"include_children\":false}",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "685"
+      },
+      "HttpVersion": "1.1",
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "4aee9dd5623b8941e78b9f22000bcdd7",
+        "Cache-Control": "no-store, no-cache",
+        "Pragma": "no-cache",
+        "ETag": "W/\"31f7f38ae033f8f6a16566017e73f7d1\"",
+        "x-runtime": "0.043747",
+        "x-node": "bigweb1nuq",
+        "x-version-label": "easypost-202203231943-61a988cd70-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb2nuq 3e97db20d4,extlb1nuq 3e97db20d4",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
       "Status": {
         "Code": 201,
         "Message": "Created"
-      },
-      "ResponseHeaders": {
-        "X-Frame-Options": "SAMEORIGIN",
-        "X-XSS-Protection": "1; mode=block",
-        "X-Content-Type-Options": "nosniff",
-        "x-download-options": "noopen",
-        "x-permitted-cross-domain-policies": "none",
-        "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "5f596080621d5dcbe4d1746000a40a74",
-        "Cache-Control": "no-store, no-cache",
-        "Pragma": "no-cache",
-        "ETag": "W/\"9981fe77ff35ec2a33f29269b2ee95a0\"",
-        "X-Request-ID": "4c74dddb-db7e-471d-a319-be89e5f6f3a1",
-        "x-runtime": "0.117855",
-        "x-node": "bigweb8nuq",
-        "x-version-label": "easypost-202202282222-e6cd2b4eed-master",
-        "x-backend": "easypost",
-        "x-proxied": "intlb1nuq 88c34981dc,extlb2nuq 88c34981dc",
-        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
-      },
-      "ContentHeaders": {
-        "Expires": "0",
-        "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "685"
-      },
-      "Body": "{\"id\":\"trkrep_391a27d3e52c4eb9bf150830dce0759a\",\"object\":\"TrackerReport\",\"created_at\":\"2022-02-25T19:32:58Z\",\"updated_at\":\"2022-02-28T22:01:13Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/tracker_report/20220228/978946e53f5146c89ffa64224827c679.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20220228%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220228T234203Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=3ce048fde566929919d82cff1e0e90de845aa3997cd46e8b8ad6aa232eaad815\",\"url_expires_at\":\"2022-02-28T23:42:33Z\",\"include_children\":false}",
-      "RequestMessage": null,
-      "HttpVersion": "1.1"
-    },
-    "RecordedAt": "2022-02-28T15:42:03.794745-08:00"
+      }
+    }
   },
   {
+    "RecordedAt": "2022-03-23T14:55:29.428667-06:00",
     "Request": {
+      "Body": "",
+      "ContentHeaders": {},
       "Method": "GET",
-      "URI": "https://api.easypost.com/v2/reports/trkrep_391a27d3e52c4eb9bf150830dce0759a",
       "RequestHeaders": {
         "Accept": "application/json",
         "Authorization": "********",
         "content_type": "application/json",
         "User-Agent": "EasyPost/v2,CSharpClient/2.8.1,.NET/5.0.13"
       },
-      "ContentHeaders": {},
-      "Body": ""
+      "Uri": "https://api.easypost.com/v2/reports/trkrep_391a27d3e52c4eb9bf150830dce0759a"
     },
     "Response": {
-      "Status": {
-        "Code": 200,
-        "Message": "OK"
+      "Body": "{\"id\":\"trkrep_391a27d3e52c4eb9bf150830dce0759a\",\"object\":\"TrackerReport\",\"created_at\":\"2022-02-25T19:32:58Z\",\"updated_at\":\"2022-03-23T18:29:51Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/tracker_report/20220323/a74587592fac437b99ef1bb8a27684ea.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQS5SPYTWI%2F20220323%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220323T205529Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=58cb81dc9b61353e8fe98a2d6472a830f3d72ceff8110a8fec38b02090654863\",\"url_expires_at\":\"2022-03-23T20:55:59Z\",\"include_children\":false}",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "685"
       },
+      "HttpVersion": "1.1",
       "ResponseHeaders": {
         "X-Frame-Options": "SAMEORIGIN",
         "X-XSS-Protection": "1; mode=block",
@@ -72,27 +77,21 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "5f596082621d5dcce4d1746100a40a91",
+        "x-ep-request-uuid": "4aee9dd2623b8941e78b9f23000bcdee",
         "Cache-Control": "no-store, no-cache",
         "Pragma": "no-cache",
-        "ETag": "W/\"80a104f1a0680e0ea71313bb20e2ad3c\"",
-        "X-Request-ID": "deb52c61-88a0-4de3-be83-15220e176039",
-        "x-runtime": "0.034136",
-        "x-node": "bigweb1nuq",
-        "x-version-label": "easypost-202202282222-e6cd2b4eed-master",
+        "ETag": "W/\"31f7f38ae033f8f6a16566017e73f7d1\"",
+        "x-runtime": "0.034944",
+        "x-node": "bigweb5nuq",
+        "x-version-label": "easypost-202203231943-61a988cd70-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb2nuq 88c34981dc,extlb2nuq 88c34981dc",
+        "x-proxied": "intlb1nuq 3e97db20d4,extlb1nuq 3e97db20d4",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
-      "ContentHeaders": {
-        "Expires": "0",
-        "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "685"
-      },
-      "Body": "{\"id\":\"trkrep_391a27d3e52c4eb9bf150830dce0759a\",\"object\":\"TrackerReport\",\"created_at\":\"2022-02-25T19:32:58Z\",\"updated_at\":\"2022-02-28T22:01:13Z\",\"start_date\":\"2022-02-01\",\"end_date\":\"2022-02-03\",\"mode\":\"test\",\"status\":\"available\",\"url\":\"https://easypost-files.s3.us-west-2.amazonaws.com/files/tracker_report/20220228/978946e53f5146c89ffa64224827c679.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAY27LO6YQVHEFDONM%2F20220228%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20220228T234204Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=b8e929e62f147bf09a23cd0149f765a811055aa40b8957f693a392042e295cc6\",\"url_expires_at\":\"2022-02-28T23:42:34Z\",\"include_children\":false}",
-      "RequestMessage": null,
-      "HttpVersion": "1.1"
-    },
-    "RecordedAt": "2022-02-28T15:42:04.189101-08:00"
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      }
+    }
   }
 ]

--- a/EasyPost.nuspec
+++ b/EasyPost.nuspec
@@ -3,7 +3,7 @@
     <metadata>
         <id>EasyPost-Official</id>
         <title>EasyPost (Official)</title>
-        <version>2.8.1</version>
+        <version>2.8.2</version>
         <authors>EasyPost</authors>
         <owners>EasyPost</owners>
         <projectUrl>https://www.easypost.com</projectUrl>
@@ -12,32 +12,32 @@
         <description>EasyPost Shipping API Client Library for .NET https://easypost.com/docs</description>
         <tags>EasyPost ShippingAPI USPS UPS FedEx</tags>
         <dependencies>
-            <group targetFramework="net35">
+            <group targetFramework="netstandard2.0">
                 <dependency id="Newtonsoft.Json" version="11.0.2" />
-                <dependency id="RestSharpSigned" version="105.2.3" />
+                <dependency id="RestSharp" version="107.3.0" />
             </group>
             <group targetFramework="netcoreapp3.1">
                 <dependency id="Newtonsoft.Json" version="11.0.2" />
-                <dependency id="RestSharp" version="106.4.2" />
+                <dependency id="RestSharp" version="107.3.0" />
             </group>
             <group targetFramework="net5.0">
                 <dependency id="Newtonsoft.Json" version="11.0.2" />
-                <dependency id="RestSharp" version="106.4.2" />
+                <dependency id="RestSharp" version="107.3.0" />
             </group>
             <group targetFramework="net6.0">
                 <dependency id="Newtonsoft.Json" version="11.0.2" />
-                <dependency id="RestSharp" version="106.4.2" />
+                <dependency id="RestSharp" version="107.3.0" />
             </group>
         </dependencies>
     </metadata>
     <files>
-        <file src="lib\netframework\EasyPost.NetFramework.dll" target="lib\net3.5" />
-        <file src="lib\netframework\EasyPost.NetFramework.XML" target="lib\net3.5" />
-        <file src="lib\net\netcoreapp3.1\EasyPost.Net.dll" target="lib\netcoreapp3.1" />
-        <file src="lib\net\netcoreapp3.1\EasyPost.Net.XML" target="lib\netcoreapp3.1" />
-        <file src="lib\net\net5.0\EasyPost.Net.dll" target="lib\net5.0" />
-        <file src="lib\net\net5.0\EasyPost.Net.XML" target="lib\net5.0" />
-        <file src="lib\net\net6.0\EasyPost.Net.dll" target="lib\net6.0" />
-        <file src="lib\net\net6.0\EasyPost.Net.XML" target="lib\net6.0" />
+        <file src="lib\net\netstandard2.0\EasyPost.dll" target="lib\netstandard2.0" />
+        <file src="lib\netstandard2.0\EasyPost.XML" target="lib\netstandard2.0" />
+        <file src="lib\net\netcoreapp3.1\EasyPost.dll" target="lib\netcoreapp3.1" />
+        <file src="lib\net\netcoreapp3.1\EasyPost.XML" target="lib\netcoreapp3.1" />
+        <file src="lib\net\net5.0\EasyPost.dll" target="lib\net5.0" />
+        <file src="lib\net\net5.0\EasyPost.XML" target="lib\net5.0" />
+        <file src="lib\net\net6.0\EasyPost.dll" target="lib\net6.0" />
+        <file src="lib\net\net6.0\EasyPost.XML" target="lib\net6.0" />
     </files>
 </package>

--- a/EasyPost/Properties/VersionInfo.cs
+++ b/EasyPost/Properties/VersionInfo.cs
@@ -1,0 +1,6 @@
+﻿using System.Reflection;
+
+// Version information for an assembly must follow semantic versioning
+[assembly: AssemblyVersion("2.8.2")]
+[assembly: AssemblyFileVersion("2.8.2")]
+[assembly: AssemblyInformationalVersion("2.8.2")]

--- a/EasyPost/Report.cs
+++ b/EasyPost/Report.cs
@@ -40,6 +40,9 @@ namespace EasyPost
         ///     * {"start_date", string} Date to start the report at.
         ///     * {"end_date", string} Date to end the report at.
         ///     * {"include_children", string} Whether or not to include child objects in the report.
+        ///     * {"send_email", string} Whether or not to send the report via email.
+        ///     * {"columns", List&lt;string&gt;} Specify the exact columns you want in your report.
+        ///     * {"additional_columns", List&lt;string&gt;} Request additional columns (if any) outside of the defaults.
         ///     All invalid keys will be ignored.
         /// </param>
         /// <returns>EasyPost.Report instance.</returns>
@@ -47,7 +50,7 @@ namespace EasyPost
         {
             Request request = new Request("reports/{type}", Method.Post);
             request.AddUrlSegment("type", type);
-            request.AddQueryString(parameters ?? new Dictionary<string, object>());
+            request.AddBody(parameters ?? new Dictionary<string, object>());
 
             return await request.Execute<Report>();
         }

--- a/EasyPost/VersionInfo.cs
+++ b/EasyPost/VersionInfo.cs
@@ -1,6 +1,0 @@
-﻿using System.Reflection;
-
-// Version information for an assembly must follow semantic versioning
-[assembly: AssemblyVersion("2.8.1")]
-[assembly: AssemblyFileVersion("2.8.1")]
-[assembly: AssemblyInformationalVersion("2.8.1")]


### PR DESCRIPTION
Our API now supports specifying `columns` and `additional_columns` when [creating reports](https://www.easypost.com/docs/api#create-a-report).

This PR:
- Adds support for specifying `columns` and `additional_columns` (both lists of strings) in the `parameters` dictionary passed into `Report.Create(parameters)`
- Adds unit tests for this feature

Unfortunately, since the API response does not indicate the columns used for a report, the only way to ensure the report actually includes the columns requested would be to make a live API call, download the generated CSV report and parse its column headers. That is a complex unit test with many points of failure and prevents us from using VCR.

Instead, we simply assume that if no error is thrown during the API call to generate and retrieve the report, that the report contains the correct columns. If it doesn't, that constitutes a server-side error that is out of our control.

This has been end-to-end tested locally. The generated report included the requested columns as expected.