### PR TITLE
Compare objects rather than IDs in unit tests

### DIFF
--- a/EasyPost.Tests/AddressTest.cs
+++ b/EasyPost.Tests/AddressTest.cs
@@ -60,7 +60,7 @@ namespace EasyPost.Tests.Net
             Address retrievedAddress = await Address.Retrieve(address.id);
 
             Assert.IsInstanceOfType(retrievedAddress, typeof(Address));
-            Assert.AreEqual(address.id, retrievedAddress.id);
+            Assert.AreEqual(address, retrievedAddress);
         }
 
         [TestMethod]

--- a/EasyPost.Tests/BatchTest.cs
+++ b/EasyPost.Tests/BatchTest.cs
@@ -63,6 +63,7 @@ namespace EasyPost.Tests.Net
             Batch retrievedBatch = await Batch.Retrieve(batch.id);
 
             Assert.IsInstanceOfType(retrievedBatch, typeof(Batch));
+            // Must compare IDs since elements of batch (i.e. status) may be different
             Assert.AreEqual(batch.id, retrievedBatch.id);
         }
 

--- a/EasyPost.Tests/CarrierAccountTest.cs
+++ b/EasyPost.Tests/CarrierAccountTest.cs
@@ -40,7 +40,7 @@ namespace EasyPost.Tests.Net
             CarrierAccount retrievedCarrierAccount = await CarrierAccount.Retrieve(carrierAccount.id);
 
             Assert.IsInstanceOfType(retrievedCarrierAccount, typeof(CarrierAccount));
-            Assert.AreEqual(carrierAccount.id, retrievedCarrierAccount.id);
+            Assert.AreEqual(carrierAccount, retrievedCarrierAccount);
         }
 
         [TestMethod]

--- a/EasyPost.Tests/CustomsInfoTest.cs
+++ b/EasyPost.Tests/CustomsInfoTest.cs
@@ -40,7 +40,7 @@ namespace EasyPost.Tests.Net
             CustomsInfo retrievedCustomsInfo = await CustomsInfo.Retrieve(customsInfo.id);
 
             Assert.IsInstanceOfType(retrievedCustomsInfo, typeof(CustomsInfo));
-            Assert.AreEqual(customsInfo.id, retrievedCustomsInfo.id);
+            Assert.AreEqual(customsInfo, retrievedCustomsInfo);
         }
     }
 }

--- a/EasyPost.Tests/CustomsItemTest.cs
+++ b/EasyPost.Tests/CustomsItemTest.cs
@@ -40,7 +40,7 @@ namespace EasyPost.Tests.Net
             CustomsItem retrievedCustomsItem = await CustomsItem.Retrieve(customsItem.id);
 
             Assert.IsInstanceOfType(retrievedCustomsItem, typeof(CustomsItem));
-            Assert.AreEqual(customsItem.id, retrievedCustomsItem.id);
+            Assert.AreEqual(customsItem, retrievedCustomsItem);
         }
     }
 }

--- a/EasyPost.Tests/EventTest.cs
+++ b/EasyPost.Tests/EventTest.cs
@@ -53,6 +53,7 @@ namespace EasyPost.Tests.Net
             Event retrievedEvent = await Event.Retrieve(_event.id);
 
             Assert.IsInstanceOfType(retrievedEvent, typeof(Event));
+            // Must compare IDs because other elements of objects may be different
             Assert.AreEqual(_event.id, retrievedEvent.id);
         }
     }

--- a/EasyPost.Tests/InsuranceTest.cs
+++ b/EasyPost.Tests/InsuranceTest.cs
@@ -41,6 +41,7 @@ namespace EasyPost.Tests.Net
 
             Insurance retrievedInsurance = await Insurance.Retrieve(insurance.id);
             Assert.IsInstanceOfType(retrievedInsurance, typeof(Insurance));
+            // Must compare IDs since other elements of object may be different
             Assert.AreEqual(insurance.id, retrievedInsurance.id);
         }
 

--- a/EasyPost.Tests/OrderTest.cs
+++ b/EasyPost.Tests/OrderTest.cs
@@ -41,6 +41,7 @@ namespace EasyPost.Tests.Net
             Order retrievedOrder = await Order.Retrieve(order.id);
 
             Assert.IsInstanceOfType(retrievedOrder, typeof(Order));
+            // Must compare IDs since other elements of objects may be different
             Assert.AreEqual(order.id, retrievedOrder.id);
         }
 

--- a/EasyPost.Tests/ParcelTest.cs
+++ b/EasyPost.Tests/ParcelTest.cs
@@ -40,7 +40,7 @@ namespace EasyPost.Tests.Net
             Parcel retrievedParcel = await Parcel.Retrieve(parcel.id);
 
             Assert.IsInstanceOfType(retrievedParcel, typeof(Parcel));
-            Assert.AreEqual(parcel.id, retrievedParcel.id);
+            Assert.AreEqual(parcel, retrievedParcel);
         }
     }
 }

--- a/EasyPost.Tests/PickupTest.cs
+++ b/EasyPost.Tests/PickupTest.cs
@@ -44,7 +44,7 @@ namespace EasyPost.Tests.Net
             Pickup retrievedPickup = await Pickup.Retrieve(pickup.id);
 
             Assert.IsInstanceOfType(retrievedPickup, typeof(Pickup));
-            Assert.AreEqual(pickup.id, retrievedPickup.id);
+            Assert.AreEqual(pickup, retrievedPickup);
         }
 
         [TestMethod]

--- a/EasyPost.Tests/RateTest.cs
+++ b/EasyPost.Tests/RateTest.cs
@@ -23,7 +23,7 @@ namespace EasyPost.Tests.Net
 
             Assert.IsInstanceOfType(rate, typeof(Rate));
             Assert.IsTrue(rate.id.StartsWith("rate_"));
-            Assert.AreEqual(shipment.rates[0].id, rate.id);
+            Assert.AreEqual(shipment.rates[0], rate);
         }
     }
 }

--- a/EasyPost.Tests/RefundTest.cs
+++ b/EasyPost.Tests/RefundTest.cs
@@ -88,7 +88,7 @@ namespace EasyPost.Tests.Net
             Refund retrievedRefund = await Refund.Retrieve(refund.id);
 
             Assert.IsInstanceOfType(retrievedRefund, typeof(Refund));
-            Assert.AreEqual(refund.id, retrievedRefund.id);
+            Assert.AreEqual(refund, retrievedRefund);
         }
     }
 }

--- a/EasyPost.Tests/ScanFormTest.cs
+++ b/EasyPost.Tests/ScanFormTest.cs
@@ -44,7 +44,7 @@ namespace EasyPost.Tests.Net
             ScanForm retrievedScanForm = await ScanForm.Retrieve(scanForm.id);
 
             Assert.IsInstanceOfType(retrievedScanForm, typeof(ScanForm));
-            Assert.AreEqual(scanForm.id, retrievedScanForm.id);
+            Assert.AreEqual(scanForm, retrievedScanForm);
         }
 
         [TestMethod]

--- a/EasyPost.Tests/ShipmentTest.cs
+++ b/EasyPost.Tests/ShipmentTest.cs
@@ -40,7 +40,7 @@ namespace EasyPost.Tests.Net
             Shipment retrievedShipment = await Shipment.Retrieve(shipment.id);
 
             Assert.IsInstanceOfType(shipment, typeof(Shipment));
-            Assert.AreEqual(shipment.id, retrievedShipment.id);
+            Assert.AreEqual(shipment, retrievedShipment);
         }
 
         [TestMethod]
@@ -153,6 +153,7 @@ namespace EasyPost.Tests.Net
 
             List<Smartrate> smartRates = await shipment.GetSmartrates();
             Smartrate smartrate = smartRates.First();
+            // Must compare IDs because one is a Rate object and one is a Smartrate object
             Assert.AreEqual(shipment.rates[0].id, smartrate.id);
             Assert.IsNotNull(smartrate.time_in_transit.percentile_50);
             Assert.IsNotNull(smartrate.time_in_transit.percentile_75);

--- a/EasyPost.Tests/TrackerTest.cs
+++ b/EasyPost.Tests/TrackerTest.cs
@@ -42,6 +42,7 @@ namespace EasyPost.Tests.Net
             Tracker retrievedTracker = await Tracker.Retrieve(tracker.id);
 
             Assert.IsInstanceOfType(retrievedTracker, typeof(Tracker));
+            // Must compare IDs because other elements of objects may be different
             Assert.AreEqual(tracker.id, retrievedTracker.id);
         }
 

--- a/EasyPost.Tests/WebhookTest.cs
+++ b/EasyPost.Tests/WebhookTest.cs
@@ -77,7 +77,7 @@ namespace EasyPost.Tests.Net
             Webhook retrievedWebhook = await Webhook.Retrieve(webhook.id);
 
             Assert.IsInstanceOfType(retrievedWebhook, typeof(Webhook));
-            Assert.AreEqual(webhook.id, retrievedWebhook.id);
+            Assert.AreEqual(webhook, retrievedWebhook);
 
             _webhookId = webhook.id; // trigger deletion
         }

--- a/EasyPost/IResource.cs
+++ b/EasyPost/IResource.cs
@@ -6,6 +6,8 @@ namespace EasyPost
     {
         Dictionary<string, object?> AsDictionary();
 
+        string? AsJson();
+
         void Merge(object source);
     }
 }

--- a/EasyPost/Resource.cs
+++ b/EasyPost/Resource.cs
@@ -10,6 +10,23 @@ namespace EasyPost
 {
     public class Resource : IResource
     {
+        public override bool Equals(object obj)
+        {
+            if (this.GetType() != obj.GetType())
+            {
+                return false;
+            }
+
+            string? thisJson = AsJson();
+            string? otherJson = ((Resource)obj).AsJson();
+            if (thisJson == null || otherJson == null)
+            {
+                // can't do proper comparison if either or both could not be serialized
+                return false;
+            }
+            return thisJson == otherJson;
+        }
+
         /// <summary>
         ///     Get the dictionary representation of this object instance.
         /// </summary>
@@ -18,6 +35,15 @@ namespace EasyPost
             GetType()
                 .GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance)
                 .ToDictionary(info => info.Name, info => GetValue(info));
+
+        /// <summary>
+        ///     Get the JSON representation of this object instance.
+        /// </summary>
+        /// <returns>A JSON string representation of this object instance's attributes</returns>
+        public string? AsJson()
+        {
+            return JsonSerialization.ConvertObjectToJson(this);
+        }
 
         /// <summary>
         ///     Merge the properties of this object instance with the properties of another object instance.


### PR DESCRIPTION
For a number of our unit tests, we're simply comparing the IDs of the original and test object, rather than comparing the whole objects. This PR introduces that functionality.

- New overloaded function for evaluating equality of Resource objects
- New function to convert Resource objects to JSON representation
- Unit tests now assert whole-object equality rather than just IDs (sans special cases where the two objects have known differences; ID comparison only in those situations)