### PR TITLE
add declaration attribute in customs info class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   * `ReportList`, `ScanFormList`, `ShipmentList` and `TrackerList` renamed to `ReportCollection`, `ScanFormCollection`, `ShipmentCollection` and `TrackerCollection`
 * Add support for `columns` and `additional_columns` on Report creation
 * Must use `verify` and `verify_strict` parameters to verify addresses during creation, per our API docs; `verification` and `strict_verification` will no longer work
+* Add `declaration` attribute to Customs Info class
 
 ## v2.8.1 (2022-02-17)
 

--- a/EasyPost/CustomsInfo.cs
+++ b/EasyPost/CustomsInfo.cs
@@ -34,6 +34,8 @@ namespace EasyPost
         public string restriction_type { get; set; }
         [JsonProperty("updated_at")]
         public DateTime? updated_at { get; set; }
+        [JsonProperty("declaration")]
+        public string declaration { get; set; }
 
         /// <summary>
         ///     Create a CustomsInfo.


### PR DESCRIPTION
Customs Info class is currently missing the `declaration` attribute.

This PR adds the `declaration` attribute in the Customs Info class.