### PR TITLE
Capture OS details in User-Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 
 - Adds `billing_type` attribute in CarrierAccount and Rate classes.
+- Collect OS details in User-Agent header.
 
 ## v3.1.0 (2022-05-19)
 

--- a/EasyPost.Tests/TestUtils.cs
+++ b/EasyPost.Tests/TestUtils.cs
@@ -31,7 +31,6 @@ namespace EasyPost.Tests
         {
             "Authorization",
             "User-Agent",
-            "X-Client-User-Agent"
         };
 
         private static readonly List<string> QueryCensors = new List<string>

--- a/EasyPost/Client.cs
+++ b/EasyPost/Client.cs
@@ -49,7 +49,7 @@ namespace EasyPost
 
             _libraryVersion = RuntimeInfo.ApplicationInfo.ApplicationVersion;
             _dotNetVersion = RuntimeInfo.ApplicationInfo.DotNetVersion;
-            _osDetails = RuntimeInfo.OperationSystemInfo.UserAgentOsDetails;
+            _osDetails = $"OS/{RuntimeInfo.OperationSystemInfo.Name} OSVersion/{RuntimeInfo.OperationSystemInfo.Version} OSArch/{RuntimeInfo.OperationSystemInfo.Architecture}";
 
             RestClientOptions clientOptions = new RestClientOptions
             {

--- a/EasyPost/Client.cs
+++ b/EasyPost/Client.cs
@@ -17,7 +17,9 @@ namespace EasyPost
 
         private readonly string _dotNetVersion;
         private readonly string _libraryVersion;
-        private readonly string _osDetails;
+        private readonly string _osArch;
+        private readonly string _osName;
+        private readonly string _osVersion;
 
         private readonly RestClient _restClient;
         private int? _connectTimeoutMilliseconds;
@@ -35,7 +37,7 @@ namespace EasyPost
             set => _requestTimeoutMilliseconds = value;
         }
 
-        private string UserAgent => $"EasyPost/v2 CSharpClient/{_libraryVersion} .NET/{_dotNetVersion} {_osDetails}";
+        private string UserAgent => $"EasyPost/v2 CSharpClient/{_libraryVersion} .NET/{_dotNetVersion} OS/{_osName} OSVersion/{_osVersion} OSArch/{_osArch}";
 
         /// <summary>
         ///     Constructor for the EasyPost client.
@@ -49,7 +51,9 @@ namespace EasyPost
 
             _libraryVersion = RuntimeInfo.ApplicationInfo.ApplicationVersion;
             _dotNetVersion = RuntimeInfo.ApplicationInfo.DotNetVersion;
-            _osDetails = $"OS/{RuntimeInfo.OperationSystemInfo.Name} OSVersion/{RuntimeInfo.OperationSystemInfo.Version} OSArch/{RuntimeInfo.OperationSystemInfo.Architecture}";
+            _osName = RuntimeInfo.OperationSystemInfo.Name;
+            _osVersion = RuntimeInfo.OperationSystemInfo.Version;
+            _osArch = RuntimeInfo.OperationSystemInfo.Architecture;
 
             RestClientOptions clientOptions = new RestClientOptions
             {

--- a/EasyPost/Utilities/RuntimeInfo.cs
+++ b/EasyPost/Utilities/RuntimeInfo.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace EasyPost.Utilities
+{
+    internal static class RuntimeInfo
+    {
+        internal struct ApplicationInfo
+        {
+            /// <summary>
+            ///     Get the version of the application as a string.
+            /// </summary>
+            /// <returns>The version of the application as a string.</returns>
+            internal static string ApplicationVersion
+            {
+                get
+                {
+                    try
+                    {
+                        Assembly assembly = typeof(ApplicationInfo).Assembly;
+                        FileVersionInfo info = FileVersionInfo.GetVersionInfo(assembly.Location);
+                        return info.FileVersion ?? "Unknown";
+                    }
+                    catch (Exception)
+                    {
+                        return "Unknown";
+                    }
+                }
+            }
+
+            /// <summary>
+            ///     Get the .NET framework version as a string.
+            /// </summary>
+            /// <returns>The .NET framework version as a string.</returns>
+            internal static string DotNetVersion
+            {
+                get { return Environment.Version.ToString(); }
+            }
+        }
+
+        internal struct OperationSystemInfo
+        {
+            /// <summary>
+            ///     Get details about the operating system.
+            /// </summary>
+            /// <returns>Details about the operating system.</returns>
+            private static OperatingSystem OperatingSystem
+            {
+                get { return Environment.OSVersion; }
+            }
+
+            /// <summary>
+            ///     Get user-agent pre-formatted operating system details.
+            /// </summary>
+            /// <returns>Operating system details pre-formatted for the User-Agent header.</returns>
+            internal static string UserAgentOsDetails
+            {
+                get { return $"OS/{Name} OSVersion/{Version} OSArch/{Architecture}"; }
+            }
+
+            /// <summary>
+            ///     Get the name of the operating system.
+            /// </summary>
+            /// <returns>Name of the operating system.</returns>
+            internal static string Name
+            {
+                get
+                {
+#if NET45
+                    switch (OperatingSystem.Platform)
+                    {
+                        case PlatformID.Win32S:
+                        case PlatformID.Win32Windows:
+                        case PlatformID.Win32NT:
+                        case PlatformID.WinCE:
+                            return "Windows";
+                        case PlatformID.Xbox:
+                            return "Xbox"; // yes, really
+                        case PlatformID.Unix:
+                            return "Linux";
+                        case PlatformID.MacOSX: // in newer versions, Mac OS X is PlatformID.Unix unfortunately
+                            return "Darwin";
+                        default:
+                            return "NA";
+                    }
+#else
+                            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                            {
+                                return "Linux";
+                            }
+                            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                            {
+                                return "Darwin";
+                            }
+                            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                            {
+                                return "Windows";
+                            }
+                            return "Unknown";
+#endif
+                }
+            }
+
+            /// <summary>
+            ///     Get the version of the operating system.
+            /// </summary>
+            /// <returns>Version of the operating system.</returns>
+            internal static string Version
+            {
+                get { return OperatingSystem.Version.ToString(); }
+            }
+
+            /// <summary>
+            ///     Get the architecture of the operating system.
+            /// </summary>
+            /// <returns>Architecture of the operating system.</returns>
+            internal static string Architecture
+            {
+                get
+                {
+                    // sorry, ARM users
+                    return Environment.Is64BitOperatingSystem ? "x64" : "x86";
+                }
+            }
+        }
+    }
+}

--- a/EasyPost/Utilities/RuntimeInfo.cs
+++ b/EasyPost/Utilities/RuntimeInfo.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace EasyPost.Utilities
 {
@@ -51,15 +52,6 @@ namespace EasyPost.Utilities
             }
 
             /// <summary>
-            ///     Get user-agent pre-formatted operating system details.
-            /// </summary>
-            /// <returns>Operating system details pre-formatted for the User-Agent header.</returns>
-            internal static string UserAgentOsDetails
-            {
-                get { return $"OS/{Name} OSVersion/{Version} OSArch/{Architecture}"; }
-            }
-
-            /// <summary>
             ///     Get the name of the operating system.
             /// </summary>
             /// <returns>Name of the operating system.</returns>
@@ -67,7 +59,7 @@ namespace EasyPost.Utilities
             {
                 get
                 {
-#if NET45
+#if NET462
                     switch (OperatingSystem.Platform)
                     {
                         case PlatformID.Win32S:
@@ -75,8 +67,6 @@ namespace EasyPost.Utilities
                         case PlatformID.Win32NT:
                         case PlatformID.WinCE:
                             return "Windows";
-                        case PlatformID.Xbox:
-                            return "Xbox"; // yes, really
                         case PlatformID.Unix:
                             return "Linux";
                         case PlatformID.MacOSX: // in newer versions, Mac OS X is PlatformID.Unix unfortunately
@@ -85,19 +75,22 @@ namespace EasyPost.Utilities
                             return "NA";
                     }
 #else
-                            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                            {
-                                return "Linux";
-                            }
-                            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                            {
-                                return "Darwin";
-                            }
-                            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                            {
-                                return "Windows";
-                            }
-                            return "Unknown";
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    {
+                        return "Linux";
+                    }
+
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                    {
+                        return "Darwin";
+                    }
+
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        return "Windows";
+                    }
+
+                    return "Unknown";
 #endif
                 }
             }
@@ -119,8 +112,24 @@ namespace EasyPost.Utilities
             {
                 get
                 {
-                    // sorry, ARM users
+#if NET462
+                    // Sorry, Windows ARM users (if you exist), best we can do is determine if we are running on a 64-bit or 32-bit
                     return Environment.Is64BitOperatingSystem ? "x64" : "x86";
+#else
+                    switch (RuntimeInformation.OSArchitecture)
+                    {
+                        case System.Runtime.InteropServices.Architecture.Arm:
+                            return "arm";
+                        case System.Runtime.InteropServices.Architecture.Arm64:
+                            return "arm64";
+                        case System.Runtime.InteropServices.Architecture.X64:
+                            return "x64";
+                        case System.Runtime.InteropServices.Architecture.X86:
+                            return "x86";
+                        default:
+                            return "NA";
+                    }
+#endif
                 }
             }
         }

--- a/EasyPost/Utilities/RuntimeInfo.cs
+++ b/EasyPost/Utilities/RuntimeInfo.cs
@@ -72,7 +72,7 @@ namespace EasyPost.Utilities
                         case PlatformID.MacOSX: // in newer versions, Mac OS X is PlatformID.Unix unfortunately
                             return "Darwin";
                         default:
-                            return "NA";
+                            return "Unknown";
                     }
 #else
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
@@ -127,7 +127,7 @@ namespace EasyPost.Utilities
                         case System.Runtime.InteropServices.Architecture.X86:
                             return "x86";
                         default:
-                            return "NA";
+                            return "Unknown";
                     }
 #endif
                 }


### PR DESCRIPTION
# Description

- Capture OS details in User-Agent
- Removed outdated, unused X-Client-User-Agent header
- Improve user agent detail calculation logic

# Testing

- Implementation works on all supported versions of .NET. Examples below (notice the different `.NET` value):
<img width="855" alt="image" src="https://user-images.githubusercontent.com/17054780/176537020-4b5c716a-25d5-43e5-8ff5-96c14bd9b135.png">

<img width="791" alt="image" src="https://user-images.githubusercontent.com/17054780/176537153-1de7dbd0-caa0-41cd-9fe5-93f00228e0c6.png">

<img width="767" alt="image" src="https://user-images.githubusercontent.com/17054780/176537074-d5f6c52d-94b4-4261-b55f-19918f10b86c.png">

<img width="767" alt="image" src="https://user-images.githubusercontent.com/17054780/176537107-4e0b7890-11d0-4ecc-8eec-b8ee510f46ca.png">

- All tests pass as expected

# Notes
- The legacy .NET Framework does not have pretty version numbers (will look something like 4.0.xxxx.xxxx), but it thankfully sticks out compared to the other .NET/.NET Core versions (which follow the X.Y.Z pattern)
- In the screenshots above, the `OSVersion` for .NET 5 and .NET 6 report "12.0.1", while .NET Core 3.1 and .NET Framework report "21.1.0.0". This is due to a change [introduced in .NET 5](https://docs.microsoft.com/en-us/dotnet/api/system.environment.osversion?view=net-6.0#remarks) that improved the accuracy of OS version reporting. To make sense of this, .NET Framework and .NET Core 3.1 are seeing "Darwin 21.1.0.0", while .NET 5 and .NET 6 are seeing "MacOS 12.0.1". These are [the same thing](https://en.wikipedia.org/wiki/MacOS_Monterey#Release_history) ultimately.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
