### PR TITLE
Backport User-Agent to V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v2.8.3 (TBD)
+
+* Backport improved User-Agent to collect OS details.
+
 ## v2.8.2 (2022-02-25)
 
 * Fixes a bug where failure to retrieve Assembly information to populate the `User-Agent` header on some platforms/versions would result in the inability to make HTTP requests

--- a/EasyPost/Client.cs
+++ b/EasyPost/Client.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Net;
-using System.Reflection;
 using Newtonsoft.Json;
 using RestSharp;
 
@@ -17,6 +15,9 @@ namespace EasyPost
 
         private readonly string _dotNetVersion;
         private readonly string _libraryVersion;
+        private readonly string _osArch;
+        private readonly string _osName;
+        private readonly string _osVersion;
 
         private readonly RestClient _restClient;
         private int? _connectTimeoutMilliseconds;
@@ -34,7 +35,7 @@ namespace EasyPost
             set => _requestTimeoutMilliseconds = value;
         }
 
-        private string UserAgent => $"EasyPost/v2 CSharpClient/{_libraryVersion} .NET/{_dotNetVersion}";
+        private string UserAgent => $"EasyPost/v2 CSharpClient/{_libraryVersion} .NET/{_dotNetVersion} OS/{_osName} OSVersion/{_osVersion} OSArch/{_osArch}";
 
         /// <summary>
         ///     Constructor for the EasyPost client.
@@ -44,6 +45,12 @@ namespace EasyPost
         {
             ServicePointManager.SecurityProtocol |= Security.GetProtocol();
             _configuration = clientConfiguration ?? throw new ArgumentNullException("clientConfiguration");
+
+            _libraryVersion = RuntimeInfo.ApplicationInfo.ApplicationVersion;
+            _dotNetVersion = RuntimeInfo.ApplicationInfo.DotNetVersion;
+            _osName = RuntimeInfo.OperationSystemInfo.Name;
+            _osVersion = RuntimeInfo.OperationSystemInfo.Version;
+            _osArch = RuntimeInfo.OperationSystemInfo.Architecture;
 
             _restClient = new RestClient(clientConfiguration.ApiBase);
             _restClient.Timeout = ConnectTimeoutMilliseconds;
@@ -57,19 +64,6 @@ namespace EasyPost
             {
                 _libraryVersion = "Unknown";
             }
-
-            string dotNetVersion = Environment.Version.ToString();
-            if (dotNetVersion == "4.0.30319.42000")
-            {
-                /*
-                 * We're on a v4.6+ version (or pre-.NET Core 3.0, which we don't support),
-                 * but we can't get the exact version.
-                 * See: https://docs.microsoft.com/en-us/dotnet/api/system.environment.version?view=net-6.0#remarks
-                 */
-                dotNetVersion = "4.6 or higher";
-            }
-
-            _dotNetVersion = dotNetVersion;
         }
 
         /// <summary>

--- a/EasyPost/EasyPost.csproj
+++ b/EasyPost/EasyPost.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Report.cs" />
     <Compile Include="ReportList.cs" />
     <Compile Include="Resource.cs" />
+    <Compile Include="RuntimeInfo.cs"/>
     <Compile Include="Smartrate.cs" />
     <Compile Include="TimeInTransit.cs" />
     <Compile Include="TrackerList.cs" />

--- a/EasyPost/RuntimeInfo.cs
+++ b/EasyPost/RuntimeInfo.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace EasyPost
+{
+    internal static class RuntimeInfo
+    {
+        internal struct ApplicationInfo
+        {
+            /// <summary>
+            ///     Get the version of the application as a string.
+            /// </summary>
+            /// <returns>The version of the application as a string.</returns>
+            internal static string ApplicationVersion
+            {
+                get
+                {
+                    try
+                    {
+                        Assembly assembly = typeof(ApplicationInfo).Assembly;
+                        FileVersionInfo info = FileVersionInfo.GetVersionInfo(assembly.Location);
+                        return info.FileVersion ?? "Unknown";
+                    }
+                    catch (Exception)
+                    {
+                        return "Unknown";
+                    }
+                }
+            }
+
+            /// <summary>
+            ///     Get the .NET framework version as a string.
+            /// </summary>
+            /// <returns>The .NET framework version as a string.</returns>
+            internal static string DotNetVersion
+            {
+                get
+                {
+                    string dotNetVersion = Environment.Version.ToString();
+                    if (dotNetVersion == "4.0.30319.42000")
+                    {
+                        /*
+                         * We're on a v4.6+ version (or pre-.NET Core 3.0, which we don't support),
+                         * but we can't get the exact version.
+                         * See: https://docs.microsoft.com/en-us/dotnet/api/system.environment.version?view=net-6.0#remarks
+                         */
+                        dotNetVersion = "4.6 or higher";
+                    }
+
+                    return dotNetVersion;
+                }
+            }
+        }
+
+        internal struct OperationSystemInfo
+        {
+            /// <summary>
+            ///     Get details about the operating system.
+            /// </summary>
+            /// <returns>Details about the operating system.</returns>
+            private static OperatingSystem OperatingSystem
+            {
+                get { return Environment.OSVersion; }
+            }
+
+            /// <summary>
+            ///     Get the name of the operating system.
+            /// </summary>
+            /// <returns>Name of the operating system.</returns>
+            internal static string Name
+            {
+                get
+                {
+                    switch (OperatingSystem.Platform)
+                    {
+                        case PlatformID.Win32S:
+                        case PlatformID.Win32Windows:
+                        case PlatformID.Win32NT:
+                        case PlatformID.WinCE:
+                            return "Windows";
+                        case PlatformID.Unix:
+                            return "Linux";
+                        case PlatformID.MacOSX: // in newer versions, Mac OS X is PlatformID.Unix unfortunately
+                            return "Darwin";
+                        default:
+                            return "Unknown";
+                    }
+                }
+            }
+
+            /// <summary>
+            ///     Get the version of the operating system.
+            /// </summary>
+            /// <returns>Version of the operating system.</returns>
+            internal static string Version
+            {
+                get { return OperatingSystem.Version.ToString(); }
+            }
+
+            /// <summary>
+            ///     Get the architecture of the operating system.
+            /// </summary>
+            /// <returns>Architecture of the operating system.</returns>
+            internal static string Architecture
+            {
+                get
+                {
+                    // Sorry, Windows ARM users (if you exist), best we can do is determine if we are running on a 64-bit or 32-bit
+                    return Environment.Is64BitOperatingSystem ? "x64" : "x86";
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description

- Backport OS details in User-Agent

# Testing

- `v2` of the C# library didn't have VCR, so testing will be done by GitHub Actions (may fail if API keys are not stored in GitHub Secrets)

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
