### PR TITLE
Add static analysis tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,17 @@ jobs:
       - uses: actions/checkout@v3
       - name: Check dotnet Style
         run: dotnet-format --check --exclude /
+  security:
+    runs-on: windows-2022
+    steps:
+      - name: Install security-code-scan
+        run: dotnet tool install -g security-scan
+      - uses: actions/checkout@v3
+      - name: Run security analysis
+        run: security-scan EasyPost.sln --ignore-msbuild-errors
+        # "--ignore-msbuild-errors" needed since MSBuild does not F#: https://github.com/security-code-scan/security-code-scan/issues/235
+        # In the future, we can collect the output logs by enabling Code Scanning and using the pre-built GitHub Action: https://github.com/marketplace/actions/securitycodescan
+        # https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#uploading-a-code-scanning-analysis-with-github-actions
   NET_Tests:
     # derived from https://dev.to/felipetofoli/github-actions-for-net-full-framework-build-and-test-299h
     runs-on: windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: dotnet tool install -g security-scan
       - uses: actions/checkout@v3
       - name: Run security analysis
-        run: security-scan EasyPost.sln --ignore-msbuild-errors
+        run: security-scan EasyPost.sln --ignore-msbuild-errors --verbose
         # "--ignore-msbuild-errors" needed since MSBuild does not F#: https://github.com/security-code-scan/security-code-scan/issues/235
         # In the future, we can collect the output logs by enabling Code Scanning and using the pre-built GitHub Action: https://github.com/marketplace/actions/securitycodescan
         # https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#uploading-a-code-scanning-analysis-with-github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run security analysis
         run: security-scan EasyPost.sln --ignore-msbuild-errors --verbose
-        # "--ignore-msbuild-errors" needed since MSBuild does not F#: https://github.com/security-code-scan/security-code-scan/issues/235
+        # "--ignore-msbuild-errors" needed since MSBuild does not like F#: https://github.com/security-code-scan/security-code-scan/issues/235
         # In the future, we can collect the output logs by enabling Code Scanning and using the pre-built GitHub Action: https://github.com/marketplace/actions/securitycodescan
         # https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#uploading-a-code-scanning-analysis-with-github-actions
   NET_Tests:

--- a/EasyPost.Tests.FSharp/EasyPost.Tests.FSharp.fsproj
+++ b/EasyPost.Tests.FSharp/EasyPost.Tests.FSharp.fsproj
@@ -14,9 +14,13 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-      <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-      <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
+        <PackageReference Include="MSTest.TestAdapter" Version="2.2.8"/>
+        <PackageReference Include="MSTest.TestFramework" Version="2.2.8"/>
+        <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.3">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/EasyPost.Tests.FSharp/EasyPost.Tests.FSharp.fsproj
+++ b/EasyPost.Tests.FSharp/EasyPost.Tests.FSharp.fsproj
@@ -17,7 +17,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.8"/>
         <PackageReference Include="MSTest.TestFramework" Version="2.2.8"/>
-        <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.3">
+        <PackageReference Include="SecurityCodeScan.VS2019" Version="[5.0.0, 6.0.0)">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/EasyPost.Tests.VB/EasyPost.Tests.VB.vbproj
+++ b/EasyPost.Tests.VB/EasyPost.Tests.VB.vbproj
@@ -13,7 +13,7 @@
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
       <PackageReference Include="MSTest.TestAdapter" Version="2.2.8"/>
       <PackageReference Include="MSTest.TestFramework" Version="2.2.8"/>
-      <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.3">
+      <PackageReference Include="SecurityCodeScan.VS2019" Version="[5.0.0, 6.0.0)">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/EasyPost.Tests.VB/EasyPost.Tests.VB.vbproj
+++ b/EasyPost.Tests.VB/EasyPost.Tests.VB.vbproj
@@ -10,9 +10,13 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-      <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-      <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
+      <PackageReference Include="MSTest.TestAdapter" Version="2.2.8"/>
+      <PackageReference Include="MSTest.TestFramework" Version="2.2.8"/>
+      <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.3">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/EasyPost.Tests/EasyPost.Tests.csproj
+++ b/EasyPost.Tests/EasyPost.Tests.csproj
@@ -12,13 +12,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EasyVCR" Version="0.3.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="[13.0.1, 14.0.0)" />
-    <PackageReference Include="RestSharp" Version="[107.3.0, 108.0.0)" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="EasyVCR" Version="0.3.1"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0"/>
+    <PackageReference Include="coverlet.collector" Version="1.2.0"/>
+    <PackageReference Include="Newtonsoft.Json" Version="[13.0.1, 14.0.0)"/>
+    <PackageReference Include="RestSharp" Version="[107.3.0, 108.0.0)"/>
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8"/>
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8"/>
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/EasyPost.Tests/EasyPost.Tests.csproj
+++ b/EasyPost.Tests/EasyPost.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="RestSharp" Version="[107.3.0, 108.0.0)"/>
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8"/>
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8"/>
-    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.3">
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="[5.0.0, 6.0.0)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/EasyPost/Base/Address.cs
+++ b/EasyPost/Base/Address.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace EasyPost.Base

--- a/EasyPost/EasyPost.csproj
+++ b/EasyPost/EasyPost.csproj
@@ -61,7 +61,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="[13.0.1, 14.0.0)"/>
     <PackageReference Include="RestSharp" Version="[107.3.0, 108.0.0)"/>
-    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.3">
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="[5.0.0, 6.0.0)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/EasyPost/EasyPost.csproj
+++ b/EasyPost/EasyPost.csproj
@@ -61,6 +61,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="[13.0.1, 14.0.0)"/>
     <PackageReference Include="RestSharp" Version="[107.3.0, 108.0.0)"/>
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="5.6.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/EasyPost/Exception.cs
+++ b/EasyPost/Exception.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
-using System.Security.Permissions;
 
 namespace EasyPost
 {
@@ -52,14 +51,14 @@ namespace EasyPost
     {
         private readonly string _property;
 
-        public PropertyMissing(string property)
-        {
-            _property = property;
-        }
-
         public override string Message
         {
             get { return $"Missing {_property}"; }
+        }
+
+        public PropertyMissing(string property)
+        {
+            _property = property;
         }
     }
 

--- a/EasyPost/Pickup.cs
+++ b/EasyPost/Pickup.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using EasyPost.Utilities;
 using Newtonsoft.Json;
 using RestSharp;
 

--- a/EasyPost/Shipment.cs
+++ b/EasyPost/Shipment.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using EasyPost.Utilities;
 using Newtonsoft.Json;

--- a/Makefile
+++ b/Makefile
@@ -64,5 +64,6 @@ lint-scripts:
 # Makefile cannot access global dotnet tools, so you need to run the below command manually.
 scan:
 	security-scan --verbose --no-banner --ignore-msbuild-errors EasyPost.sln
+	# "--ignore-msbuild-errors" needed since MSBuild does not like F#: https://github.com/security-code-scan/security-code-scan/issues/235
 
 .PHONY: help release build-dev build install-cert sign clean restore lint lint-check test lint-scripts install-scanner scan

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ build:
 install-cert:
 	scripts\install_cert.bat ${cert} ${pass}
 
+## install-scanner - Install SecurityCodeScan to your system
+install-scanner:
+	dotnet tool install -g security-scan
+
 ## sign - Sign all generated DLLs and NuGet packages with the provided certificate (Windows only)
 # @parameters:
 # cert= - The certificate to use for signing the built assets.
@@ -56,4 +60,9 @@ test:
 lint-scripts:
 	scripts\lint_scripts.bat
 
-.PHONY: help release build-dev build install-cert sign clean restore lint lint-check test lint-scripts
+## scan - Scan the project for security issues (must run install-scanner first)
+# Makefile cannot access global dotnet tools, so you need to run the below command manually.
+scan:
+	security-scan --verbose --no-banner --ignore-msbuild-errors EasyPost.sln
+
+.PHONY: help release build-dev build install-cert sign clean restore lint lint-check test lint-scripts install-scanner scan


### PR DESCRIPTION
# Description

- Add [SecurityCodeScan](https://security-code-scan.github.io/#Installation) as NuGet dependency (during build, not install)
- Add SecurityCodeScan as CI step
- Fix some linting

# Testing

- Performed code analysis in IDE (NuGet package would step in, no errors found)
- Tested build process (NuGet package would step in, no errors found)
- Ran code manually through standalone scanner (no errors found)
- All unit tests pass as expected, no new recordings needed

# Notes
- We should enable proper [Code Scanning via GitHub](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning). SecurityCodeScan can [take advantage](https://github.com/marketplace/actions/securitycodescan) of that feature (see comment in `ci.yml`)

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
