### PR TITLE
Automate the environment setup process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,4 +80,8 @@ scan:
 	security-scan --verbose --no-banner --ignore-msbuild-errors EasyPost.sln
 	# "--ignore-msbuild-errors" needed since MSBuild does not like F#: https://github.com/security-code-scan/security-code-scan/issues/235
 
+## setup - Install required .NET versions and tools (Windows only)5
+setup:
+	scripts\setup.bat
+
 .PHONY: help release build-dev build install-cert sign clean restore lint lint-check test lint-scripts install-scanner scan

--- a/scripts/publish_all_nuget.bat
+++ b/scripts/publish_all_nuget.bat
@@ -1,4 +1,4 @@
-﻿:: This script will find and publish any NuGet packages to Nuget.org
+:: This script will find and publish any NuGet packages to Nuget.org
 
 :: Requirements:
 :: - NuGet is installed on the machine and is accessible everywhere (added to PATH)

--- a/scripts/publish_nuget.bat
+++ b/scripts/publish_nuget.bat
@@ -1,4 +1,4 @@
-﻿:: This script will find and publish a NuGet packages to Nuget.org
+:: This script will find and publish a NuGet packages to Nuget.org
 
 :: Requirements:
 :: - NuGet is installed on the machine and is accessible everywhere (added to PATH)

--- a/scripts/setup.bat
+++ b/scripts/setup.bat
@@ -1,0 +1,49 @@
+:: This script will:
+:: 	- use Microsoft's PowerShell script (https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-install-script) to install the latest version of all required .NET SDKs.
+::	- install required third-party tools for running these scripts
+::	- add files to the current user's PATH environment variable
+
+:: Requirements:
+:: - PowerShell is enabled on the machine
+:: - Do not install dotnet via any other method (including via installing Visual Studio/Rider). This might otherwise cause two conflicting versions of 'dotnet' to exist in your PATH
+
+@ECHO OFF
+
+:: .NET Versions we want to install and destination
+SET NetVersions=Current 6.0 5.0 3.1
+SET InstallPath=C:\dotnet
+
+:: Dependencies for these scripts
+SET DepFiles=SnInstallPfx.exe nuget.exe 7z.exe
+SET FileHost=https://files.nateharr.is/netdeps/
+
+:: Install each .NET version
+@ECHO Installing .NET SDKs ...
+SETLOCAL
+    for %%x IN (%NetVersions%) DO (
+        @ECHO Installing .NET %%x ...
+        powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; &([scriptblock]::Create((Invoke-WebRequest -UseBasicParsing 'https://dot.net/v1/dotnet-install.ps1'))) -InstallDir %InstallPath% -Channel %%x -Verbose"
+    )
+ENDLOCAL
+
+:: Download dependencies to the same directory as 'dotnet'
+@ECHO Downloading third-party tools ...
+SETLOCAL
+    for %%x IN (%DepFiles%) DO (
+        @ECHO Downloading %%x ...
+        powershell -NoProfile -ExecutionPolicy unrestricted -Command "Invoke-WebRequest -Uri '%FileHost%%%x' -OutFile '%InstallPath%\%%x'"
+    )
+ENDLOCAL
+
+:: Add dotnet folder to PATH
+powershell -NoProfile -ExecutionPolicy unrestricted -Command "[Environment]::SetEnvironmentVariable('Path', $env:Path + ';%InstallPath%', 'User')"
+
+EXIT /B 0
+
+:commandFailed
+@ECHO Command failed.
+GOTO :exitWithError
+
+:exitWithError
+@ECHO Exiting...
+EXIT /B 1


### PR DESCRIPTION
# Description
Let's make it as easy as possible for someone with a "fresh" Windows machine to get their environment up and running for developing and testing our code.

- New script/Makefile step "setup" installs all required .NET versions and third-party tools (NuGet CLI tool for a variety of functions, SnInstallPfx for signing DLLs)

(Bit of a catch-22 here, as the user WILL still need to install Make (and, perhaps in the process, Chocolatey) to be able to use our Makefile. They could always bypass the Makefile shortcut and simply call the `setup.bat` script directly via a terminal. The `setup.bat` script does NOT install Chocolatey or Make.

# Testing

- [x] Script run in a fresh Windows installation, works as expected
- [x] No valid concerns from BatCodeCheck

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
