### PR TITLE
Lock down model constructors

### DIFF
--- a/EasyPost.Tests.FSharp/FSharpCompileTest.fs
+++ b/EasyPost.Tests.FSharp/FSharpCompileTest.fs
@@ -3,12 +3,12 @@
 
 namespace EasyPost.Tests.FSharp
 
-open EasyPost.Models.API
+open EasyPost
 open Xunit
 
 type FSharpCompileTest() =
     [<Fact>]
     member this.TestCompile() =
-        let address = new Address()
+        let client = new Client("fake_api_key")
         // The assert doesn't really do anything, but as long as this test can run, then the code is compiling correctly.
-        Assert.NotNull(address)
+        Assert.NotNull(client)

--- a/EasyPost.Tests.VB/VbCompileTest.vb
+++ b/EasyPost.Tests.VB/VbCompileTest.vb
@@ -1,14 +1,13 @@
 'This test checks that EasyPost C# code can be used in Visual Basic.
 'This test project is running on .NET 6.0, although a success here should mean a success in all versions of .NET.
-Imports EasyPost.Models.API
 Imports Xunit
 
 Public Class VbCompileTest
     <Fact>
     Public Sub TestCompile()
-        Dim address = New Address()
+        Dim client = New Client("fake_api_key")
 
         'Do not need to actually assert anything here. If it runs, it means it compiled successfully.
-        Assert.NotNull(address)
+        Assert.NotNull(client)
     End Sub
 End Class

--- a/EasyPost.Tests/packages.lock.json
+++ b/EasyPost.Tests/packages.lock.json
@@ -1,755 +1,755 @@
 {
-    "version": 1,
-    "dependencies": {
-        ".NETCoreApp,Version=v3.1": {
-            "coverlet.collector": {
-                "type": "Direct",
-                "requested": "[3.1.2, 4.0.0)",
-                "resolved": "3.1.2",
-                "contentHash": "wuLDIDKD5XMt0A7lE31JPenT7QQwZPFkP5rRpdJeblyXZ9MGLI8rYjvm5fvAKln+2/X+4IxxQDxBtwdrqKNLZw=="
-            },
-            "EasyVCR": {
-                "type": "Direct",
-                "requested": "[0.4.0, 1.0.0)",
-                "resolved": "0.4.0",
-                "contentHash": "Vd3h4PWG5HCqN+BNoSu5gL6/MDtZAczNWh2s/PV+yP/85TFmpPRLWW4YYuzgtc3tcOdpL5X88Ivi6N60R/SdBw==",
-                "dependencies": {
-                    "Newtonsoft.Json": "13.0.1"
-                }
-            },
-            "Microsoft.NET.Test.Sdk": {
-                "type": "Direct",
-                "requested": "[17.3.0, 18.0.0)",
-                "resolved": "17.3.0",
-                "contentHash": "ch4JCT7AZdBzvCAKD36t6fDsl7NEzzunwW7MwXUG2uFPoWcMd8B8KYg5fiwxnpdXJHodJk6yIBdSwMpN3Ikt9w==",
-                "dependencies": {
-                    "Microsoft.CodeCoverage": "17.3.0",
-                    "Microsoft.TestPlatform.TestHost": "17.3.0"
-                }
-            },
-            "Microsoft.NETFramework.ReferenceAssemblies": {
-                "type": "Direct",
-                "requested": "[1.0.2, )",
-                "resolved": "1.0.2",
-                "contentHash": "5/cSEVld+px/CuRrbohO/djfg6++eR6zGpy88MgqloXvkj//WXWpFZyu/OpkXPN0u5m+dN/EVwLNYFUxD4h2+A==",
-                "dependencies": {
-                    "Microsoft.NETFramework.ReferenceAssemblies.net461": "1.0.2"
-                }
-            },
-            "Microsoft.VisualStudio.TestPlatform.ObjectModel": {
-                "type": "Direct",
-                "requested": "[14.0.0, 15.0.0)",
-                "resolved": "14.0.0",
-                "contentHash": "PlQ38dL950pnyptA3CcnYIqAKpqlP7xpoz8n5ZfS1QgxFiZrh2x1lw05V3VNmq0ZZ9Xy3SHB5tOyvFjmjNR1HQ=="
-            },
-            "NETStandard.Library": {
-                "type": "Direct",
-                "requested": "[2.0.3, 3.0.0)",
-                "resolved": "2.0.3",
-                "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
-                "dependencies": {
-                    "Microsoft.NETCore.Platforms": "1.1.0"
-                }
-            },
-            "Newtonsoft.Json": {
-                "type": "Direct",
-                "requested": "[13.0.1, 14.0.0)",
-                "resolved": "13.0.1",
-                "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-            },
-            "RestSharp": {
-                "type": "Direct",
-                "requested": "[108.0.1, 109.0.0)",
-                "resolved": "108.0.1",
-                "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
-                "dependencies": {
-                    "System.Text.Json": "5.0.0"
-                }
-            },
-            "SecurityCodeScan.VS2019": {
-                "type": "Direct",
-                "requested": "[5.6.6, 6.0.0)",
-                "resolved": "5.6.6",
-                "contentHash": "1BEkaTw2iZ5QccesAYfRcab9ttQvg6xyIItazCWLJEt5aKf3cDXvGtX+Z4p11a1QwYmf3WaNxpiZXfzXK/0VIw=="
-            },
-            "xunit": {
-                "type": "Direct",
-                "requested": "[2.4.2, 3.0.0)",
-                "resolved": "2.4.2",
-                "contentHash": "6Mj73Ont3zj2CJuoykVJfE0ZmRwn7C+pTuRP8c4bnaaTFjwNG6tGe0prJ1yIbMe9AHrpDys63ctWacSsFJWK/w==",
-                "dependencies": {
-                    "xunit.analyzers": "1.0.0",
-                    "xunit.assert": "2.4.2",
-                    "xunit.core": "[2.4.2]"
-                }
-            },
-            "xunit.runner.visualstudio": {
-                "type": "Direct",
-                "requested": "[2.4.5, 3.0.0)",
-                "resolved": "2.4.5",
-                "contentHash": "OwHamvBdUKgqsXfBzWiCW/O98BTx81UKzx2bieIOQI7CZFE5NEQZGi8PBQGIKawDW96xeRffiNf20SjfC0x9hw=="
-            },
-            "Microsoft.CodeCoverage": {
-                "type": "Transitive",
-                "resolved": "17.3.0",
-                "contentHash": "/xxz+e29F2V5pePtInjbLffoqWVTm60KCX87vSj2laNboeWq65WFJ634fGtBcMZO3VEfOmh9/XcoWEfLlWWG+g=="
-            },
-            "Microsoft.NETCore.Platforms": {
-                "type": "Transitive",
-                "resolved": "1.1.0",
-                "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
-            },
-            "Microsoft.NETFramework.ReferenceAssemblies.net461": {
-                "type": "Transitive",
-                "resolved": "1.0.2",
-                "contentHash": "8shzGaD5pZi4npuJYCM3de6pl0zlefcbyTIvXIiCdsTqauZ7lAhdaJVtJSqlhYid9VosFAOygBykoJ1SEOlGWA=="
-            },
-            "Microsoft.TestPlatform.ObjectModel": {
-                "type": "Transitive",
-                "resolved": "17.3.0",
-                "contentHash": "6NRzi6QbmWV49Psf8A9z1LTJU4nBrlJdCcDOUyD4Ttm1J2wvksu98GlV+52CkxtpgNsUjGr9Mv1Rbb1/dB06yQ==",
-                "dependencies": {
-                    "NuGet.Frameworks": "5.11.0",
-                    "System.Reflection.Metadata": "1.6.0"
-                }
-            },
-            "Microsoft.TestPlatform.TestHost": {
-                "type": "Transitive",
-                "resolved": "17.3.0",
-                "contentHash": "uOJALDWtKXZkISKuNI7kOlRi/lk2CqXZtLkNS0Ei+RXqRUjUpCsjAPYSP+DJ/a4QwJ5cI9CVF52vtajnGOaEpw==",
-                "dependencies": {
-                    "Microsoft.TestPlatform.ObjectModel": "17.3.0",
-                    "Newtonsoft.Json": "9.0.1"
-                }
-            },
-            "NuGet.Frameworks": {
-                "type": "Transitive",
-                "resolved": "5.11.0",
-                "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
-            },
-            "System.Reflection.Metadata": {
-                "type": "Transitive",
-                "resolved": "1.6.0",
-                "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
-            },
-            "System.Text.Json": {
-                "type": "Transitive",
-                "resolved": "5.0.0",
-                "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
-            },
-            "xunit.abstractions": {
-                "type": "Transitive",
-                "resolved": "2.0.3",
-                "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
-            },
-            "xunit.analyzers": {
-                "type": "Transitive",
-                "resolved": "1.0.0",
-                "contentHash": "BeO8hEgs/c8Ls2647fPfieMngncvf0D0xYNDfIO59MolxtCtVjFRd6SRc+7tj8VMqkVOuJcnc9eh4ngI2cAmLQ=="
-            },
-            "xunit.assert": {
-                "type": "Transitive",
-                "resolved": "2.4.2",
-                "contentHash": "pxJISOFjn2XTTi1mcDCkRZrTFb9OtRRCtx2kZFNF51GdReLr1ls2rnyxvAS4JO247K3aNtflvh5Q0346K5BROA==",
-                "dependencies": {
-                    "NETStandard.Library": "1.6.1"
-                }
-            },
-            "xunit.core": {
-                "type": "Transitive",
-                "resolved": "2.4.2",
-                "contentHash": "KB4yGCxNqIVyekhJLXtKSEq6BaXVp/JO3mbGVE1hxypZTLEe7h+sTbAhpA+yZW2dPtXTuiW+C1B2oxxHEkrmOw==",
-                "dependencies": {
-                    "xunit.extensibility.core": "[2.4.2]",
-                    "xunit.extensibility.execution": "[2.4.2]"
-                }
-            },
-            "xunit.extensibility.core": {
-                "type": "Transitive",
-                "resolved": "2.4.2",
-                "contentHash": "W1BoXTIN1C6kpVSMw25huSet25ky6IAQUNovu3zGOGN/jWnbgSoTyCrlIhmXSg0tH5nEf8q7h3OjNHOjyu5PfA==",
-                "dependencies": {
-                    "NETStandard.Library": "1.6.1",
-                    "xunit.abstractions": "2.0.3"
-                }
-            },
-            "xunit.extensibility.execution": {
-                "type": "Transitive",
-                "resolved": "2.4.2",
-                "contentHash": "CZmgcKkwpyo8FlupZdWpJCryrAOWLh1FBPG6gmVZuPQkGQsim/oL4PcP4nfrC2hHgXUFtluvaJ0Sp9PQKUMNpg==",
-                "dependencies": {
-                    "NETStandard.Library": "1.6.1",
-                    "xunit.extensibility.core": "[2.4.2]"
-                }
-            },
-            "easypost": {
-                "type": "Project",
-                "dependencies": {
-                    "Newtonsoft.Json": "[13.0.1, 14.0.0)",
-                    "RestSharp": "[108.0.1, 109.0.0)"
-                }
-            }
-        },
-        ".NETFramework,Version=v4.6.2": {
-            "coverlet.collector": {
-                "type": "Direct",
-                "requested": "[3.1.2, 4.0.0)",
-                "resolved": "3.1.2",
-                "contentHash": "wuLDIDKD5XMt0A7lE31JPenT7QQwZPFkP5rRpdJeblyXZ9MGLI8rYjvm5fvAKln+2/X+4IxxQDxBtwdrqKNLZw=="
-            },
-            "EasyVCR": {
-                "type": "Direct",
-                "requested": "[0.4.0, 1.0.0)",
-                "resolved": "0.4.0",
-                "contentHash": "Vd3h4PWG5HCqN+BNoSu5gL6/MDtZAczNWh2s/PV+yP/85TFmpPRLWW4YYuzgtc3tcOdpL5X88Ivi6N60R/SdBw==",
-                "dependencies": {
-                    "Newtonsoft.Json": "13.0.1"
-                }
-            },
-            "Microsoft.NET.Test.Sdk": {
-                "type": "Direct",
-                "requested": "[17.3.0, 18.0.0)",
-                "resolved": "17.3.0",
-                "contentHash": "ch4JCT7AZdBzvCAKD36t6fDsl7NEzzunwW7MwXUG2uFPoWcMd8B8KYg5fiwxnpdXJHodJk6yIBdSwMpN3Ikt9w==",
-                "dependencies": {
-                    "Microsoft.CodeCoverage": "17.3.0"
-                }
-            },
-            "Microsoft.NETFramework.ReferenceAssemblies": {
-                "type": "Direct",
-                "requested": "[1.0.2, )",
-                "resolved": "1.0.2",
-                "contentHash": "5/cSEVld+px/CuRrbohO/djfg6++eR6zGpy88MgqloXvkj//WXWpFZyu/OpkXPN0u5m+dN/EVwLNYFUxD4h2+A==",
-                "dependencies": {
-                    "Microsoft.NETFramework.ReferenceAssemblies.net462": "1.0.2"
-                }
-            },
-            "Microsoft.VisualStudio.TestPlatform.ObjectModel": {
-                "type": "Direct",
-                "requested": "[14.0.0, 15.0.0)",
-                "resolved": "14.0.0",
-                "contentHash": "PlQ38dL950pnyptA3CcnYIqAKpqlP7xpoz8n5ZfS1QgxFiZrh2x1lw05V3VNmq0ZZ9Xy3SHB5tOyvFjmjNR1HQ=="
-            },
-            "NETStandard.Library": {
-                "type": "Direct",
-                "requested": "[2.0.3, 3.0.0)",
-                "resolved": "2.0.3",
-                "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
-                "dependencies": {
-                    "Microsoft.NETCore.Platforms": "1.1.0"
-                }
-            },
-            "Newtonsoft.Json": {
-                "type": "Direct",
-                "requested": "[13.0.1, 14.0.0)",
-                "resolved": "13.0.1",
-                "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-            },
-            "RestSharp": {
-                "type": "Direct",
-                "requested": "[108.0.1, 109.0.0)",
-                "resolved": "108.0.1",
-                "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
-                "dependencies": {
-                    "System.Text.Json": "5.0.0"
-                }
-            },
-            "SecurityCodeScan.VS2019": {
-                "type": "Direct",
-                "requested": "[5.6.6, 6.0.0)",
-                "resolved": "5.6.6",
-                "contentHash": "1BEkaTw2iZ5QccesAYfRcab9ttQvg6xyIItazCWLJEt5aKf3cDXvGtX+Z4p11a1QwYmf3WaNxpiZXfzXK/0VIw=="
-            },
-            "xunit": {
-                "type": "Direct",
-                "requested": "[2.4.2, 3.0.0)",
-                "resolved": "2.4.2",
-                "contentHash": "6Mj73Ont3zj2CJuoykVJfE0ZmRwn7C+pTuRP8c4bnaaTFjwNG6tGe0prJ1yIbMe9AHrpDys63ctWacSsFJWK/w==",
-                "dependencies": {
-                    "xunit.analyzers": "1.0.0",
-                    "xunit.assert": "2.4.2",
-                    "xunit.core": "[2.4.2]"
-                }
-            },
-            "xunit.runner.visualstudio": {
-                "type": "Direct",
-                "requested": "[2.4.5, 3.0.0)",
-                "resolved": "2.4.5",
-                "contentHash": "OwHamvBdUKgqsXfBzWiCW/O98BTx81UKzx2bieIOQI7CZFE5NEQZGi8PBQGIKawDW96xeRffiNf20SjfC0x9hw=="
-            },
-            "Microsoft.Bcl.AsyncInterfaces": {
-                "type": "Transitive",
-                "resolved": "5.0.0",
-                "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
-                "dependencies": {
-                    "System.Threading.Tasks.Extensions": "4.5.4"
-                }
-            },
-            "Microsoft.CodeCoverage": {
-                "type": "Transitive",
-                "resolved": "17.3.0",
-                "contentHash": "/xxz+e29F2V5pePtInjbLffoqWVTm60KCX87vSj2laNboeWq65WFJ634fGtBcMZO3VEfOmh9/XcoWEfLlWWG+g=="
-            },
-            "Microsoft.NETCore.Platforms": {
-                "type": "Transitive",
-                "resolved": "1.1.0",
-                "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
-            },
-            "Microsoft.NETFramework.ReferenceAssemblies.net462": {
-                "type": "Transitive",
-                "resolved": "1.0.2",
-                "contentHash": "vnWMOt5+4SLOLu5hlB54LMK5OHqsX+5ekbo6vb7USvCM5uA4UKtATuMvIAw69ak62F94c+3895XwF5TcjjzpVw=="
-            },
-            "System.Buffers": {
-                "type": "Transitive",
-                "resolved": "4.5.1",
-                "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
-            },
-            "System.Memory": {
-                "type": "Transitive",
-                "resolved": "4.5.4",
-                "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw==",
-                "dependencies": {
-                    "System.Buffers": "4.5.1",
-                    "System.Numerics.Vectors": "4.5.0",
-                    "System.Runtime.CompilerServices.Unsafe": "4.5.3"
-                }
-            },
-            "System.Numerics.Vectors": {
-                "type": "Transitive",
-                "resolved": "4.5.0",
-                "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
-            },
-            "System.Runtime.CompilerServices.Unsafe": {
-                "type": "Transitive",
-                "resolved": "5.0.0",
-                "contentHash": "ZD9TMpsmYJLrxbbmdvhwt9YEgG5WntEnZ/d1eH8JBX9LBp+Ju8BSBhUGbZMNVHHomWo2KVImJhTDl2hIgw/6MA=="
-            },
-            "System.Text.Encodings.Web": {
-                "type": "Transitive",
-                "resolved": "5.0.0",
-                "contentHash": "EEslUvHKll1ftizbn20mX3Ix/l4Ygk/bdJ2LY6/X6FlGaP0RIhKMo9nS6JIGnKKT6KBP2PGj6JC3B9/ZF6ErqQ==",
-                "dependencies": {
-                    "System.Memory": "4.5.4"
-                }
-            },
-            "System.Text.Json": {
-                "type": "Transitive",
-                "resolved": "5.0.0",
-                "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw==",
-                "dependencies": {
-                    "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
-                    "System.Buffers": "4.5.1",
-                    "System.Memory": "4.5.4",
-                    "System.Numerics.Vectors": "4.5.0",
-                    "System.Runtime.CompilerServices.Unsafe": "5.0.0",
-                    "System.Text.Encodings.Web": "5.0.0",
-                    "System.Threading.Tasks.Extensions": "4.5.4",
-                    "System.ValueTuple": "4.5.0"
-                }
-            },
-            "System.Threading.Tasks.Extensions": {
-                "type": "Transitive",
-                "resolved": "4.5.4",
-                "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
-                "dependencies": {
-                    "System.Runtime.CompilerServices.Unsafe": "4.5.3"
-                }
-            },
-            "System.ValueTuple": {
-                "type": "Transitive",
-                "resolved": "4.5.0",
-                "contentHash": "okurQJO6NRE/apDIP23ajJ0hpiNmJ+f0BwOlB/cSqTLQlw5upkf+5+96+iG2Jw40G1fCVCyPz/FhIABUjMR+RQ=="
-            },
-            "xunit.abstractions": {
-                "type": "Transitive",
-                "resolved": "2.0.3",
-                "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
-            },
-            "xunit.analyzers": {
-                "type": "Transitive",
-                "resolved": "1.0.0",
-                "contentHash": "BeO8hEgs/c8Ls2647fPfieMngncvf0D0xYNDfIO59MolxtCtVjFRd6SRc+7tj8VMqkVOuJcnc9eh4ngI2cAmLQ=="
-            },
-            "xunit.assert": {
-                "type": "Transitive",
-                "resolved": "2.4.2",
-                "contentHash": "pxJISOFjn2XTTi1mcDCkRZrTFb9OtRRCtx2kZFNF51GdReLr1ls2rnyxvAS4JO247K3aNtflvh5Q0346K5BROA=="
-            },
-            "xunit.core": {
-                "type": "Transitive",
-                "resolved": "2.4.2",
-                "contentHash": "KB4yGCxNqIVyekhJLXtKSEq6BaXVp/JO3mbGVE1hxypZTLEe7h+sTbAhpA+yZW2dPtXTuiW+C1B2oxxHEkrmOw==",
-                "dependencies": {
-                    "xunit.extensibility.core": "[2.4.2]",
-                    "xunit.extensibility.execution": "[2.4.2]"
-                }
-            },
-            "xunit.extensibility.core": {
-                "type": "Transitive",
-                "resolved": "2.4.2",
-                "contentHash": "W1BoXTIN1C6kpVSMw25huSet25ky6IAQUNovu3zGOGN/jWnbgSoTyCrlIhmXSg0tH5nEf8q7h3OjNHOjyu5PfA==",
-                "dependencies": {
-                    "xunit.abstractions": "2.0.3"
-                }
-            },
-            "xunit.extensibility.execution": {
-                "type": "Transitive",
-                "resolved": "2.4.2",
-                "contentHash": "CZmgcKkwpyo8FlupZdWpJCryrAOWLh1FBPG6gmVZuPQkGQsim/oL4PcP4nfrC2hHgXUFtluvaJ0Sp9PQKUMNpg==",
-                "dependencies": {
-                    "xunit.extensibility.core": "[2.4.2]"
-                }
-            },
-            "easypost": {
-                "type": "Project",
-                "dependencies": {
-                    "Newtonsoft.Json": "[13.0.1, 14.0.0)",
-                    "RestSharp": "[108.0.1, 109.0.0)"
-                }
-            }
-        },
-        ".NETCoreApp,Version=v5.0": {
-            "coverlet.collector": {
-                "type": "Direct",
-                "requested": "[3.1.2, 4.0.0)",
-                "resolved": "3.1.2",
-                "contentHash": "wuLDIDKD5XMt0A7lE31JPenT7QQwZPFkP5rRpdJeblyXZ9MGLI8rYjvm5fvAKln+2/X+4IxxQDxBtwdrqKNLZw=="
-            },
-            "EasyVCR": {
-                "type": "Direct",
-                "requested": "[0.4.0, 1.0.0)",
-                "resolved": "0.4.0",
-                "contentHash": "Vd3h4PWG5HCqN+BNoSu5gL6/MDtZAczNWh2s/PV+yP/85TFmpPRLWW4YYuzgtc3tcOdpL5X88Ivi6N60R/SdBw==",
-                "dependencies": {
-                    "Newtonsoft.Json": "13.0.1"
-                }
-            },
-            "Microsoft.NET.Test.Sdk": {
-                "type": "Direct",
-                "requested": "[17.3.0, 18.0.0)",
-                "resolved": "17.3.0",
-                "contentHash": "ch4JCT7AZdBzvCAKD36t6fDsl7NEzzunwW7MwXUG2uFPoWcMd8B8KYg5fiwxnpdXJHodJk6yIBdSwMpN3Ikt9w==",
-                "dependencies": {
-                    "Microsoft.CodeCoverage": "17.3.0",
-                    "Microsoft.TestPlatform.TestHost": "17.3.0"
-                }
-            },
-            "Microsoft.VisualStudio.TestPlatform.ObjectModel": {
-                "type": "Direct",
-                "requested": "[14.0.0, 15.0.0)",
-                "resolved": "14.0.0",
-                "contentHash": "PlQ38dL950pnyptA3CcnYIqAKpqlP7xpoz8n5ZfS1QgxFiZrh2x1lw05V3VNmq0ZZ9Xy3SHB5tOyvFjmjNR1HQ=="
-            },
-            "NETStandard.Library": {
-                "type": "Direct",
-                "requested": "[2.0.3, 3.0.0)",
-                "resolved": "2.0.3",
-                "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
-                "dependencies": {
-                    "Microsoft.NETCore.Platforms": "1.1.0"
-                }
-            },
-            "Newtonsoft.Json": {
-                "type": "Direct",
-                "requested": "[13.0.1, 14.0.0)",
-                "resolved": "13.0.1",
-                "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-            },
-            "RestSharp": {
-                "type": "Direct",
-                "requested": "[108.0.1, 109.0.0)",
-                "resolved": "108.0.1",
-                "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
-                "dependencies": {
-                    "System.Text.Json": "5.0.0"
-                }
-            },
-            "SecurityCodeScan.VS2019": {
-                "type": "Direct",
-                "requested": "[5.6.6, 6.0.0)",
-                "resolved": "5.6.6",
-                "contentHash": "1BEkaTw2iZ5QccesAYfRcab9ttQvg6xyIItazCWLJEt5aKf3cDXvGtX+Z4p11a1QwYmf3WaNxpiZXfzXK/0VIw=="
-            },
-            "xunit": {
-                "type": "Direct",
-                "requested": "[2.4.2, 3.0.0)",
-                "resolved": "2.4.2",
-                "contentHash": "6Mj73Ont3zj2CJuoykVJfE0ZmRwn7C+pTuRP8c4bnaaTFjwNG6tGe0prJ1yIbMe9AHrpDys63ctWacSsFJWK/w==",
-                "dependencies": {
-                    "xunit.analyzers": "1.0.0",
-                    "xunit.assert": "2.4.2",
-                    "xunit.core": "[2.4.2]"
-                }
-            },
-            "xunit.runner.visualstudio": {
-                "type": "Direct",
-                "requested": "[2.4.5, 3.0.0)",
-                "resolved": "2.4.5",
-                "contentHash": "OwHamvBdUKgqsXfBzWiCW/O98BTx81UKzx2bieIOQI7CZFE5NEQZGi8PBQGIKawDW96xeRffiNf20SjfC0x9hw=="
-            },
-            "Microsoft.CodeCoverage": {
-                "type": "Transitive",
-                "resolved": "17.3.0",
-                "contentHash": "/xxz+e29F2V5pePtInjbLffoqWVTm60KCX87vSj2laNboeWq65WFJ634fGtBcMZO3VEfOmh9/XcoWEfLlWWG+g=="
-            },
-            "Microsoft.NETCore.Platforms": {
-                "type": "Transitive",
-                "resolved": "1.1.0",
-                "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
-            },
-            "Microsoft.TestPlatform.ObjectModel": {
-                "type": "Transitive",
-                "resolved": "17.3.0",
-                "contentHash": "6NRzi6QbmWV49Psf8A9z1LTJU4nBrlJdCcDOUyD4Ttm1J2wvksu98GlV+52CkxtpgNsUjGr9Mv1Rbb1/dB06yQ==",
-                "dependencies": {
-                    "NuGet.Frameworks": "5.11.0",
-                    "System.Reflection.Metadata": "1.6.0"
-                }
-            },
-            "Microsoft.TestPlatform.TestHost": {
-                "type": "Transitive",
-                "resolved": "17.3.0",
-                "contentHash": "uOJALDWtKXZkISKuNI7kOlRi/lk2CqXZtLkNS0Ei+RXqRUjUpCsjAPYSP+DJ/a4QwJ5cI9CVF52vtajnGOaEpw==",
-                "dependencies": {
-                    "Microsoft.TestPlatform.ObjectModel": "17.3.0",
-                    "Newtonsoft.Json": "9.0.1"
-                }
-            },
-            "NuGet.Frameworks": {
-                "type": "Transitive",
-                "resolved": "5.11.0",
-                "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
-            },
-            "System.Reflection.Metadata": {
-                "type": "Transitive",
-                "resolved": "1.6.0",
-                "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
-            },
-            "System.Text.Json": {
-                "type": "Transitive",
-                "resolved": "5.0.0",
-                "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
-            },
-            "xunit.abstractions": {
-                "type": "Transitive",
-                "resolved": "2.0.3",
-                "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
-            },
-            "xunit.analyzers": {
-                "type": "Transitive",
-                "resolved": "1.0.0",
-                "contentHash": "BeO8hEgs/c8Ls2647fPfieMngncvf0D0xYNDfIO59MolxtCtVjFRd6SRc+7tj8VMqkVOuJcnc9eh4ngI2cAmLQ=="
-            },
-            "xunit.assert": {
-                "type": "Transitive",
-                "resolved": "2.4.2",
-                "contentHash": "pxJISOFjn2XTTi1mcDCkRZrTFb9OtRRCtx2kZFNF51GdReLr1ls2rnyxvAS4JO247K3aNtflvh5Q0346K5BROA==",
-                "dependencies": {
-                    "NETStandard.Library": "1.6.1"
-                }
-            },
-            "xunit.core": {
-                "type": "Transitive",
-                "resolved": "2.4.2",
-                "contentHash": "KB4yGCxNqIVyekhJLXtKSEq6BaXVp/JO3mbGVE1hxypZTLEe7h+sTbAhpA+yZW2dPtXTuiW+C1B2oxxHEkrmOw==",
-                "dependencies": {
-                    "xunit.extensibility.core": "[2.4.2]",
-                    "xunit.extensibility.execution": "[2.4.2]"
-                }
-            },
-            "xunit.extensibility.core": {
-                "type": "Transitive",
-                "resolved": "2.4.2",
-                "contentHash": "W1BoXTIN1C6kpVSMw25huSet25ky6IAQUNovu3zGOGN/jWnbgSoTyCrlIhmXSg0tH5nEf8q7h3OjNHOjyu5PfA==",
-                "dependencies": {
-                    "NETStandard.Library": "1.6.1",
-                    "xunit.abstractions": "2.0.3"
-                }
-            },
-            "xunit.extensibility.execution": {
-                "type": "Transitive",
-                "resolved": "2.4.2",
-                "contentHash": "CZmgcKkwpyo8FlupZdWpJCryrAOWLh1FBPG6gmVZuPQkGQsim/oL4PcP4nfrC2hHgXUFtluvaJ0Sp9PQKUMNpg==",
-                "dependencies": {
-                    "NETStandard.Library": "1.6.1",
-                    "xunit.extensibility.core": "[2.4.2]"
-                }
-            },
-            "easypost": {
-                "type": "Project",
-                "dependencies": {
-                    "Newtonsoft.Json": "[13.0.1, 14.0.0)",
-                    "RestSharp": "[108.0.1, 109.0.0)"
-                }
-            }
-        },
-        "net6.0": {
-            "coverlet.collector": {
-                "type": "Direct",
-                "requested": "[3.1.2, 4.0.0)",
-                "resolved": "3.1.2",
-                "contentHash": "wuLDIDKD5XMt0A7lE31JPenT7QQwZPFkP5rRpdJeblyXZ9MGLI8rYjvm5fvAKln+2/X+4IxxQDxBtwdrqKNLZw=="
-            },
-            "EasyVCR": {
-                "type": "Direct",
-                "requested": "[0.4.0, 1.0.0)",
-                "resolved": "0.4.0",
-                "contentHash": "Vd3h4PWG5HCqN+BNoSu5gL6/MDtZAczNWh2s/PV+yP/85TFmpPRLWW4YYuzgtc3tcOdpL5X88Ivi6N60R/SdBw==",
-                "dependencies": {
-                    "Newtonsoft.Json": "13.0.1"
-                }
-            },
-            "Microsoft.NET.Test.Sdk": {
-                "type": "Direct",
-                "requested": "[17.3.0, 18.0.0)",
-                "resolved": "17.3.0",
-                "contentHash": "ch4JCT7AZdBzvCAKD36t6fDsl7NEzzunwW7MwXUG2uFPoWcMd8B8KYg5fiwxnpdXJHodJk6yIBdSwMpN3Ikt9w==",
-                "dependencies": {
-                    "Microsoft.CodeCoverage": "17.3.0",
-                    "Microsoft.TestPlatform.TestHost": "17.3.0"
-                }
-            },
-            "Microsoft.VisualStudio.TestPlatform.ObjectModel": {
-                "type": "Direct",
-                "requested": "[14.0.0, 15.0.0)",
-                "resolved": "14.0.0",
-                "contentHash": "PlQ38dL950pnyptA3CcnYIqAKpqlP7xpoz8n5ZfS1QgxFiZrh2x1lw05V3VNmq0ZZ9Xy3SHB5tOyvFjmjNR1HQ=="
-            },
-            "NETStandard.Library": {
-                "type": "Direct",
-                "requested": "[2.0.3, 3.0.0)",
-                "resolved": "2.0.3",
-                "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
-                "dependencies": {
-                    "Microsoft.NETCore.Platforms": "1.1.0"
-                }
-            },
-            "Newtonsoft.Json": {
-                "type": "Direct",
-                "requested": "[13.0.1, 14.0.0)",
-                "resolved": "13.0.1",
-                "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-            },
-            "RestSharp": {
-                "type": "Direct",
-                "requested": "[108.0.1, 109.0.0)",
-                "resolved": "108.0.1",
-                "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA=="
-            },
-            "SecurityCodeScan.VS2019": {
-                "type": "Direct",
-                "requested": "[5.6.6, 6.0.0)",
-                "resolved": "5.6.6",
-                "contentHash": "1BEkaTw2iZ5QccesAYfRcab9ttQvg6xyIItazCWLJEt5aKf3cDXvGtX+Z4p11a1QwYmf3WaNxpiZXfzXK/0VIw=="
-            },
-            "xunit": {
-                "type": "Direct",
-                "requested": "[2.4.2, 3.0.0)",
-                "resolved": "2.4.2",
-                "contentHash": "6Mj73Ont3zj2CJuoykVJfE0ZmRwn7C+pTuRP8c4bnaaTFjwNG6tGe0prJ1yIbMe9AHrpDys63ctWacSsFJWK/w==",
-                "dependencies": {
-                    "xunit.analyzers": "1.0.0",
-                    "xunit.assert": "2.4.2",
-                    "xunit.core": "[2.4.2]"
-                }
-            },
-            "xunit.runner.visualstudio": {
-                "type": "Direct",
-                "requested": "[2.4.5, 3.0.0)",
-                "resolved": "2.4.5",
-                "contentHash": "OwHamvBdUKgqsXfBzWiCW/O98BTx81UKzx2bieIOQI7CZFE5NEQZGi8PBQGIKawDW96xeRffiNf20SjfC0x9hw=="
-            },
-            "Microsoft.CodeCoverage": {
-                "type": "Transitive",
-                "resolved": "17.3.0",
-                "contentHash": "/xxz+e29F2V5pePtInjbLffoqWVTm60KCX87vSj2laNboeWq65WFJ634fGtBcMZO3VEfOmh9/XcoWEfLlWWG+g=="
-            },
-            "Microsoft.NETCore.Platforms": {
-                "type": "Transitive",
-                "resolved": "1.1.0",
-                "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
-            },
-            "Microsoft.TestPlatform.ObjectModel": {
-                "type": "Transitive",
-                "resolved": "17.3.0",
-                "contentHash": "6NRzi6QbmWV49Psf8A9z1LTJU4nBrlJdCcDOUyD4Ttm1J2wvksu98GlV+52CkxtpgNsUjGr9Mv1Rbb1/dB06yQ==",
-                "dependencies": {
-                    "NuGet.Frameworks": "5.11.0",
-                    "System.Reflection.Metadata": "1.6.0"
-                }
-            },
-            "Microsoft.TestPlatform.TestHost": {
-                "type": "Transitive",
-                "resolved": "17.3.0",
-                "contentHash": "uOJALDWtKXZkISKuNI7kOlRi/lk2CqXZtLkNS0Ei+RXqRUjUpCsjAPYSP+DJ/a4QwJ5cI9CVF52vtajnGOaEpw==",
-                "dependencies": {
-                    "Microsoft.TestPlatform.ObjectModel": "17.3.0",
-                    "Newtonsoft.Json": "9.0.1"
-                }
-            },
-            "NuGet.Frameworks": {
-                "type": "Transitive",
-                "resolved": "5.11.0",
-                "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
-            },
-            "System.Reflection.Metadata": {
-                "type": "Transitive",
-                "resolved": "1.6.0",
-                "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
-            },
-            "xunit.abstractions": {
-                "type": "Transitive",
-                "resolved": "2.0.3",
-                "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
-            },
-            "xunit.analyzers": {
-                "type": "Transitive",
-                "resolved": "1.0.0",
-                "contentHash": "BeO8hEgs/c8Ls2647fPfieMngncvf0D0xYNDfIO59MolxtCtVjFRd6SRc+7tj8VMqkVOuJcnc9eh4ngI2cAmLQ=="
-            },
-            "xunit.assert": {
-                "type": "Transitive",
-                "resolved": "2.4.2",
-                "contentHash": "pxJISOFjn2XTTi1mcDCkRZrTFb9OtRRCtx2kZFNF51GdReLr1ls2rnyxvAS4JO247K3aNtflvh5Q0346K5BROA==",
-                "dependencies": {
-                    "NETStandard.Library": "1.6.1"
-                }
-            },
-            "xunit.core": {
-                "type": "Transitive",
-                "resolved": "2.4.2",
-                "contentHash": "KB4yGCxNqIVyekhJLXtKSEq6BaXVp/JO3mbGVE1hxypZTLEe7h+sTbAhpA+yZW2dPtXTuiW+C1B2oxxHEkrmOw==",
-                "dependencies": {
-                    "xunit.extensibility.core": "[2.4.2]",
-                    "xunit.extensibility.execution": "[2.4.2]"
-                }
-            },
-            "xunit.extensibility.core": {
-                "type": "Transitive",
-                "resolved": "2.4.2",
-                "contentHash": "W1BoXTIN1C6kpVSMw25huSet25ky6IAQUNovu3zGOGN/jWnbgSoTyCrlIhmXSg0tH5nEf8q7h3OjNHOjyu5PfA==",
-                "dependencies": {
-                    "NETStandard.Library": "1.6.1",
-                    "xunit.abstractions": "2.0.3"
-                }
-            },
-            "xunit.extensibility.execution": {
-                "type": "Transitive",
-                "resolved": "2.4.2",
-                "contentHash": "CZmgcKkwpyo8FlupZdWpJCryrAOWLh1FBPG6gmVZuPQkGQsim/oL4PcP4nfrC2hHgXUFtluvaJ0Sp9PQKUMNpg==",
-                "dependencies": {
-                    "NETStandard.Library": "1.6.1",
-                    "xunit.extensibility.core": "[2.4.2]"
-                }
-            },
-            "easypost": {
-                "type": "Project",
-                "dependencies": {
-                    "Newtonsoft.Json": "[13.0.1, 14.0.0)",
-                    "RestSharp": "[108.0.1, 109.0.0)"
-                }
-            }
+  "version": 1,
+  "dependencies": {
+    ".NETCoreApp,Version=v3.1": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[3.1.2, 4.0.0)",
+        "resolved": "3.1.2",
+        "contentHash": "wuLDIDKD5XMt0A7lE31JPenT7QQwZPFkP5rRpdJeblyXZ9MGLI8rYjvm5fvAKln+2/X+4IxxQDxBtwdrqKNLZw=="
+      },
+      "EasyVCR": {
+        "type": "Direct",
+        "requested": "[0.4.0, 1.0.0)",
+        "resolved": "0.4.0",
+        "contentHash": "Vd3h4PWG5HCqN+BNoSu5gL6/MDtZAczNWh2s/PV+yP/85TFmpPRLWW4YYuzgtc3tcOdpL5X88Ivi6N60R/SdBw==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1"
         }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.3.0, 18.0.0)",
+        "resolved": "17.3.0",
+        "contentHash": "ch4JCT7AZdBzvCAKD36t6fDsl7NEzzunwW7MwXUG2uFPoWcMd8B8KYg5fiwxnpdXJHodJk6yIBdSwMpN3Ikt9w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.3.0",
+          "Microsoft.TestPlatform.TestHost": "17.3.0"
+        }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.2, )",
+        "resolved": "1.0.2",
+        "contentHash": "5/cSEVld+px/CuRrbohO/djfg6++eR6zGpy88MgqloXvkj//WXWpFZyu/OpkXPN0u5m+dN/EVwLNYFUxD4h2+A==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net461": "1.0.2"
+        }
+      },
+      "Microsoft.VisualStudio.TestPlatform.ObjectModel": {
+        "type": "Direct",
+        "requested": "[14.0.0, 15.0.0)",
+        "resolved": "14.0.0",
+        "contentHash": "PlQ38dL950pnyptA3CcnYIqAKpqlP7xpoz8n5ZfS1QgxFiZrh2x1lw05V3VNmq0ZZ9Xy3SHB5tOyvFjmjNR1HQ=="
+      },
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, 3.0.0)",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.1, 14.0.0)",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "RestSharp": {
+        "type": "Direct",
+        "requested": "[108.0.1, 109.0.0)",
+        "resolved": "108.0.1",
+        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
+        "dependencies": {
+          "System.Text.Json": "5.0.0"
+        }
+      },
+      "SecurityCodeScan.VS2019": {
+        "type": "Direct",
+        "requested": "[5.6.6, 6.0.0)",
+        "resolved": "5.6.6",
+        "contentHash": "1BEkaTw2iZ5QccesAYfRcab9ttQvg6xyIItazCWLJEt5aKf3cDXvGtX+Z4p11a1QwYmf3WaNxpiZXfzXK/0VIw=="
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.4.2, 3.0.0)",
+        "resolved": "2.4.2",
+        "contentHash": "6Mj73Ont3zj2CJuoykVJfE0ZmRwn7C+pTuRP8c4bnaaTFjwNG6tGe0prJ1yIbMe9AHrpDys63ctWacSsFJWK/w==",
+        "dependencies": {
+          "xunit.analyzers": "1.0.0",
+          "xunit.assert": "2.4.2",
+          "xunit.core": "[2.4.2]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[2.4.5, 3.0.0)",
+        "resolved": "2.4.5",
+        "contentHash": "OwHamvBdUKgqsXfBzWiCW/O98BTx81UKzx2bieIOQI7CZFE5NEQZGi8PBQGIKawDW96xeRffiNf20SjfC0x9hw=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.3.0",
+        "contentHash": "/xxz+e29F2V5pePtInjbLffoqWVTm60KCX87vSj2laNboeWq65WFJ634fGtBcMZO3VEfOmh9/XcoWEfLlWWG+g=="
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net461": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "8shzGaD5pZi4npuJYCM3de6pl0zlefcbyTIvXIiCdsTqauZ7lAhdaJVtJSqlhYid9VosFAOygBykoJ1SEOlGWA=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.3.0",
+        "contentHash": "6NRzi6QbmWV49Psf8A9z1LTJU4nBrlJdCcDOUyD4Ttm1J2wvksu98GlV+52CkxtpgNsUjGr9Mv1Rbb1/dB06yQ==",
+        "dependencies": {
+          "NuGet.Frameworks": "5.11.0",
+          "System.Reflection.Metadata": "1.6.0"
+        }
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.3.0",
+        "contentHash": "uOJALDWtKXZkISKuNI7kOlRi/lk2CqXZtLkNS0Ei+RXqRUjUpCsjAPYSP+DJ/a4QwJ5cI9CVF52vtajnGOaEpw==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.3.0",
+          "Newtonsoft.Json": "9.0.1"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "5.11.0",
+        "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "1.6.0",
+        "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "BeO8hEgs/c8Ls2647fPfieMngncvf0D0xYNDfIO59MolxtCtVjFRd6SRc+7tj8VMqkVOuJcnc9eh4ngI2cAmLQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "pxJISOFjn2XTTi1mcDCkRZrTFb9OtRRCtx2kZFNF51GdReLr1ls2rnyxvAS4JO247K3aNtflvh5Q0346K5BROA==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1"
+        }
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "KB4yGCxNqIVyekhJLXtKSEq6BaXVp/JO3mbGVE1hxypZTLEe7h+sTbAhpA+yZW2dPtXTuiW+C1B2oxxHEkrmOw==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.4.2]",
+          "xunit.extensibility.execution": "[2.4.2]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "W1BoXTIN1C6kpVSMw25huSet25ky6IAQUNovu3zGOGN/jWnbgSoTyCrlIhmXSg0tH5nEf8q7h3OjNHOjyu5PfA==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "CZmgcKkwpyo8FlupZdWpJCryrAOWLh1FBPG6gmVZuPQkGQsim/oL4PcP4nfrC2hHgXUFtluvaJ0Sp9PQKUMNpg==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "xunit.extensibility.core": "[2.4.2]"
+        }
+      },
+      "easypost": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "[13.0.1, 14.0.0)",
+          "RestSharp": "[108.0.1, 109.0.0)"
+        }
+      }
+    },
+    ".NETFramework,Version=v4.6.2": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[3.1.2, 4.0.0)",
+        "resolved": "3.1.2",
+        "contentHash": "wuLDIDKD5XMt0A7lE31JPenT7QQwZPFkP5rRpdJeblyXZ9MGLI8rYjvm5fvAKln+2/X+4IxxQDxBtwdrqKNLZw=="
+      },
+      "EasyVCR": {
+        "type": "Direct",
+        "requested": "[0.4.0, 1.0.0)",
+        "resolved": "0.4.0",
+        "contentHash": "Vd3h4PWG5HCqN+BNoSu5gL6/MDtZAczNWh2s/PV+yP/85TFmpPRLWW4YYuzgtc3tcOdpL5X88Ivi6N60R/SdBw==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.3.0, 18.0.0)",
+        "resolved": "17.3.0",
+        "contentHash": "ch4JCT7AZdBzvCAKD36t6fDsl7NEzzunwW7MwXUG2uFPoWcMd8B8KYg5fiwxnpdXJHodJk6yIBdSwMpN3Ikt9w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.3.0"
+        }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.2, )",
+        "resolved": "1.0.2",
+        "contentHash": "5/cSEVld+px/CuRrbohO/djfg6++eR6zGpy88MgqloXvkj//WXWpFZyu/OpkXPN0u5m+dN/EVwLNYFUxD4h2+A==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net462": "1.0.2"
+        }
+      },
+      "Microsoft.VisualStudio.TestPlatform.ObjectModel": {
+        "type": "Direct",
+        "requested": "[14.0.0, 15.0.0)",
+        "resolved": "14.0.0",
+        "contentHash": "PlQ38dL950pnyptA3CcnYIqAKpqlP7xpoz8n5ZfS1QgxFiZrh2x1lw05V3VNmq0ZZ9Xy3SHB5tOyvFjmjNR1HQ=="
+      },
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, 3.0.0)",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.1, 14.0.0)",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "RestSharp": {
+        "type": "Direct",
+        "requested": "[108.0.1, 109.0.0)",
+        "resolved": "108.0.1",
+        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
+        "dependencies": {
+          "System.Text.Json": "5.0.0"
+        }
+      },
+      "SecurityCodeScan.VS2019": {
+        "type": "Direct",
+        "requested": "[5.6.6, 6.0.0)",
+        "resolved": "5.6.6",
+        "contentHash": "1BEkaTw2iZ5QccesAYfRcab9ttQvg6xyIItazCWLJEt5aKf3cDXvGtX+Z4p11a1QwYmf3WaNxpiZXfzXK/0VIw=="
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.4.2, 3.0.0)",
+        "resolved": "2.4.2",
+        "contentHash": "6Mj73Ont3zj2CJuoykVJfE0ZmRwn7C+pTuRP8c4bnaaTFjwNG6tGe0prJ1yIbMe9AHrpDys63ctWacSsFJWK/w==",
+        "dependencies": {
+          "xunit.analyzers": "1.0.0",
+          "xunit.assert": "2.4.2",
+          "xunit.core": "[2.4.2]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[2.4.5, 3.0.0)",
+        "resolved": "2.4.5",
+        "contentHash": "OwHamvBdUKgqsXfBzWiCW/O98BTx81UKzx2bieIOQI7CZFE5NEQZGi8PBQGIKawDW96xeRffiNf20SjfC0x9hw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.3.0",
+        "contentHash": "/xxz+e29F2V5pePtInjbLffoqWVTm60KCX87vSj2laNboeWq65WFJ634fGtBcMZO3VEfOmh9/XcoWEfLlWWG+g=="
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net462": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "vnWMOt5+4SLOLu5hlB54LMK5OHqsX+5ekbo6vb7USvCM5uA4UKtATuMvIAw69ak62F94c+3895XwF5TcjjzpVw=="
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.5.1",
+        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Numerics.Vectors": "4.5.0",
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "System.Numerics.Vectors": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZD9TMpsmYJLrxbbmdvhwt9YEgG5WntEnZ/d1eH8JBX9LBp+Ju8BSBhUGbZMNVHHomWo2KVImJhTDl2hIgw/6MA=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "EEslUvHKll1ftizbn20mX3Ix/l4Ygk/bdJ2LY6/X6FlGaP0RIhKMo9nS6JIGnKKT6KBP2PGj6JC3B9/ZF6ErqQ==",
+        "dependencies": {
+          "System.Memory": "4.5.4"
+        }
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.4",
+          "System.Numerics.Vectors": "4.5.0",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0",
+          "System.Text.Encodings.Web": "5.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "okurQJO6NRE/apDIP23ajJ0hpiNmJ+f0BwOlB/cSqTLQlw5upkf+5+96+iG2Jw40G1fCVCyPz/FhIABUjMR+RQ=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "BeO8hEgs/c8Ls2647fPfieMngncvf0D0xYNDfIO59MolxtCtVjFRd6SRc+7tj8VMqkVOuJcnc9eh4ngI2cAmLQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "pxJISOFjn2XTTi1mcDCkRZrTFb9OtRRCtx2kZFNF51GdReLr1ls2rnyxvAS4JO247K3aNtflvh5Q0346K5BROA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "KB4yGCxNqIVyekhJLXtKSEq6BaXVp/JO3mbGVE1hxypZTLEe7h+sTbAhpA+yZW2dPtXTuiW+C1B2oxxHEkrmOw==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.4.2]",
+          "xunit.extensibility.execution": "[2.4.2]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "W1BoXTIN1C6kpVSMw25huSet25ky6IAQUNovu3zGOGN/jWnbgSoTyCrlIhmXSg0tH5nEf8q7h3OjNHOjyu5PfA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "CZmgcKkwpyo8FlupZdWpJCryrAOWLh1FBPG6gmVZuPQkGQsim/oL4PcP4nfrC2hHgXUFtluvaJ0Sp9PQKUMNpg==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.4.2]"
+        }
+      },
+      "easypost": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "[13.0.1, 14.0.0)",
+          "RestSharp": "[108.0.1, 109.0.0)"
+        }
+      }
+    },
+    ".NETCoreApp,Version=v5.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[3.1.2, 4.0.0)",
+        "resolved": "3.1.2",
+        "contentHash": "wuLDIDKD5XMt0A7lE31JPenT7QQwZPFkP5rRpdJeblyXZ9MGLI8rYjvm5fvAKln+2/X+4IxxQDxBtwdrqKNLZw=="
+      },
+      "EasyVCR": {
+        "type": "Direct",
+        "requested": "[0.4.0, 1.0.0)",
+        "resolved": "0.4.0",
+        "contentHash": "Vd3h4PWG5HCqN+BNoSu5gL6/MDtZAczNWh2s/PV+yP/85TFmpPRLWW4YYuzgtc3tcOdpL5X88Ivi6N60R/SdBw==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.3.0, 18.0.0)",
+        "resolved": "17.3.0",
+        "contentHash": "ch4JCT7AZdBzvCAKD36t6fDsl7NEzzunwW7MwXUG2uFPoWcMd8B8KYg5fiwxnpdXJHodJk6yIBdSwMpN3Ikt9w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.3.0",
+          "Microsoft.TestPlatform.TestHost": "17.3.0"
+        }
+      },
+      "Microsoft.VisualStudio.TestPlatform.ObjectModel": {
+        "type": "Direct",
+        "requested": "[14.0.0, 15.0.0)",
+        "resolved": "14.0.0",
+        "contentHash": "PlQ38dL950pnyptA3CcnYIqAKpqlP7xpoz8n5ZfS1QgxFiZrh2x1lw05V3VNmq0ZZ9Xy3SHB5tOyvFjmjNR1HQ=="
+      },
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, 3.0.0)",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.1, 14.0.0)",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "RestSharp": {
+        "type": "Direct",
+        "requested": "[108.0.1, 109.0.0)",
+        "resolved": "108.0.1",
+        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
+        "dependencies": {
+          "System.Text.Json": "5.0.0"
+        }
+      },
+      "SecurityCodeScan.VS2019": {
+        "type": "Direct",
+        "requested": "[5.6.6, 6.0.0)",
+        "resolved": "5.6.6",
+        "contentHash": "1BEkaTw2iZ5QccesAYfRcab9ttQvg6xyIItazCWLJEt5aKf3cDXvGtX+Z4p11a1QwYmf3WaNxpiZXfzXK/0VIw=="
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.4.2, 3.0.0)",
+        "resolved": "2.4.2",
+        "contentHash": "6Mj73Ont3zj2CJuoykVJfE0ZmRwn7C+pTuRP8c4bnaaTFjwNG6tGe0prJ1yIbMe9AHrpDys63ctWacSsFJWK/w==",
+        "dependencies": {
+          "xunit.analyzers": "1.0.0",
+          "xunit.assert": "2.4.2",
+          "xunit.core": "[2.4.2]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[2.4.5, 3.0.0)",
+        "resolved": "2.4.5",
+        "contentHash": "OwHamvBdUKgqsXfBzWiCW/O98BTx81UKzx2bieIOQI7CZFE5NEQZGi8PBQGIKawDW96xeRffiNf20SjfC0x9hw=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.3.0",
+        "contentHash": "/xxz+e29F2V5pePtInjbLffoqWVTm60KCX87vSj2laNboeWq65WFJ634fGtBcMZO3VEfOmh9/XcoWEfLlWWG+g=="
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.3.0",
+        "contentHash": "6NRzi6QbmWV49Psf8A9z1LTJU4nBrlJdCcDOUyD4Ttm1J2wvksu98GlV+52CkxtpgNsUjGr9Mv1Rbb1/dB06yQ==",
+        "dependencies": {
+          "NuGet.Frameworks": "5.11.0",
+          "System.Reflection.Metadata": "1.6.0"
+        }
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.3.0",
+        "contentHash": "uOJALDWtKXZkISKuNI7kOlRi/lk2CqXZtLkNS0Ei+RXqRUjUpCsjAPYSP+DJ/a4QwJ5cI9CVF52vtajnGOaEpw==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.3.0",
+          "Newtonsoft.Json": "9.0.1"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "5.11.0",
+        "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "1.6.0",
+        "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "BeO8hEgs/c8Ls2647fPfieMngncvf0D0xYNDfIO59MolxtCtVjFRd6SRc+7tj8VMqkVOuJcnc9eh4ngI2cAmLQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "pxJISOFjn2XTTi1mcDCkRZrTFb9OtRRCtx2kZFNF51GdReLr1ls2rnyxvAS4JO247K3aNtflvh5Q0346K5BROA==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1"
+        }
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "KB4yGCxNqIVyekhJLXtKSEq6BaXVp/JO3mbGVE1hxypZTLEe7h+sTbAhpA+yZW2dPtXTuiW+C1B2oxxHEkrmOw==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.4.2]",
+          "xunit.extensibility.execution": "[2.4.2]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "W1BoXTIN1C6kpVSMw25huSet25ky6IAQUNovu3zGOGN/jWnbgSoTyCrlIhmXSg0tH5nEf8q7h3OjNHOjyu5PfA==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "CZmgcKkwpyo8FlupZdWpJCryrAOWLh1FBPG6gmVZuPQkGQsim/oL4PcP4nfrC2hHgXUFtluvaJ0Sp9PQKUMNpg==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "xunit.extensibility.core": "[2.4.2]"
+        }
+      },
+      "easypost": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "[13.0.1, 14.0.0)",
+          "RestSharp": "[108.0.1, 109.0.0)"
+        }
+      }
+    },
+    "net6.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[3.1.2, 4.0.0)",
+        "resolved": "3.1.2",
+        "contentHash": "wuLDIDKD5XMt0A7lE31JPenT7QQwZPFkP5rRpdJeblyXZ9MGLI8rYjvm5fvAKln+2/X+4IxxQDxBtwdrqKNLZw=="
+      },
+      "EasyVCR": {
+        "type": "Direct",
+        "requested": "[0.4.0, 1.0.0)",
+        "resolved": "0.4.0",
+        "contentHash": "Vd3h4PWG5HCqN+BNoSu5gL6/MDtZAczNWh2s/PV+yP/85TFmpPRLWW4YYuzgtc3tcOdpL5X88Ivi6N60R/SdBw==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.3.0, 18.0.0)",
+        "resolved": "17.3.0",
+        "contentHash": "ch4JCT7AZdBzvCAKD36t6fDsl7NEzzunwW7MwXUG2uFPoWcMd8B8KYg5fiwxnpdXJHodJk6yIBdSwMpN3Ikt9w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.3.0",
+          "Microsoft.TestPlatform.TestHost": "17.3.0"
+        }
+      },
+      "Microsoft.VisualStudio.TestPlatform.ObjectModel": {
+        "type": "Direct",
+        "requested": "[14.0.0, 15.0.0)",
+        "resolved": "14.0.0",
+        "contentHash": "PlQ38dL950pnyptA3CcnYIqAKpqlP7xpoz8n5ZfS1QgxFiZrh2x1lw05V3VNmq0ZZ9Xy3SHB5tOyvFjmjNR1HQ=="
+      },
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, 3.0.0)",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.1, 14.0.0)",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "RestSharp": {
+        "type": "Direct",
+        "requested": "[108.0.1, 109.0.0)",
+        "resolved": "108.0.1",
+        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA=="
+      },
+      "SecurityCodeScan.VS2019": {
+        "type": "Direct",
+        "requested": "[5.6.6, 6.0.0)",
+        "resolved": "5.6.6",
+        "contentHash": "1BEkaTw2iZ5QccesAYfRcab9ttQvg6xyIItazCWLJEt5aKf3cDXvGtX+Z4p11a1QwYmf3WaNxpiZXfzXK/0VIw=="
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.4.2, 3.0.0)",
+        "resolved": "2.4.2",
+        "contentHash": "6Mj73Ont3zj2CJuoykVJfE0ZmRwn7C+pTuRP8c4bnaaTFjwNG6tGe0prJ1yIbMe9AHrpDys63ctWacSsFJWK/w==",
+        "dependencies": {
+          "xunit.analyzers": "1.0.0",
+          "xunit.assert": "2.4.2",
+          "xunit.core": "[2.4.2]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[2.4.5, 3.0.0)",
+        "resolved": "2.4.5",
+        "contentHash": "OwHamvBdUKgqsXfBzWiCW/O98BTx81UKzx2bieIOQI7CZFE5NEQZGi8PBQGIKawDW96xeRffiNf20SjfC0x9hw=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.3.0",
+        "contentHash": "/xxz+e29F2V5pePtInjbLffoqWVTm60KCX87vSj2laNboeWq65WFJ634fGtBcMZO3VEfOmh9/XcoWEfLlWWG+g=="
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.3.0",
+        "contentHash": "6NRzi6QbmWV49Psf8A9z1LTJU4nBrlJdCcDOUyD4Ttm1J2wvksu98GlV+52CkxtpgNsUjGr9Mv1Rbb1/dB06yQ==",
+        "dependencies": {
+          "NuGet.Frameworks": "5.11.0",
+          "System.Reflection.Metadata": "1.6.0"
+        }
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.3.0",
+        "contentHash": "uOJALDWtKXZkISKuNI7kOlRi/lk2CqXZtLkNS0Ei+RXqRUjUpCsjAPYSP+DJ/a4QwJ5cI9CVF52vtajnGOaEpw==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.3.0",
+          "Newtonsoft.Json": "9.0.1"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "5.11.0",
+        "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "1.6.0",
+        "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "BeO8hEgs/c8Ls2647fPfieMngncvf0D0xYNDfIO59MolxtCtVjFRd6SRc+7tj8VMqkVOuJcnc9eh4ngI2cAmLQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "pxJISOFjn2XTTi1mcDCkRZrTFb9OtRRCtx2kZFNF51GdReLr1ls2rnyxvAS4JO247K3aNtflvh5Q0346K5BROA==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1"
+        }
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "KB4yGCxNqIVyekhJLXtKSEq6BaXVp/JO3mbGVE1hxypZTLEe7h+sTbAhpA+yZW2dPtXTuiW+C1B2oxxHEkrmOw==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.4.2]",
+          "xunit.extensibility.execution": "[2.4.2]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "W1BoXTIN1C6kpVSMw25huSet25ky6IAQUNovu3zGOGN/jWnbgSoTyCrlIhmXSg0tH5nEf8q7h3OjNHOjyu5PfA==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "CZmgcKkwpyo8FlupZdWpJCryrAOWLh1FBPG6gmVZuPQkGQsim/oL4PcP4nfrC2hHgXUFtluvaJ0Sp9PQKUMNpg==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "xunit.extensibility.core": "[2.4.2]"
+        }
+      },
+      "easypost": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "[13.0.1, 14.0.0)",
+          "RestSharp": "[108.0.1, 109.0.0)"
+        }
+      }
     }
+  }
 }

--- a/EasyPost/Models/API/Address.cs
+++ b/EasyPost/Models/API/Address.cs
@@ -48,6 +48,10 @@ namespace EasyPost.Models.API
 
         #endregion
 
+        internal Address()
+        {
+        }
+
         #region CRUD Operations
 
         /// <summary>

--- a/EasyPost/Models/API/AddressCollection.cs
+++ b/EasyPost/Models/API/AddressCollection.cs
@@ -12,5 +12,9 @@ namespace EasyPost.Models.API
         public List<Address>? Addresses { get; set; }
 
         #endregion
+
+        internal AddressCollection()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/ApiKey.cs
+++ b/EasyPost/Models/API/ApiKey.cs
@@ -11,5 +11,9 @@ namespace EasyPost.Models.API
         public string? Key { get; set; }
 
         #endregion
+
+        internal ApiKey()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/ApiKeyCollection.cs
+++ b/EasyPost/Models/API/ApiKeyCollection.cs
@@ -15,5 +15,9 @@ namespace EasyPost.Models.API
         public List<ApiKey>? Keys { get; set; }
 
         #endregion
+
+        internal ApiKeyCollection()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/Batch.cs
+++ b/EasyPost/Models/API/Batch.cs
@@ -33,6 +33,10 @@ namespace EasyPost.Models.API
 
         #endregion
 
+        internal Batch()
+        {
+        }
+
         #region CRUD Operations
 
         /// <summary>

--- a/EasyPost/Models/API/BatchCollection.cs
+++ b/EasyPost/Models/API/BatchCollection.cs
@@ -12,5 +12,9 @@ namespace EasyPost.Models.API
         public List<Batch>? Batches { get; set; }
 
         #endregion
+
+        internal BatchCollection()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/BatchShipment.cs
+++ b/EasyPost/Models/API/BatchShipment.cs
@@ -15,5 +15,9 @@ namespace EasyPost.Models.API
         public string? TrackingCode { get; set; }
 
         #endregion
+
+        internal BatchShipment()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/Brand.cs
+++ b/EasyPost/Models/API/Brand.cs
@@ -27,5 +27,9 @@ namespace EasyPost.Models.API
         public string? UserId { get; set; }
 
         #endregion
+
+        internal Brand()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/CarbonOffset.cs
+++ b/EasyPost/Models/API/CarbonOffset.cs
@@ -16,5 +16,9 @@ namespace EasyPost.Models.API
         public string? Price { get; set; }
 
         #endregion
+
+        internal CarbonOffset()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/CarrierAccount.cs
+++ b/EasyPost/Models/API/CarrierAccount.cs
@@ -30,6 +30,10 @@ namespace EasyPost.Models.API
 
         #endregion
 
+        internal CarrierAccount()
+        {
+        }
+
         #region CRUD Operations
 
         /// <summary>

--- a/EasyPost/Models/API/CarrierDetail.cs
+++ b/EasyPost/Models/API/CarrierDetail.cs
@@ -27,5 +27,9 @@ namespace EasyPost.Models.API
         public string? Service { get; set; }
 
         #endregion
+
+        internal CarrierDetail()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/CarrierType.cs
+++ b/EasyPost/Models/API/CarrierType.cs
@@ -18,5 +18,9 @@ namespace EasyPost.Models.API
         public string? Type { get; set; }
 
         #endregion
+
+        internal CarrierType()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/CustomsInfo.cs
+++ b/EasyPost/Models/API/CustomsInfo.cs
@@ -30,5 +30,9 @@ namespace EasyPost.Models.API
         public string? RestrictionType { get; set; }
 
         #endregion
+
+        internal CustomsInfo()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/CustomsItem.cs
+++ b/EasyPost/Models/API/CustomsItem.cs
@@ -25,5 +25,9 @@ namespace EasyPost.Models.API
         public double? Weight { get; set; }
 
         #endregion
+
+        internal CustomsItem()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/EndShipper.cs
+++ b/EasyPost/Models/API/EndShipper.cs
@@ -39,6 +39,10 @@ namespace EasyPost.Models.API
 
         #endregion
 
+        internal EndShipper()
+        {
+        }
+
         #region CRUD Operations
 
         /// <summary>

--- a/EasyPost/Models/API/EndShipperCollection.cs
+++ b/EasyPost/Models/API/EndShipperCollection.cs
@@ -12,5 +12,9 @@ namespace EasyPost.Models.API
         public List<EndShipper>? EndShippers { get; set; }
 
         #endregion
+
+        internal EndShipperCollection()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/Error.cs
+++ b/EasyPost/Models/API/Error.cs
@@ -20,5 +20,9 @@ namespace EasyPost.Models.API
         public string? Suggestion { get; set; }
 
         #endregion
+
+        internal Error()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/Event.cs
+++ b/EasyPost/Models/API/Event.cs
@@ -22,5 +22,9 @@ namespace EasyPost.Models.API
         public string? Status { get; set; }
 
         #endregion
+
+        internal Event()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/EventCollection.cs
+++ b/EasyPost/Models/API/EventCollection.cs
@@ -12,5 +12,9 @@ namespace EasyPost.Models.API
         public List<Event>? Events { get; set; }
 
         #endregion
+
+        internal EventCollection()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/Fee.cs
+++ b/EasyPost/Models/API/Fee.cs
@@ -17,5 +17,9 @@ namespace EasyPost.Models.API
         public string? Type { get; set; }
 
         #endregion
+
+        internal Fee()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/Form.cs
+++ b/EasyPost/Models/API/Form.cs
@@ -15,5 +15,9 @@ namespace EasyPost.Models.API
         public bool? SubmittedElectronically { get; set; }
 
         #endregion
+
+        internal Form()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/Insurance.cs
+++ b/EasyPost/Models/API/Insurance.cs
@@ -36,6 +36,10 @@ namespace EasyPost.Models.API
 
         #endregion
 
+        internal Insurance()
+        {
+        }
+
         #region CRUD Operations
 
         /// <summary>

--- a/EasyPost/Models/API/InsuranceCollection.cs
+++ b/EasyPost/Models/API/InsuranceCollection.cs
@@ -12,5 +12,9 @@ namespace EasyPost.Models.API
         public List<Insurance>? Insurances { get; set; }
 
         #endregion
+
+        internal InsuranceCollection()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/Message.cs
+++ b/EasyPost/Models/API/Message.cs
@@ -17,5 +17,9 @@ namespace EasyPost.Models.API
         public string? Type { get; set; }
 
         #endregion
+
+        internal Message()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/Options.cs
+++ b/EasyPost/Models/API/Options.cs
@@ -69,10 +69,10 @@ namespace EasyPost.Models.API
         public string? DeliveryConfirmation { get; set; }
         [JsonProperty("delivery_time_preference")]
         public string? DeliveryTimePreference { get; set; }
-        [JsonProperty("dropoff_type")]
-        public string? DropoffType { get; set; }
         [JsonProperty("dropoff_max_datetime")]
         public DateTime? DropoffMaxDatetime { get; set; }
+        [JsonProperty("dropoff_type")]
+        public string? DropoffType { get; set; }
         [JsonProperty("dry_ice")]
         public bool? DryIce { get; set; }
         [JsonProperty("dry_ice_medical")]
@@ -187,5 +187,9 @@ namespace EasyPost.Models.API
         public bool? SuppressEtd { get; set; }
 
         #endregion
+
+        internal Options()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/Order.cs
+++ b/EasyPost/Models/API/Order.cs
@@ -39,6 +39,10 @@ namespace EasyPost.Models.API
 
         #endregion
 
+        internal Order()
+        {
+        }
+
         #region CRUD Operations
 
         /// <summary>

--- a/EasyPost/Models/API/Parcel.cs
+++ b/EasyPost/Models/API/Parcel.cs
@@ -19,5 +19,9 @@ namespace EasyPost.Models.API
         public double? Width { get; set; }
 
         #endregion
+
+        internal Parcel()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/PaymentMethod.cs
+++ b/EasyPost/Models/API/PaymentMethod.cs
@@ -85,6 +85,10 @@ namespace EasyPost.Models.API
             }
         }
 
+        internal PaymentMethod()
+        {
+        }
+
         /// <summary>
         ///     Payment method priority
         /// </summary>

--- a/EasyPost/Models/API/PaymentMethodsSummary.cs
+++ b/EasyPost/Models/API/PaymentMethodsSummary.cs
@@ -16,5 +16,9 @@ namespace EasyPost.Models.API
         public PaymentMethod? SecondaryPaymentMethod { get; set; }
 
         #endregion
+
+        internal PaymentMethodsSummary()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/Pickup.cs
+++ b/EasyPost/Models/API/Pickup.cs
@@ -50,6 +50,10 @@ namespace EasyPost.Models.API
             get { return PickupRates != null ? PickupRates.Cast<Rate>().ToList() : new List<Rate>(); }
         }
 
+        internal Pickup()
+        {
+        }
+
         #region CRUD Operations
 
         /// <summary>

--- a/EasyPost/Models/API/PickupRate.cs
+++ b/EasyPost/Models/API/PickupRate.cs
@@ -11,6 +11,10 @@ namespace EasyPost.Models.API
 
         #endregion
 
+        internal PickupRate()
+        {
+        }
+
         /// <summary>
         ///     Convert this PickupRate object to a Rate object.
         /// </summary>

--- a/EasyPost/Models/API/PostageLabel.cs
+++ b/EasyPost/Models/API/PostageLabel.cs
@@ -34,5 +34,9 @@ namespace EasyPost.Models.API
         public string? LabelZplUrl { get; set; }
 
         #endregion
+
+        internal PostageLabel()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/Rate.cs
+++ b/EasyPost/Models/API/Rate.cs
@@ -42,5 +42,9 @@ namespace EasyPost.Models.API
         public string? ShipmentId { get; set; }
 
         #endregion
+
+        internal Rate()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/Referral.cs
+++ b/EasyPost/Models/API/Referral.cs
@@ -4,5 +4,8 @@ namespace EasyPost.Models.API
 {
     public class ReferralCustomer : BaseUser
     {
+        internal ReferralCustomer()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/ReferralCustomerCollection.cs
+++ b/EasyPost/Models/API/ReferralCustomerCollection.cs
@@ -12,5 +12,9 @@ namespace EasyPost.Models.API
         public List<ReferralCustomer>? ReferralCustomers { get; set; }
 
         #endregion
+
+        internal ReferralCustomerCollection()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/Refund.cs
+++ b/EasyPost/Models/API/Refund.cs
@@ -19,5 +19,9 @@ namespace EasyPost.Models.API
         public string? TrackingCode { get; set; }
 
         #endregion
+
+        internal Refund()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/RefundCollection.cs
+++ b/EasyPost/Models/API/RefundCollection.cs
@@ -12,5 +12,9 @@ namespace EasyPost.Models.API
         public List<Refund>? Refunds { get; set; }
 
         #endregion
+
+        internal RefundCollection()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/Report.cs
+++ b/EasyPost/Models/API/Report.cs
@@ -22,5 +22,9 @@ namespace EasyPost.Models.API
         public DateTime? UrlExpiresAt { get; set; }
 
         #endregion
+
+        internal Report()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/ReportCollection.cs
+++ b/EasyPost/Models/API/ReportCollection.cs
@@ -14,5 +14,9 @@ namespace EasyPost.Models.API
         public string? Type { get; set; }
 
         #endregion
+
+        internal ReportCollection()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/ScanForm.cs
+++ b/EasyPost/Models/API/ScanForm.cs
@@ -24,5 +24,9 @@ namespace EasyPost.Models.API
         public List<string>? TrackingCodes { get; set; }
 
         #endregion
+
+        internal ScanForm()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/ScanFormCollection.cs
+++ b/EasyPost/Models/API/ScanFormCollection.cs
@@ -12,5 +12,9 @@ namespace EasyPost.Models.API
         public List<ScanForm>? ScanForms { get; set; }
 
         #endregion
+
+        internal ScanFormCollection()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/Shipment.cs
+++ b/EasyPost/Models/API/Shipment.cs
@@ -73,6 +73,10 @@ namespace EasyPost.Models.API
 
         #endregion
 
+        internal Shipment()
+        {
+        }
+
         #region CRUD Operations
 
         /// <summary>

--- a/EasyPost/Models/API/ShipmentCollection.cs
+++ b/EasyPost/Models/API/ShipmentCollection.cs
@@ -12,5 +12,9 @@ namespace EasyPost.Models.API
         public List<Shipment>? Shipments { get; set; }
 
         #endregion
+
+        internal ShipmentCollection()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/Smartrate.cs
+++ b/EasyPost/Models/API/Smartrate.cs
@@ -42,5 +42,9 @@ namespace EasyPost.Models.API
         public TimeInTransit? TimeInTransit { get; set; }
 
         #endregion
+
+        internal Smartrate()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/SmartrateResult.cs
+++ b/EasyPost/Models/API/SmartrateResult.cs
@@ -12,5 +12,9 @@ namespace EasyPost.Models.API
         public List<Smartrate>? Result { get; set; }
 
         #endregion
+
+        internal SmartrateResult()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/TaxIdentifier.cs
+++ b/EasyPost/Models/API/TaxIdentifier.cs
@@ -16,5 +16,9 @@ namespace EasyPost.Models.API
         public string? TaxIdType { get; set; }
 
         #endregion
+
+        internal TaxIdentifier()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/TimeInTransit.cs
+++ b/EasyPost/Models/API/TimeInTransit.cs
@@ -23,6 +23,10 @@ namespace EasyPost.Models.API
 
         #endregion
 
+        internal TimeInTransit()
+        {
+        }
+
         /// <summary>
         ///     Get the value of a specific percentile by its corresponding SmartrateAccuracy enum.
         /// </summary>

--- a/EasyPost/Models/API/Tracker.cs
+++ b/EasyPost/Models/API/Tracker.cs
@@ -33,5 +33,9 @@ namespace EasyPost.Models.API
         public double? Weight { get; set; }
 
         #endregion
+
+        internal Tracker()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/TrackerCollection.cs
+++ b/EasyPost/Models/API/TrackerCollection.cs
@@ -12,5 +12,9 @@ namespace EasyPost.Models.API
         public List<Tracker>? Trackers { get; set; }
 
         #endregion
+
+        internal TrackerCollection()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/TrackingDetail.cs
+++ b/EasyPost/Models/API/TrackingDetail.cs
@@ -18,5 +18,9 @@ namespace EasyPost.Models.API
         public TrackingLocation? TrackingLocation { get; set; }
 
         #endregion
+
+        internal TrackingDetail()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/TrackingLocation.cs
+++ b/EasyPost/Models/API/TrackingLocation.cs
@@ -16,5 +16,9 @@ namespace EasyPost.Models.API
         public string? Zip { get; set; }
 
         #endregion
+
+        internal TrackingLocation()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/User.cs
+++ b/EasyPost/Models/API/User.cs
@@ -8,6 +8,10 @@ namespace EasyPost.Models.API
 {
     public class User : BaseUser
     {
+        internal User()
+        {
+        }
+
         #region CRUD Operations
 
         /// <summary>

--- a/EasyPost/Models/API/Verification.cs
+++ b/EasyPost/Models/API/Verification.cs
@@ -16,5 +16,9 @@ namespace EasyPost.Models.API
         public bool? Success { get; set; }
 
         #endregion
+
+        internal Verification()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/VerificationDetails.cs
+++ b/EasyPost/Models/API/VerificationDetails.cs
@@ -15,5 +15,9 @@ namespace EasyPost.Models.API
         public string? TimeZone { get; set; }
 
         #endregion
+
+        internal VerificationDetails()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/Verifications.cs
+++ b/EasyPost/Models/API/Verifications.cs
@@ -13,5 +13,9 @@ namespace EasyPost.Models.API
         public Verification? Zip4 { get; set; }
 
         #endregion
+
+        internal Verifications()
+        {
+        }
     }
 }

--- a/EasyPost/Models/API/Webhook.cs
+++ b/EasyPost/Models/API/Webhook.cs
@@ -19,6 +19,10 @@ namespace EasyPost.Models.API
 
         #endregion
 
+        internal Webhook()
+        {
+        }
+
         #region CRUD Operations
 
         /// <summary>

--- a/EasyPost/_base/EasyPostClient.cs
+++ b/EasyPost/_base/EasyPostClient.cs
@@ -48,7 +48,7 @@ namespace EasyPost._base
         /// <summary>
         ///     Execute a request against the EasyPost API.
         /// </summary>
-        /// <typeparam name="T">Type of object to deserialize response data into.</typeparam>
+        /// <typeparam name="T">Type of object to deserialize response data into. Must be subclass of EasyPostObject.</typeparam>
         /// <returns>An instance of a T type object.</returns>
         internal async Task<T> Request<T>(Method method, string url, ApiVersion apiVersion, Dictionary<string, object>? parameters = null, string? rootElement = null) where T : class
         {

--- a/EasyPost/_base/WithClient.cs
+++ b/EasyPost/_base/WithClient.cs
@@ -12,22 +12,22 @@ namespace EasyPost._base
         internal EasyPostClient? Client { get; set; }
 
         [CrudOperations.Create]
-        protected async Task<T> Create<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class, new() => await Request<T>(Method.Post, url, parameters, rootElement, overrideApiVersion);
+        protected async Task<T> Create<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class => await Request<T>(Method.Post, url, parameters, rootElement, overrideApiVersion);
 
         [CrudOperations.Create]
         protected async Task CreateNoResponse(string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Request(Method.Post, url, parameters, overrideApiVersion);
 
         [CrudOperations.Delete]
-        protected async Task<T> Delete<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class, new() => await Request<T>(Method.Delete, url, parameters, rootElement, overrideApiVersion);
+        protected async Task<T> Delete<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class => await Request<T>(Method.Delete, url, parameters, rootElement, overrideApiVersion);
 
         [CrudOperations.Delete]
         protected async Task DeleteNoResponse(string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Request(Method.Delete, url, parameters, overrideApiVersion);
 
         [CrudOperations.Read]
-        protected async Task<T> Get<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class, new() => await Request<T>(Method.Get, url, parameters, rootElement, overrideApiVersion);
+        protected async Task<T> Get<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class => await Request<T>(Method.Get, url, parameters, rootElement, overrideApiVersion);
 
         [CrudOperations.Read]
-        protected async Task<T> List<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class, new() => await Request<T>(Method.Get, url, parameters, rootElement, overrideApiVersion);
+        protected async Task<T> List<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class => await Request<T>(Method.Get, url, parameters, rootElement, overrideApiVersion);
 
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace EasyPost._base
         protected async Task Request(Method method, string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Client!.Request(method, url, overrideApiVersion ?? ApiVersion.Current, parameters);
 
         [CrudOperations.Update]
-        protected async Task<T> Update<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class, new() => await Request<T>(Method.Patch, url, parameters, rootElement, overrideApiVersion);
+        protected async Task<T> Update<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class => await Request<T>(Method.Patch, url, parameters, rootElement, overrideApiVersion);
 
         [CrudOperations.Update]
         protected async Task UpdateNoResponse(string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Request(Method.Patch, url, parameters, overrideApiVersion);


### PR DESCRIPTION
# Description

- Mark constructors for all models as "internal" to prevent end-users from making instances directly
  - `var address = new Address() \\ bad`
  - `var address = await myClient.Address.Retrieve() \\ good`
- Update unit tests for F# and VB to account for redesign

# Testing

- All unit tests pass

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
