### PR TITLE
Fix nullability warning for CreateStripeToken function in .NET 5.0

### DIFF
--- a/EasyPost/Services/PartnerService.cs
+++ b/EasyPost/Services/PartnerService.cs
@@ -133,19 +133,35 @@ namespace EasyPost.Services
         /// <exception cref="Exception">When the request fails.</exception>
         private async Task<string> CreateStripeToken(string number, int expirationMonth, int expirationYear, string cvc, string easypostStripeApiKey)
         {
-            List<KeyValuePair<string, string>> parameters = new List<KeyValuePair<string, string>>
-            {
-                new KeyValuePair<string, string>("card[number]", number),
-                new KeyValuePair<string, string>("card[exp_month]", expirationMonth.ToString()),
-                new KeyValuePair<string, string>("card[exp_year]", expirationYear.ToString()),
-                new KeyValuePair<string, string>("card[cvc]", cvc)
-            };
-
             HttpClient client = new HttpClient();
             client.DefaultRequestHeaders.Add("Authorization", $"Bearer {easypostStripeApiKey}");
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/x-www-form-urlencoded"));
 
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, "https://api.stripe.com/v1/tokens") { Content = new FormUrlEncodedContent(parameters) };
+            const string url = "https://api.stripe.com/v1/tokens";
+
+#if NET5_0
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = new FormUrlEncodedContent(new List<KeyValuePair<string?, string?>>
+                {
+                    new KeyValuePair<string?, string?>("card[number]", number),
+                    new KeyValuePair<string?, string?>("card[exp_month]", expirationMonth.ToString()),
+                    new KeyValuePair<string?, string?>("card[exp_year]", expirationYear.ToString()),
+                    new KeyValuePair<string?, string?>("card[cvc]", cvc)
+                })
+            };
+#else
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = new FormUrlEncodedContent(new List<KeyValuePair<string, string>>
+                {
+                    new KeyValuePair<string, string>("card[number]", number),
+                    new KeyValuePair<string, string>("card[exp_month]", expirationMonth.ToString()),
+                    new KeyValuePair<string, string>("card[exp_year]", expirationYear.ToString()),
+                    new KeyValuePair<string, string>("card[cvc]", cvc)
+                })
+            };
+#endif
 
             HttpResponseMessage response = await client.SendAsync(request);
             string responseString = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
# Description

- Fix a nullability warning for CreateStripeToken function in .NET 5.0 due to nullability of form-encoded parameters (specific to .NET 5.0, see below):

<img width="904" alt="image" src="https://user-images.githubusercontent.com/17054780/192946917-691892de-5e52-46a8-9031-e4b286a23050.png">


# Testing

- All unit tests pass
- No modification to cassettes needed

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
