### PR TITLE
Fix API key bug when adding credit card to referral user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+- Fix bug where the temporary internal API key switch when adding a credit card to a referral user was not reverted after the request.
+  - After adding a credit card to a referral user, the existing Client would be misconfigured for following requests.
+
 ## v4.0.1 (2022-10-24)
 
 - `myInsurance.Refresh()` function HTTP method fixed from `PATCH` to `GET`

--- a/EasyPost.Tests/ServicesTests/PartnerServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/PartnerServiceTest.cs
@@ -88,6 +88,9 @@ namespace EasyPost.Tests.ServicesTests
             Assert.IsType<PaymentMethod>(paymentMethod);
             Assert.NotNull(paymentMethod.Id);
             Assert.EndsWith(paymentMethod.Last4, card.Number);
+
+            // Assert that the original API key was restored to the client properly after the request
+            Assert.Equal(TestUtils.GetApiKey(TestUtils.ApiKey.Mock), Client.Configuration.ApiKey);
         }
 
         [Fact]

--- a/EasyPost.Tests/TestUtils.cs
+++ b/EasyPost.Tests/TestUtils.cs
@@ -17,7 +17,7 @@ namespace EasyPost.Tests._Utilities
 {
     public class TestUtils
     {
-        private const string ApiKeyFailedToPull = "couldnotpullapikey";
+        internal const string ApiKeyFailedToPull = "couldnotpullapikey";
 
         private static readonly List<string> BodyCensors = new()
         {
@@ -50,7 +50,8 @@ namespace EasyPost.Tests._Utilities
             Test,
             Production,
             Partner,
-            Referral
+            Referral,
+            Mock
         }
 
         public static string GetSourceFileDirectory([CallerFilePath] string sourceFilePath = "") => Path.GetDirectoryName(sourceFilePath);
@@ -71,6 +72,9 @@ namespace EasyPost.Tests._Utilities
                     break;
                 case ApiKey.Referral:
                     keyName = "REFERRAL_USER_PROD_API_KEY";
+                    break;
+                case ApiKey.Mock:
+                    keyName = "EASYPOST_MOCK_API_KEY"; // does not exist, will trigger to use ApiKeyFailedToPull
                     break;
                 default:
                     throw new Exception(Constants.ErrorMessages.InvalidApiKeyType);

--- a/EasyPost.Tests/_Utilities/UnitTest.cs
+++ b/EasyPost.Tests/_Utilities/UnitTest.cs
@@ -98,7 +98,7 @@ namespace EasyPost.Tests._Utilities
         protected void UseMockClient(IEnumerable<TestUtils.MockRequest>? mockRequestsOverride = null)
         {
             // set up the mock client
-            Client = new TestUtils.MockClient(new Client("mock_api_key")); // API key doesn't matter for mock client, since no real requests are made);
+            Client = new TestUtils.MockClient(new Client(TestUtils.GetApiKey(TestUtils.ApiKey.Mock))); // API key doesn't matter for mock client, since no real requests are made);
 
             // add the mock requests to the mock client
             ((TestUtils.MockClient)Client).AddMockRequests(mockRequestsOverride ?? MockRequests);

--- a/EasyPost/Services/PartnerService.cs
+++ b/EasyPost/Services/PartnerService.cs
@@ -117,10 +117,19 @@ namespace EasyPost.Services
                 }
             };
 
-            // Custom override client with new API key
-            EasyPostClient tempClient = Client!;
-            tempClient.Configuration.ApiKey = referralApiKey;
-            return await tempClient.Request<PaymentMethod>(Method.Post, "credit_cards", ApiVersion.Current, parameters);
+            // Store the old API key
+            string oldApiKey = Client!.Configuration.ApiKey;
+
+            // Change API key temporarily to referral user's API key.
+            Client.Configuration.ApiKey = referralApiKey;
+
+            // Make request
+            PaymentMethod paymentMethod = await Client.Request<PaymentMethod>(Method.Post, "credit_cards", ApiVersion.Current, parameters);
+
+            // Restore old API key
+            Client!.Configuration.ApiKey = oldApiKey;
+
+            return paymentMethod;
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

- Fix bug where the temporary API key switch while adding a referral credit card did not switch back after request completed

# Testing

- Add unit test to verify API key switching is correct
- Add Mock key to TestUtils

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
