### PR TITLE
Improve logic handling API key switch on exception

### DIFF
--- a/EasyPost/Services/PartnerService.cs
+++ b/EasyPost/Services/PartnerService.cs
@@ -123,11 +123,16 @@ namespace EasyPost.Services
             // Change API key temporarily to referral user's API key.
             Client.Configuration.ApiKey = referralApiKey;
 
-            // Make request
-            PaymentMethod paymentMethod = await Client.Request<PaymentMethod>(Method.Post, "credit_cards", ApiVersion.Current, parameters);
-
-            // Restore old API key
-            Client!.Configuration.ApiKey = oldApiKey;
+            PaymentMethod paymentMethod;
+            try
+            {
+                // Make request
+                paymentMethod = await Client.Request<PaymentMethod>(Method.Post, "credit_cards", ApiVersion.Current, parameters);
+            }
+            finally
+            {
+                Client.Configuration.ApiKey = oldApiKey;
+            }
 
             return paymentMethod;
         }


### PR DESCRIPTION
# Description

- Handle switching the API key back (https://github.com/EasyPost/easypost-csharp/pull/361) even on exception

# Testing

- New unit test to confirm that API key is reverted even when API call fails

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
