### PR TITLE
Project, test suite, NuGet package updated to add .NET 7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-        # install .NET SDK
+        # Install .NET SDK
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v3
         with:
@@ -107,10 +107,10 @@ jobs:
             5.x.x
             6.x.x
             7.x.x
-        # install MSBuild, used to build the test project
+        # Install MSBuild, used to build the test project
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.1
-        # install NuGet.exe to restore required NuGet packages
+        # Install NuGet.exe to restore required NuGet packages
       - name: Setup Nuget
         uses: NuGet/setup-nuget@v1.0.5
         # Load NuGet package cache
@@ -144,7 +144,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-        # install .NET SDK
+        # Install .NET SDK
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v3
         with:
@@ -157,13 +157,13 @@ jobs:
       - name: Set up variables
         id: test_project
         run: echo "::set-output name=test_file::EasyPost.Tests.${{ matrix.lang }}"
-        # install MSBuild, used to build the test project
+        # Install MSBuild, used to build the test project
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.1
-        # install NuGet.exe to restore required NuGet packages
+        # Install NuGet.exe to restore required NuGet packages
       - name: Setup Nuget
         uses: NuGet/setup-nuget@v1.0.5
-        # install Visual Studio's console test application, to execute tests
+        # Install Visual Studio's console test application, to execute tests
       - name: Setup VSTest
         uses: darenm/Setup-VSTest@v1
         # Load NuGet package cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - name: Install .NET SDK
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 7.x.x
       - name: Set up dotnet tools and dependencies
         run: make install
       - name: Generate coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       EASYPOST_PROD_API_KEY: "123"
     strategy:
       matrix:
-        name: [ 'NetStandard20', 'NetCore31', 'Net50', 'Net60' ]
+        name: [ 'NetStandard20', 'NetCore31', 'Net50', 'Net60', 'Net70' ]
         include:
           - name: NetStandard20
             # can't run tests on .NET Standard, it's just a bridge between .NET Framework and .NET.
@@ -68,6 +68,8 @@ jobs:
             framework: net5.0
           - name: Net60
             framework: net6.0
+          - name: Net70
+            framework: net7.0
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v3
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.x.x
       - name: Set up dotnet tools
         run: make install-tools
       - name: Check dotnet Style
@@ -19,6 +23,10 @@ jobs:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v3
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.x.x
       - name: Set up dotnet tools and dependencies
         run: make install
       - name: Run security analysis
@@ -29,6 +37,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.x.x
       - name: Set up dotnet tools and dependencies
         run: make install
       - name: Check if test suite coverage meets requirements
@@ -38,6 +50,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.x.x
       - name: Set up dotnet tools and dependencies
         run: make install
       - name: Generate coverage report
@@ -74,6 +90,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+        # install .NET SDK
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.x.x
         # install MSBuild, used to build the test project
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.1
@@ -111,6 +132,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+        # install .NET SDK
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 7.x.x
         # Set the project name, based on platform version currently selected
       - name: Set up variables
         id: test_project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,11 @@ jobs:
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.x.x
+          dotnet-version: |
+            3.1.x
+            5.x.x
+            6.x.x
+            7.x.x
       - name: Set up dotnet tools
         run: make install-tools
       - name: Check dotnet Style
@@ -26,7 +30,11 @@ jobs:
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.x.x
+          dotnet-version: |
+            3.1.x
+            5.x.x
+            6.x.x
+            7.x.x
       - name: Set up dotnet tools and dependencies
         run: make install
       - name: Run security analysis
@@ -40,7 +48,11 @@ jobs:
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.x.x
+          dotnet-version: |
+            3.1.x
+            5.x.x
+            6.x.x
+            7.x.x
       - name: Set up dotnet tools and dependencies
         run: make install
       - name: Check if test suite coverage meets requirements
@@ -90,7 +102,11 @@ jobs:
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.x.x
+          dotnet-version: |
+            3.1.x
+            5.x.x
+            6.x.x
+            7.x.x
         # install MSBuild, used to build the test project
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.1
@@ -132,7 +148,11 @@ jobs:
       - name: Install .NET SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.x.x
+          dotnet-version: |
+            3.1.x
+            5.x.x
+            6.x.x
+            7.x.x
         # Set the project name, based on platform version currently selected
       - name: Set up variables
         id: test_project

--- a/EasyPost.Tests/EasyPost.Tests.csproj
+++ b/EasyPost.Tests/EasyPost.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
 

--- a/EasyPost.Tests/packages.lock.json
+++ b/EasyPost.Tests/packages.lock.json
@@ -1046,6 +1046,241 @@
           "RestSharp": "[108.0.1, 109.0.0)"
         }
       }
+    },
+    "net7.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[3.1.2, 4.0.0)",
+        "resolved": "3.1.2",
+        "contentHash": "wuLDIDKD5XMt0A7lE31JPenT7QQwZPFkP5rRpdJeblyXZ9MGLI8rYjvm5fvAKln+2/X+4IxxQDxBtwdrqKNLZw=="
+      },
+      "coverlet.msbuild": {
+        "type": "Direct",
+        "requested": "[3.2.0, )",
+        "resolved": "3.2.0",
+        "contentHash": "lu/eJJpqJb4qy3BGPtDD/LI5RSOwXYYyRErTyaG0OTP69llzVK3FEe74hBQx0JtLUTLEVBfERV4uGYcE1Br2sg=="
+      },
+      "EasyVCR": {
+        "type": "Direct",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "rvNLrrOKVdWC3f95anMJIkhdkPO7CZpt7nC+83jVYH8pCEfdfi3QG0Nx+4+oS1OOaWue6P5tn9DDI3GCaQdbNw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "6.0.0",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.3.0, 18.0.0)",
+        "resolved": "17.3.0",
+        "contentHash": "ch4JCT7AZdBzvCAKD36t6fDsl7NEzzunwW7MwXUG2uFPoWcMd8B8KYg5fiwxnpdXJHodJk6yIBdSwMpN3Ikt9w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.3.0",
+          "Microsoft.TestPlatform.TestHost": "17.3.0"
+        }
+      },
+      "Microsoft.VisualStudio.TestPlatform.ObjectModel": {
+        "type": "Direct",
+        "requested": "[14.0.0, 15.0.0)",
+        "resolved": "14.0.0",
+        "contentHash": "PlQ38dL950pnyptA3CcnYIqAKpqlP7xpoz8n5ZfS1QgxFiZrh2x1lw05V3VNmq0ZZ9Xy3SHB5tOyvFjmjNR1HQ=="
+      },
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, 3.0.0)",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.1, 14.0.0)",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "RestSharp": {
+        "type": "Direct",
+        "requested": "[108.0.1, 109.0.0)",
+        "resolved": "108.0.1",
+        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA=="
+      },
+      "SecurityCodeScan.VS2019": {
+        "type": "Direct",
+        "requested": "[5.6.6, 6.0.0)",
+        "resolved": "5.6.6",
+        "contentHash": "1BEkaTw2iZ5QccesAYfRcab9ttQvg6xyIItazCWLJEt5aKf3cDXvGtX+Z4p11a1QwYmf3WaNxpiZXfzXK/0VIw=="
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.4.2, 3.0.0)",
+        "resolved": "2.4.2",
+        "contentHash": "6Mj73Ont3zj2CJuoykVJfE0ZmRwn7C+pTuRP8c4bnaaTFjwNG6tGe0prJ1yIbMe9AHrpDys63ctWacSsFJWK/w==",
+        "dependencies": {
+          "xunit.analyzers": "1.0.0",
+          "xunit.assert": "2.4.2",
+          "xunit.core": "[2.4.2]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[2.4.5, 3.0.0)",
+        "resolved": "2.4.5",
+        "contentHash": "OwHamvBdUKgqsXfBzWiCW/O98BTx81UKzx2bieIOQI7CZFE5NEQZGi8PBQGIKawDW96xeRffiNf20SjfC0x9hw=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.3.0",
+        "contentHash": "/xxz+e29F2V5pePtInjbLffoqWVTm60KCX87vSj2laNboeWq65WFJ634fGtBcMZO3VEfOmh9/XcoWEfLlWWG+g=="
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "k6PWQMuoBDGGHOQTtyois2u4AwyVcIwL2LaSLlTZQm2CYcJ1pxbt6jfAnpWmzENA/wfrYRI/X9DTLoUkE4AsLw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "xlzi2IYREJH3/m6+lUrQlujzX8wDitm4QGnUu6kUXTQAWPuZY8i+ticFJbzfqaetLA6KR/rO6Ew/HuYD+bxifg=="
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "eIbyj40QDg1NDz0HBW0S5f3wrLVnKWnDJ/JtZ+yJDFnDj90VoPuoPmFkeaXrtu+0cKm5GRAwoDf+dBWXK0TUdg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "6.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Options": "6.0.0",
+          "System.Diagnostics.DiagnosticSource": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/HggWBbTwy8TgebGSX5DBZ24ndhzi93sHUBDvP1IxbZD7FDokYzdAr6+vbWGjw2XAfR2EJ1sfKUotpjHnFWPxA=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "dzXN0+V1AyjOe2xcJ86Qbo233KHuLEY0njf/P2Kw8SfJU+d45HNS2ctJdnEnrWbM9Ye2eFgaC5Mj9otRMU6IsQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "6.0.0",
+          "Microsoft.Extensions.Primitives": "6.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "9+PnzmQFfEFNR9J2aDTfJGGupShHjOuGw4VUv+JB044biSHrnmCIMD+mJHmb2H7YryrfBEXDurxQ47gJZdCKNQ==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.3.0",
+        "contentHash": "6NRzi6QbmWV49Psf8A9z1LTJU4nBrlJdCcDOUyD4Ttm1J2wvksu98GlV+52CkxtpgNsUjGr9Mv1Rbb1/dB06yQ==",
+        "dependencies": {
+          "NuGet.Frameworks": "5.11.0",
+          "System.Reflection.Metadata": "1.6.0"
+        }
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.3.0",
+        "contentHash": "uOJALDWtKXZkISKuNI7kOlRi/lk2CqXZtLkNS0Ei+RXqRUjUpCsjAPYSP+DJ/a4QwJ5cI9CVF52vtajnGOaEpw==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.3.0",
+          "Newtonsoft.Json": "9.0.1"
+        }
+      },
+      "NuGet.Frameworks": {
+        "type": "Transitive",
+        "resolved": "5.11.0",
+        "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "frQDfv0rl209cKm1lnwTgFPzNigy2EKk1BS3uAvHvlBVKe5cymGyHO+Sj+NLv5VF/AhHsqPIUUwya5oV4CHMUw==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "1.6.0",
+        "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ=="
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "BeO8hEgs/c8Ls2647fPfieMngncvf0D0xYNDfIO59MolxtCtVjFRd6SRc+7tj8VMqkVOuJcnc9eh4ngI2cAmLQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "pxJISOFjn2XTTi1mcDCkRZrTFb9OtRRCtx2kZFNF51GdReLr1ls2rnyxvAS4JO247K3aNtflvh5Q0346K5BROA==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1"
+        }
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "KB4yGCxNqIVyekhJLXtKSEq6BaXVp/JO3mbGVE1hxypZTLEe7h+sTbAhpA+yZW2dPtXTuiW+C1B2oxxHEkrmOw==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.4.2]",
+          "xunit.extensibility.execution": "[2.4.2]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "W1BoXTIN1C6kpVSMw25huSet25ky6IAQUNovu3zGOGN/jWnbgSoTyCrlIhmXSg0tH5nEf8q7h3OjNHOjyu5PfA==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.4.2",
+        "contentHash": "CZmgcKkwpyo8FlupZdWpJCryrAOWLh1FBPG6gmVZuPQkGQsim/oL4PcP4nfrC2hHgXUFtluvaJ0Sp9PQKUMNpg==",
+        "dependencies": {
+          "NETStandard.Library": "1.6.1",
+          "xunit.extensibility.core": "[2.4.2]"
+        }
+      },
+      "easypost": {
+        "type": "Project",
+        "dependencies": {
+          "Newtonsoft.Json": "[13.0.1, 14.0.0)",
+          "RestSharp": "[108.0.1, 109.0.0)"
+        }
+      }
     }
   }
 }

--- a/EasyPost.nuspec
+++ b/EasyPost.nuspec
@@ -31,6 +31,10 @@
                 <dependency id="Newtonsoft.Json" version="[13.0.1, 14.0.0)" />
                 <dependency id="RestSharp" version="[108.0.1, 109.0.0)" />
             </group>
+            <group targetFramework="net7.0">
+                <dependency id="Newtonsoft.Json" version="[13.0.1, 14.0.0)" />
+                <dependency id="RestSharp" version="[108.0.1, 109.0.0)" />
+            </group>
         </dependencies>
     </metadata>
     <files>
@@ -42,6 +46,8 @@
         <file src="lib\net\net5.0\EasyPost.XML" target="lib\net5.0" />
         <file src="lib\net\net6.0\EasyPost.dll" target="lib\net6.0" />
         <file src="lib\net\net6.0\EasyPost.XML" target="lib\net6.0" />
+        <file src="lib\net\net7.0\EasyPost.dll" target="lib\net7.0" />
+        <file src="lib\net\net7.0\EasyPost.XML" target="lib\net7.0" />
         <file src="README.md" target="docs\" />
         <file src="icon.png" target="images\" />
     </files>

--- a/EasyPost/EasyPost.csproj
+++ b/EasyPost/EasyPost.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>

--- a/EasyPost/packages.lock.json
+++ b/EasyPost/packages.lock.json
@@ -1,157 +1,171 @@
 {
-    "version": 1,
-    "dependencies": {
-        ".NETCoreApp,Version=v3.1": {
-            "Newtonsoft.Json": {
-                "type": "Direct",
-                "requested": "[13.0.1, 14.0.0)",
-                "resolved": "13.0.1",
-                "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-            },
-            "RestSharp": {
-                "type": "Direct",
-                "requested": "[108.0.1, 109.0.0)",
-                "resolved": "108.0.1",
-                "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
-                "dependencies": {
-                    "System.Text.Json": "5.0.0"
-                }
-            },
-            "System.Text.Json": {
-                "type": "Transitive",
-                "resolved": "5.0.0",
-                "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
-            }
-        },
-        ".NETStandard,Version=v2.0": {
-            "NETStandard.Library": {
-                "type": "Direct",
-                "requested": "[2.0.3, )",
-                "resolved": "2.0.3",
-                "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
-                "dependencies": {
-                    "Microsoft.NETCore.Platforms": "1.1.0"
-                }
-            },
-            "Newtonsoft.Json": {
-                "type": "Direct",
-                "requested": "[13.0.1, 14.0.0)",
-                "resolved": "13.0.1",
-                "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-            },
-            "RestSharp": {
-                "type": "Direct",
-                "requested": "[108.0.1, 109.0.0)",
-                "resolved": "108.0.1",
-                "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
-                "dependencies": {
-                    "System.Text.Json": "5.0.0"
-                }
-            },
-            "Microsoft.Bcl.AsyncInterfaces": {
-                "type": "Transitive",
-                "resolved": "5.0.0",
-                "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
-                "dependencies": {
-                    "System.Threading.Tasks.Extensions": "4.5.4"
-                }
-            },
-            "Microsoft.NETCore.Platforms": {
-                "type": "Transitive",
-                "resolved": "1.1.0",
-                "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
-            },
-            "System.Buffers": {
-                "type": "Transitive",
-                "resolved": "4.5.1",
-                "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
-            },
-            "System.Memory": {
-                "type": "Transitive",
-                "resolved": "4.5.4",
-                "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw==",
-                "dependencies": {
-                    "System.Buffers": "4.5.1",
-                    "System.Numerics.Vectors": "4.4.0",
-                    "System.Runtime.CompilerServices.Unsafe": "4.5.3"
-                }
-            },
-            "System.Numerics.Vectors": {
-                "type": "Transitive",
-                "resolved": "4.5.0",
-                "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
-            },
-            "System.Runtime.CompilerServices.Unsafe": {
-                "type": "Transitive",
-                "resolved": "5.0.0",
-                "contentHash": "ZD9TMpsmYJLrxbbmdvhwt9YEgG5WntEnZ/d1eH8JBX9LBp+Ju8BSBhUGbZMNVHHomWo2KVImJhTDl2hIgw/6MA=="
-            },
-            "System.Text.Encodings.Web": {
-                "type": "Transitive",
-                "resolved": "5.0.0",
-                "contentHash": "EEslUvHKll1ftizbn20mX3Ix/l4Ygk/bdJ2LY6/X6FlGaP0RIhKMo9nS6JIGnKKT6KBP2PGj6JC3B9/ZF6ErqQ==",
-                "dependencies": {
-                    "System.Memory": "4.5.4"
-                }
-            },
-            "System.Text.Json": {
-                "type": "Transitive",
-                "resolved": "5.0.0",
-                "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw==",
-                "dependencies": {
-                    "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
-                    "System.Buffers": "4.5.1",
-                    "System.Memory": "4.5.4",
-                    "System.Numerics.Vectors": "4.5.0",
-                    "System.Runtime.CompilerServices.Unsafe": "5.0.0",
-                    "System.Text.Encodings.Web": "5.0.0",
-                    "System.Threading.Tasks.Extensions": "4.5.4"
-                }
-            },
-            "System.Threading.Tasks.Extensions": {
-                "type": "Transitive",
-                "resolved": "4.5.4",
-                "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
-                "dependencies": {
-                    "System.Runtime.CompilerServices.Unsafe": "4.5.3"
-                }
-            }
-        },
-        ".NETCoreApp,Version=v5.0": {
-            "Newtonsoft.Json": {
-                "type": "Direct",
-                "requested": "[13.0.1, 14.0.0)",
-                "resolved": "13.0.1",
-                "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-            },
-            "RestSharp": {
-                "type": "Direct",
-                "requested": "[108.0.1, 109.0.0)",
-                "resolved": "108.0.1",
-                "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
-                "dependencies": {
-                    "System.Text.Json": "5.0.0"
-                }
-            },
-            "System.Text.Json": {
-                "type": "Transitive",
-                "resolved": "5.0.0",
-                "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
-            }
-        },
-        "net6.0": {
-            "Newtonsoft.Json": {
-                "type": "Direct",
-                "requested": "[13.0.1, 14.0.0)",
-                "resolved": "13.0.1",
-                "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-            },
-            "RestSharp": {
-                "type": "Direct",
-                "requested": "[108.0.1, 109.0.0)",
-                "resolved": "108.0.1",
-                "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA=="
-            }
+  "version": 1,
+  "dependencies": {
+    ".NETCoreApp,Version=v3.1": {
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.1, 14.0.0)",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "RestSharp": {
+        "type": "Direct",
+        "requested": "[108.0.1, 109.0.0)",
+        "resolved": "108.0.1",
+        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
+        "dependencies": {
+          "System.Text.Json": "5.0.0"
         }
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
+      }
+    },
+    ".NETStandard,Version=v2.0": {
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.1, 14.0.0)",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "RestSharp": {
+        "type": "Direct",
+        "requested": "[108.0.1, 109.0.0)",
+        "resolved": "108.0.1",
+        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
+        "dependencies": {
+          "System.Text.Json": "5.0.0"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.5.1",
+        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Numerics.Vectors": "4.4.0",
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "System.Numerics.Vectors": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZD9TMpsmYJLrxbbmdvhwt9YEgG5WntEnZ/d1eH8JBX9LBp+Ju8BSBhUGbZMNVHHomWo2KVImJhTDl2hIgw/6MA=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "EEslUvHKll1ftizbn20mX3Ix/l4Ygk/bdJ2LY6/X6FlGaP0RIhKMo9nS6JIGnKKT6KBP2PGj6JC3B9/ZF6ErqQ==",
+        "dependencies": {
+          "System.Memory": "4.5.4"
+        }
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.4",
+          "System.Numerics.Vectors": "4.5.0",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0",
+          "System.Text.Encodings.Web": "5.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      }
+    },
+    ".NETCoreApp,Version=v5.0": {
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.1, 14.0.0)",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "RestSharp": {
+        "type": "Direct",
+        "requested": "[108.0.1, 109.0.0)",
+        "resolved": "108.0.1",
+        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
+        "dependencies": {
+          "System.Text.Json": "5.0.0"
+        }
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
+      }
+    },
+    "net6.0": {
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.1, 14.0.0)",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "RestSharp": {
+        "type": "Direct",
+        "requested": "[108.0.1, 109.0.0)",
+        "resolved": "108.0.1",
+        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA=="
+      }
+    },
+    "net7.0": {
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.1, 14.0.0)",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "RestSharp": {
+        "type": "Direct",
+        "requested": "[108.0.1, 109.0.0)",
+        "resolved": "108.0.1",
+        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA=="
+      }
     }
+  }
 }

--- a/check_coverage.sh
+++ b/check_coverage.sh
@@ -13,4 +13,4 @@ cd "$test_folder" || exit
 # This will fail to run on machines without MSBuild installed
 
 # If the coverage is below the threshold, exit with a non-zero exit code
-dotnet test /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:Threshold=$THRESHOLD /p:ThresholdType=$THRESHOLD_TYPE /p:TargetFramework=net6.0
+dotnet test /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:Threshold=$THRESHOLD /p:ThresholdType=$THRESHOLD_TYPE /p:TargetFramework=net7.0


### PR DESCRIPTION
# Description

- Add net7.0 support to source and unit tests
- Use net7.0 when testing F# and VB compatibility
- Add net7.0 support to nuspec

# Testing

- Tested locally using .NET 7 RC, works as expected
- GitHub CI will test .NET 7 as well
  -~~In draft mode until GitHub Actions runners add .NET 7 support: https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#net-core-sdk, https://github.com/actions/runner-images/issues/6539~~ Resolved by forcibly installing .NET versions via [`actions/setup-dotnet`](https://github.com/actions/setup-dotnet) rather than relying on pre-installed .NET on GitHub runner
  - This will help us lock down any .NET version issues.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
