### PR TITLE
Undo code signing changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,13 @@ coverage-check:
 format:
 	dotnet dotnet-format --no-restore
 
+## install-cert - Install the PFX certificate to your system (Windows only)
+# @parameters:
+# cert= - The certificate to use for signing the built assets.
+# pass= - The password for the certificate.
+install-cert:
+	scripts\install_cert.bat ${cert} ${pass}
+
 ## install-tools - Install required dotnet tools
 install-tools:
 	dotnet new tool-manifest || exit 0
@@ -55,8 +62,9 @@ lint-scripts:
 ## prep-release - Build, sign and package the project for distribution, signing with the provided certificate (Windows only)
 # @parameters:
 # cert= - The certificate to use for signing the built assets.
+# pass= - The password for the certificate.
 prep-release:
-	scripts\build_release_nuget.bat EasyPost ${cert} Release
+	scripts\build_release_nuget.bat EasyPost ${cert} ${pass} EasyPost Release
 
 ## publish - Publish a specific NuGet file to nuget.org (Windows only)
 # @parameters:
@@ -88,6 +96,14 @@ setup-win:
 setup-unix:
 	bash scripts/setup.sh
 
+## sign - Sign all generated DLLs and NuGet packages with the provided certificate (Windows only)
+# @parameters:
+# cert= - The certificate to use for signing the built assets.
+# pass= - The password for the certificate.
+sign:
+	install-cert cert=${cert} pass=${pass}
+	scripts\sign_assemblies.bat ${cert} ${pass} EasyPost
+
 ## test - Test the project
 test:
 	dotnet test
@@ -103,4 +119,4 @@ test-fw:
 uninstall-scanner:
 	dotnet tool uninstall security-scan
 
-.PHONY: help build build-test-fw build-prod clean coverage coverage-check format install-tools install lint lint-scripts pre-release publish release restore scan setup-win setup-unix test test-fw uninstall-scanner
+.PHONY: help build build-test-fw build-prod clean coverage coverage-check format install-cert install-tools install lint lint-scripts pre-release publish-all publish release restore scan setup-win setup-unix sign test test-fw uninstall-scanner

--- a/scripts/build_release_nuget.bat
+++ b/scripts/build_release_nuget.bat
@@ -5,30 +5,34 @@
 :: Requirements:
 :: - NuGet is installed on the machine and is accessible everywhere (added to PATH)
 :: - dotnet is installed on the machine and is accessible everywhere (added to PATH) (might be in C:\Program Files\dotnet)
+:: - SnInstallPfx (https://github.com/honzajscz/SnInstallPfx) is installed on the machine and is accessible everywhere (added to PATH)
 
 @ECHO OFF
 
 :: Parse command line arguments
 SET projectName=%1
 SET certFile=%2
-SET buildMode=%3
+SET certPass=%3
+SET containerName=%4
+SET buildMode=%5
 
 :: Delete old files
 CALL "scripts\delete_old_assemblies.bat"
+
+:: Install certificate (needed to automate signing later on)
+CALL "scripts\install_cert.bat" %certFile% %certPass% %containerName% || GOTO :commandFailed
 
 :: Restore dependencies and build solution
 CALL "scripts\build_project.bat" %buildMode% || GOTO :commandFailed
 
 :: Sign the DLLs
-CALL "scripts\sign_dlls.bat" %certFile% || GOTO :commandFailed
+CALL "scripts\sign_dlls.bat" %certFile% %certPass% %containerName% || GOTO :commandFailed
 
 :: Package the DLLs in a NuGet package (will fail if DLLs are missing)
 CALL "scripts\pack_nuget.bat" %projectName% || GOTO :commandFailed
 
 :: Sign the NuGet package
-CALL "scripts\sign_nuget.bat" %certFile% || GOTO :commandFailed
-
-:: Gather the NuGet package
+CALL "scripts\sign_nuget.bat" %certFile% %certPass% || GOTO :commandFailed
 SET nugetFileName=
 FOR /R %%F IN (*.nupkg) DO (
     SET nugetFileName="%%F"
@@ -47,7 +51,7 @@ GOTO :eof
 
 :usage
 @ECHO:
-@ECHO Usage: %0 <PROJECT_NAME> <PATH_TO_CERTIFICATE> <BUILD_MODE>
+@ECHO Usage: %0 <PROJECT_NAME> <PATH_TO_CERTIFICATE> <CERTIFICATE_PASSWORD> <CERT_CONTAINER_NAME> <BUILD_MODE>
 GOTO :exitWithError
 
 :commandFailed

--- a/scripts/dependencies.txt
+++ b/scripts/dependencies.txt
@@ -1,3 +1,5 @@
 7z.exe,1CNp7hK2e6sOg1rdB8f0iEr6CWAPAj1JD
 nuget.exe,1GdqLDyLiavrJ7A8IYSbGDJmRQQA-ld6n
 signtool.exe,1R2Ozruv6b67wVzHd6pzuS7snkJuUqB3N
+sn.exe,1kN-pj2D_PnbRqWuXgBbC6fy7k39Zpo94
+SnInstallPfx.exe,1QznnBIj4cKDLDSdYTQEAuC6SDzaqoXnP

--- a/scripts/install_cert.bat
+++ b/scripts/install_cert.bat
@@ -1,0 +1,28 @@
+:: This script will install a provided PFX certificate to the system.
+
+:: Requirements:
+:: - dotnet is installed on the machine and is accessible everywhere (added to PATH) (might be in C:\Program Files\dotnet)
+:: - SnInstallPfx (https://github.com/honzajscz/SnInstallPfx) is installed on the machine and is accessible everywhere (added to PATH)
+
+@ECHO OFF
+
+:: Parse command line arguments
+SET certFile=%1
+SET certPass=%2
+SET containerName=%3
+
+:: Install certificate
+@ECHO:
+@ECHO (Re-)Installing certificate to system...
+sn -d %containerName%
+SnInstallPfx %certFile% %certPass% %containerName% || GOTO :commandFailed
+
+EXIT /B 0
+
+:commandFailed
+@ECHO Command failed.
+GOTO :exitWithError
+
+:exitWithError
+@ECHO Exiting...
+EXIT /B 1

--- a/scripts/sign_dlls.bat
+++ b/scripts/sign_dlls.bat
@@ -2,6 +2,8 @@
 
 :: Requirements:
 :: - dotnet is installed on the machine and is accessible everywhere (added to PATH) (might be in C:\Program Files\dotnet)
+:: - sn.exe is installed on the machine and is accessible everywhere (added to PATH)
+:: - signtool is installed on the machine and is accessible everywhere (added to PATH) (might be in C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64)
 
 @ECHO OFF
 

--- a/scripts/sign_dlls.bat
+++ b/scripts/sign_dlls.bat
@@ -2,18 +2,22 @@
 
 :: Requirements:
 :: - dotnet is installed on the machine and is accessible everywhere (added to PATH) (might be in C:\Program Files\dotnet)
-:: - signtool is installed on the machine and is accessible everywhere (added to PATH) (might be in C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x64)
 
 @ECHO OFF
 
 :: Parse command line arguments
 SET certFile=%1
+SET certPass=%2
+SET containerName=%3
 
 :: Sign all DLLs found in the lib folder
 @ECHO:
 @ECHO Signing DLLs with certificate...
 FOR /R "lib" %%F IN (*.dll) DO (
-    signtool sign /f %certFile% /v /tr http://timestamp.digicert.com?alg=sha256 /td SHA256 /fd SHA256 "%%F" || GOTO :commandFailed
+    REM We need to run the DLLs through both sn.exe and signtool to get complete the signing process
+    REM sn erroneously triggers command failed if we put a fallback on this
+    sn -Rca "%%F" %containerName%
+    signtool sign /f %certFile% /p %certPass% /v /tr http://timestamp.digicert.com?alg=sha256 /td SHA256 /fd SHA256 "%%F" || GOTO :commandFailed
 )
 
 EXIT /B 0

--- a/scripts/sign_nuget.bat
+++ b/scripts/sign_nuget.bat
@@ -7,13 +7,14 @@
 
 :: Parse command line arguments
 SET certFile=%1
+SET certPass=%2
 
 :: Sign all NuGet packages found
 @ECHO:
 @ECHO Signing NuGet package with %certFile%...
 :: Should only be one .nupkg file at this point, since we deleted the old ones
 FOR /R %%F IN (*.nupkg) DO (
-    nuget sign "%%F" -Timestamper http://timestamp.digicert.com -CertificatePath "%certFile%" || GOTO :commandFailed
+    nuget sign "%%F" -Timestamper http://timestamp.digicert.com -CertificatePath "%certFile%" -CertificatePassword "%certPass%" || GOTO :commandFailed
 )
 
 EXIT /B 0


### PR DESCRIPTION
# Description

Confusion over the renewed code signing certificate caused a premature change to the code signing/NuGet packing process. Most of those changes have been reverted in this PR, and the process will largely stay the same as it was.

# Testing

- N/A

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
