### PR TITLE
Performance improvements to HTTP connections

### DIFF
--- a/EasyPost.Tests.FSharp/packages.lock.json
+++ b/EasyPost.Tests.FSharp/packages.lock.json
@@ -94,11 +94,6 @@
         "resolved": "5.11.0",
         "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
       },
-      "RestSharp": {
-        "type": "Transitive",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA=="
-      },
       "System.Reflection.Metadata": {
         "type": "Transitive",
         "resolved": "1.6.0",
@@ -152,8 +147,7 @@
       "easypost": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.1, 14.0.0)",
-          "RestSharp": "[108.0.1, 109.0.0)"
+          "Newtonsoft.Json": "[13.0.1, 14.0.0)"
         }
       }
     }

--- a/EasyPost.Tests.VB/packages.lock.json
+++ b/EasyPost.Tests.VB/packages.lock.json
@@ -88,11 +88,6 @@
         "resolved": "5.11.0",
         "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
       },
-      "RestSharp": {
-        "type": "Transitive",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA=="
-      },
       "System.Reflection.Metadata": {
         "type": "Transitive",
         "resolved": "1.6.0",
@@ -146,8 +141,7 @@
       "easypost": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.1, 14.0.0)",
-          "RestSharp": "[108.0.1, 109.0.0)"
+          "Newtonsoft.Json": "[13.0.1, 14.0.0)"
         }
       }
     }

--- a/EasyPost.Tests/ClientTest.cs
+++ b/EasyPost.Tests/ClientTest.cs
@@ -23,10 +23,8 @@ namespace EasyPost.Tests
             // we specifically want to test the getters/setters
             Client client = new(FakeApikey);
             client.Configuration.ConnectTimeoutMilliseconds = 5000;
-            client.Configuration.RequestTimeoutMilliseconds = 5000;
 
             Assert.Equal(5000, client.Configuration.ConnectTimeoutMilliseconds);
-            Assert.Equal(5000, client.Configuration.RequestTimeoutMilliseconds);
         }
 
         [Fact]

--- a/EasyPost.Tests/EasyPost.Tests.csproj
+++ b/EasyPost.Tests/EasyPost.Tests.csproj
@@ -50,7 +50,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="[13.0.1, 14.0.0)" />
-    <PackageReference Include="RestSharp" Version="[108.0.1, 109.0.0)" />
     <PackageReference Include="SecurityCodeScan.VS2019" Version="[5.6.6, 6.0.0)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/EasyPost.Tests/ServicesTests/BillingServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/BillingServiceTest.cs
@@ -7,7 +7,6 @@ using EasyPost.Models.API;
 using EasyPost.Tests._Utilities;
 using EasyPost.Tests._Utilities.Annotations;
 using EasyPost.Utilities.Annotations;
-using RestSharp;
 using Xunit;
 
 namespace EasyPost.Tests.ServicesTests
@@ -25,23 +24,23 @@ namespace EasyPost.Tests.ServicesTests
                 return new List<TestUtils.MockRequest>
                 {
                     new(
-                        new TestUtils.MockRequestMatchRules(Method.Post, @"^v2\/bank_accounts\/\S*\/charges$"),
+                        new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Post, @"v2\/bank_accounts\/\S*\/charges$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Method.Post, @"^v2\/credit_cards\/\S*\/charges$"),
+                        new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Post, @"v2\/credit_cards\/\S*\/charges$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Method.Delete, @"^v2\/bank_accounts\/\S*$"),
+                        new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Delete, @"v2\/bank_accounts\/\S*$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Method.Delete, @"^v2\/credit_cards\/\S*$"),
+                        new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Delete, @"v2\/credit_cards\/\S*$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/payment_methods$"),
+                        new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Get, @"v2\/payment_methods$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethodsSummary
                         {
                             Id = "summary_123",
@@ -111,7 +110,7 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/payment_methods$"),
+                    new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Get, @"v2\/payment_methods$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethodsSummary
                     {
                         Id = null // No ID, will throw an error when we try to interact with this summary
@@ -161,7 +160,7 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/payment_methods$"),
+                    new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Get, @"v2\/payment_methods$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethodsSummary
                     {
                         Id = "summary_123",
@@ -183,7 +182,7 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/payment_methods$"),
+                    new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Get, @"v2\/payment_methods$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethodsSummary
                     {
                         Id = "summary_123",

--- a/EasyPost.Tests/ServicesTests/PartnerServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/PartnerServiceTest.cs
@@ -7,7 +7,6 @@ using EasyPost.Models.API;
 using EasyPost.Tests._Utilities;
 using EasyPost.Tests._Utilities.Annotations;
 using EasyPost.Utilities.Annotations;
-using RestSharp;
 using Xunit;
 
 namespace EasyPost.Tests.ServicesTests
@@ -63,15 +62,15 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Get, @"v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"pk_test_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Post, @"^https://api.stripe.com/v1/tokens$"),
+                    new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Post, @"^https://api.stripe.com/v1/tokens$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"id\":\"tok_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Post, @"^v2\/credit_cards$"),
+                    new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Post, @"v2\/credit_cards$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethod
                     {
                         Id = "summary_123",
@@ -100,15 +99,15 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Get, @"v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"pk_test_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Post, @"^https://api.stripe.com/v1/tokens$"),
+                    new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Post, @"^https://api.stripe.com/v1/tokens$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"id\":\"tok_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Post, @"^v2\/credit_cards$"),
+                    new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Post, @"v2\/credit_cards$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethod
                     {
                         Id = "summary_123",
@@ -143,7 +142,7 @@ namespace EasyPost.Tests.ServicesTests
             {
                 {
                     new(
-                        new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                        new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Get, @"v2\/partners\/stripe_public_key$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"\"}")
                     )
                 }
@@ -161,7 +160,7 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Get, @"v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"not_public_key\":\"random\"}")
                 ),
             });
@@ -178,11 +177,11 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Get, @"v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"pk_test_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Post, @"^https://api.stripe.com/v1/tokens$"),
+                    new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Post, @"^https://api.stripe.com/v1/tokens$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"id\":\"\"}")
                 )
             });
@@ -199,11 +198,11 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Get, @"v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"pk_test_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Post, @"^https://api.stripe.com/v1/tokens$"),
+                    new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Post, @"^https://api.stripe.com/v1/tokens$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.NotFound, content: "{}")
                 )
             });
@@ -220,11 +219,11 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Get, @"v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"pk_test_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Post, @"^https://api.stripe.com/v1/tokens$"),
+                    new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Post, @"^https://api.stripe.com/v1/tokens$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"not_id\":\"random\"}")
                 )
             });
@@ -241,15 +240,15 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Get, @"v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"pk_test_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Post, @"^https://api.stripe.com/v1/tokens$"),
+                    new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Post, @"^https://api.stripe.com/v1/tokens$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"id\":\"tok_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Post, @"^v2\/credit_cards$"),
+                    new TestUtils.MockRequestMatchRules(Utilities.Http.Method.Post, @"v2\/credit_cards$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.NotFound, content: "{}")
                 )
             });

--- a/EasyPost.Tests/UtilitiesTests/HttpTest.cs
+++ b/EasyPost.Tests/UtilitiesTests/HttpTest.cs
@@ -1,7 +1,7 @@
 using System.Net;
+using System.Net.Http;
 using EasyPost.Tests._Utilities.Annotations;
 using EasyPost.Utilities;
-using RestSharp;
 using Xunit;
 
 namespace EasyPost.Tests.UtilitiesTests
@@ -49,7 +49,7 @@ namespace EasyPost.Tests.UtilitiesTests
         [Testing.Function]
         public void TestStatusCodeChecksRestResponse()
         {
-            RestResponse response = new() { StatusCode = HttpStatusCode.OK };
+            HttpResponseMessage response = new() { StatusCode = HttpStatusCode.OK };
 
             Assert.True(Utilities.Http.StatusCodeBetween(response, 200, 300));
             Assert.True(response.HasStatusCodeBetween(200, 300));

--- a/EasyPost.Tests/packages.lock.json
+++ b/EasyPost.Tests/packages.lock.json
@@ -55,15 +55,6 @@
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
-        "dependencies": {
-          "System.Text.Json": "5.0.0"
-        }
-      },
       "SecurityCodeScan.VS2019": {
         "type": "Direct",
         "requested": "[5.6.6, 6.0.0)",
@@ -201,11 +192,6 @@
         "resolved": "6.0.0",
         "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
-      },
       "xunit.abstractions": {
         "type": "Transitive",
         "resolved": "2.0.3",
@@ -254,8 +240,7 @@
       "easypost": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.1, 14.0.0)",
-          "RestSharp": "[108.0.1, 109.0.0)"
+          "Newtonsoft.Json": "[13.0.1, 14.0.0)"
         }
       }
     },
@@ -320,15 +305,6 @@
         "requested": "[13.0.1, 14.0.0)",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-      },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
-        "dependencies": {
-          "System.Text.Json": "5.0.0"
-        }
       },
       "SecurityCodeScan.VS2019": {
         "type": "Direct",
@@ -471,29 +447,6 @@
         "resolved": "6.0.0",
         "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       },
-      "System.Text.Encodings.Web": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "EEslUvHKll1ftizbn20mX3Ix/l4Ygk/bdJ2LY6/X6FlGaP0RIhKMo9nS6JIGnKKT6KBP2PGj6JC3B9/ZF6ErqQ==",
-        "dependencies": {
-          "System.Memory": "4.5.4"
-        }
-      },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw==",
-        "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
-          "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.4",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "5.0.0",
-          "System.Text.Encodings.Web": "5.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4",
-          "System.ValueTuple": "4.5.0"
-        }
-      },
       "System.Threading.Tasks.Extensions": {
         "type": "Transitive",
         "resolved": "4.5.4",
@@ -550,8 +503,7 @@
       "easypost": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.1, 14.0.0)",
-          "RestSharp": "[108.0.1, 109.0.0)"
+          "Newtonsoft.Json": "[13.0.1, 14.0.0)"
         }
       }
     },
@@ -608,15 +560,6 @@
         "requested": "[13.0.1, 14.0.0)",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-      },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
-        "dependencies": {
-          "System.Text.Json": "5.0.0"
-        }
       },
       "SecurityCodeScan.VS2019": {
         "type": "Direct",
@@ -754,11 +697,6 @@
         "resolved": "6.0.0",
         "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
-      },
       "xunit.abstractions": {
         "type": "Transitive",
         "resolved": "2.0.3",
@@ -807,8 +745,7 @@
       "easypost": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.1, 14.0.0)",
-          "RestSharp": "[108.0.1, 109.0.0)"
+          "Newtonsoft.Json": "[13.0.1, 14.0.0)"
         }
       }
     },
@@ -866,12 +803,6 @@
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA=="
-      },
       "SecurityCodeScan.VS2019": {
         "type": "Direct",
         "requested": "[5.6.6, 6.0.0)",
@@ -1042,8 +973,7 @@
       "easypost": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.1, 14.0.0)",
-          "RestSharp": "[108.0.1, 109.0.0)"
+          "Newtonsoft.Json": "[13.0.1, 14.0.0)"
         }
       }
     },
@@ -1101,12 +1031,6 @@
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA=="
-      },
       "SecurityCodeScan.VS2019": {
         "type": "Direct",
         "requested": "[5.6.6, 6.0.0)",
@@ -1277,8 +1201,7 @@
       "easypost": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.1, 14.0.0)",
-          "RestSharp": "[108.0.1, 109.0.0)"
+          "Newtonsoft.Json": "[13.0.1, 14.0.0)"
         }
       }
     }

--- a/EasyPost/BetaClient.cs
+++ b/EasyPost/BetaClient.cs
@@ -21,6 +21,8 @@ namespace EasyPost
          * When you are migrating a service from beta to general, you should remove/change the overrideApiVersion parameter from each function that is being migrated.
          */
 
+        // TODO: ^ Undo above, set api version as a client config and lock this client (and its services) to that version
+
         /// <summary>
         ///     Constructor for the EasyPost beta client.
         /// </summary>

--- a/EasyPost/Client.cs
+++ b/EasyPost/Client.cs
@@ -1,10 +1,11 @@
+using System;
 using System.Net.Http;
 using EasyPost._base;
 using EasyPost.Services;
 
 namespace EasyPost
 {
-    public class Client : EasyPostClient
+    public class Client : EasyPostClient, IDisposable
     {
         public AddressService Address => GetService<AddressService>();
 
@@ -64,6 +65,18 @@ namespace EasyPost
         {
             // We go ahead and initialize the Beta client internally here as well, since initializing a new one on each property call is expensive and causes lockups with the HttpClient library.
             Beta = new BetaClient(apiKey, baseUrl, customHttpClient);
+        }
+
+        public void Dispose()
+        {
+            // Dispose of the Beta client as well.
+            Beta.Dispose();
+
+            // Dispose of the base client.
+            base.Dispose();
+
+            // TODO: Null out the services once they are redesigned to be initialized by the constructor (private setters).
+
         }
     }
 }

--- a/EasyPost/EasyPost.csproj
+++ b/EasyPost/EasyPost.csproj
@@ -49,7 +49,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="[13.0.1, 14.0.0)"/>
-    <PackageReference Include="RestSharp" Version="[108.0.1, 109.0.0)"/>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\README.md">

--- a/EasyPost/Http/ClientConfiguration.cs
+++ b/EasyPost/Http/ClientConfiguration.cs
@@ -61,26 +61,12 @@ namespace EasyPost.Http
         private int? _connectTimeoutMilliseconds;
 
         /// <summary>
-        ///     The request timeout in milliseconds set by the user.
-        /// </summary>
-        private int? _requestTimeoutMilliseconds;
-
-        /// <summary>
         ///     The connect timeout in milliseconds.
         /// </summary>
         public int ConnectTimeoutMilliseconds
         {
             get => _connectTimeoutMilliseconds ?? Defaults.DefaultConnectTimeoutMilliseconds;
             set => _connectTimeoutMilliseconds = value;
-        }
-
-        /// <summary>
-        ///     The request timeout in milliseconds.
-        /// </summary>
-        public int RequestTimeoutMilliseconds
-        {
-            get => _requestTimeoutMilliseconds ?? Defaults.DefaultRequestTimeoutMilliseconds;
-            set => _requestTimeoutMilliseconds = value;
         }
 
         /*
@@ -94,12 +80,10 @@ namespace EasyPost.Http
         /// </summary>
         /// <param name="apiKey">The API key to use for the client connection.</param>
         /// <param name="baseUrl">Base URL to use with this client. This will override `apiVersion`</param>
-        /// <param name="customHttpClient">The custom HTTP client to use for the client connection.</param>
-        internal ClientConfiguration(string apiKey, string? baseUrl, HttpClient? customHttpClient = null)
+        internal ClientConfiguration(string apiKey, string? baseUrl)
         {
             ApiKey = apiKey;
             ApiBase = baseUrl ?? Defaults.DefaultBaseUrl;
-            HttpClient = customHttpClient;
 
             _libraryVersion = RuntimeInfo.ApplicationInfo.ApplicationVersion;
             _dotNetVersion = RuntimeInfo.ApplicationInfo.DotNetVersion;
@@ -119,11 +103,6 @@ namespace EasyPost.Http
             ///     The default connection timeout in milliseconds.
             /// </summary>
             internal const int DefaultConnectTimeoutMilliseconds = 30000;
-
-            /// <summary>
-            ///     The default request timeout in milliseconds.
-            /// </summary>
-            internal const int DefaultRequestTimeoutMilliseconds = 60000;
         }
 
         public override bool Equals(object? obj)

--- a/EasyPost/Http/Request.cs
+++ b/EasyPost/Http/Request.cs
@@ -1,59 +1,59 @@
+using System;
 using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
 using EasyPost._base;
 using EasyPost.Utilities;
-using RestSharp;
-using RestSharp.Serializers;
 
 namespace EasyPost.Http
 {
     internal class Request
     {
-        public readonly string? RootElement;
+        private readonly HttpRequestMessage _requestMessage;
+
+        private readonly Utilities.Http.Method _method;
 
         private readonly Dictionary<string, object> _parameters;
-        private readonly RestRequest _restRequest;
 
         // ReSharper disable once SuggestBaseTypeForParameterInConstructor
-        public Request(string endpoint, Method method, ApiVersion apiVersion, Dictionary<string, object>? parameters = null, string? rootElement = null)
+        internal Request(string domain, string endpoint, Utilities.Http.Method method, ApiVersion apiVersion, Dictionary<string, object>? parameters = null, Dictionary<string, string>? headers = null, string? rootElement = null)
         {
-            endpoint = $"{apiVersion.Value}/{endpoint}";
+            _method = method;
 
-            _restRequest = new RestRequest(endpoint, method);
-
+            Uri url = new Uri($"{domain}/{apiVersion.Value}/{endpoint}");
+            _requestMessage = new HttpRequestMessage(_method.HttpMethod, url);
             _parameters = parameters ?? new Dictionary<string, object>();
+        }
 
-            RootElement = rootElement;
+        internal HttpRequestMessage AsHttpRequestMessage()
+        {
+            // wait until the last possible moment to set the content
+            BuildParameters();
+
+            return _requestMessage;
         }
 
         /// <summary>
         ///     Build the request parameters.
         /// </summary>
-        internal void BuildParameters()
+        private void BuildParameters()
         {
             if (_parameters.Count == 0)
             {
                 return;
             }
 
-            switch (_restRequest.Method)
+            var @switch = new SwitchCase
             {
-                case Method.Get:
-                case Method.Delete:
-                    BuildQueryParameters();
-                    break;
-                case Method.Post:
-                case Method.Put:
-                case Method.Patch:
-                    BuildBodyParameters();
-                    break;
-                case Method.Head:
-                case Method.Options:
-                case Method.Merge:
-                case Method.Copy:
-                case Method.Search:
-                default:
-                    break;
-            }
+                // equality of two HttpMethod objects falls back to their inner strings, so we can compare these objects directly
+                { Utilities.Http.Method.Get.HttpMethod, BuildQueryParameters },
+                { Utilities.Http.Method.Delete.HttpMethod, BuildQueryParameters },
+                { Utilities.Http.Method.Post.HttpMethod, BuildBodyParameters },
+                { Utilities.Http.Method.Put.HttpMethod, BuildBodyParameters },
+                { Utilities.Http.Method.Patch.HttpMethod, BuildBodyParameters }
+            };
+
+            @switch.MatchFirst(_method.HttpMethod);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace EasyPost.Http
         private void BuildBodyParameters()
         {
             string body = JsonSerialization.ConvertObjectToJson(_parameters);
-            _restRequest.AddStringBody(body, ContentType.Json);
+            _requestMessage.Content = new StringContent(body, Encoding.UTF8, "application/json");
         }
 
         /// <summary>
@@ -70,6 +70,8 @@ namespace EasyPost.Http
         /// </summary>
         private void BuildQueryParameters()
         {
+            // add query parameters
+            var query = new StringBuilder();
             foreach (KeyValuePair<string, object> pair in _parameters)
             {
                 // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
@@ -78,10 +80,14 @@ namespace EasyPost.Http
                     continue;
                 }
 
-                _restRequest.AddParameter(pair.Key, pair.Value, ParameterType.QueryString);
+                query.Append($"{pair.Key}={pair.Value}&");
             }
-        }
 
-        public static explicit operator RestRequest(Request request) => request._restRequest;
+            // remove last '&'
+            query.Remove(query.Length - 1, 1);
+
+            // add query to request uri
+            _requestMessage.RequestUri = new Uri($"{_requestMessage.RequestUri}?{query}");
+        }
     }
 }

--- a/EasyPost/Models/API/Address.cs
+++ b/EasyPost/Models/API/Address.cs
@@ -5,7 +5,6 @@ using EasyPost.Exceptions.General;
 using EasyPost.Models.Shared;
 using EasyPost.Utilities.Annotations;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -68,7 +67,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, "Id");
             }
 
-            await Update<Address>(Method.Get, $"addresses/{Id}/verify", null, "address");
+            await Update<Address>(Utilities.Http.Method.Get, $"addresses/{Id}/verify", null, "address");
             return this;
         }
 

--- a/EasyPost/Models/API/Batch.cs
+++ b/EasyPost/Models/API/Batch.cs
@@ -5,7 +5,6 @@ using EasyPost._base;
 using EasyPost.Models.Shared;
 using EasyPost.Utilities.Annotations;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -48,7 +47,7 @@ namespace EasyPost.Models.API
         public async Task<Batch> AddShipments(Dictionary<string, object> parameters)
         {
             // parameters = parameters.Wrap("batch");  // TODO: Update docs to remove wrapped "batch" key
-            await Update<Batch>(Method.Post, $"batches/{Id}/add_shipments", parameters);
+            await Update<Batch>(Utilities.Http.Method.Post, $"batches/{Id}/add_shipments", parameters);
             return this;
         }
 
@@ -80,7 +79,7 @@ namespace EasyPost.Models.API
         [CrudOperations.Update]
         public async Task<Batch> Buy()
         {
-            await Update<Batch>(Method.Post, $"batches/{Id}/buy");
+            await Update<Batch>(Utilities.Http.Method.Post, $"batches/{Id}/buy");
             return this;
         }
 
@@ -92,7 +91,7 @@ namespace EasyPost.Models.API
         public async Task<Batch> GenerateLabel(string fileFormat = "pdf") // TODO: Remove default value (breaking change)
         {
             Dictionary<string, object> parameters = new Dictionary<string, object> { { "file_format", fileFormat } };
-            await Update<Batch>(Method.Post, $"batches/{Id}/label", parameters);
+            await Update<Batch>(Utilities.Http.Method.Post, $"batches/{Id}/label", parameters);
             return this;
         }
 
@@ -104,7 +103,7 @@ namespace EasyPost.Models.API
         public async Task<Batch> GenerateScanForm(string fileFormat = "pdf") // TODO: Remove default value (breaking change)
         {
             Dictionary<string, object> parameters = new Dictionary<string, object> { { "file_format", fileFormat } };
-            await Update<Batch>(Method.Post, $"batches/{Id}/scan_form", parameters);
+            await Update<Batch>(Utilities.Http.Method.Post, $"batches/{Id}/scan_form", parameters);
             return this;
         }
 
@@ -116,7 +115,7 @@ namespace EasyPost.Models.API
         public async Task<Batch> RemoveShipments(Dictionary<string, object> parameters)
         {
             // parameters = parameters.Wrap("batch");  // TODO: Update docs to remove wrapped "batch" key
-            await Update<Batch>(Method.Post, $"batches/{Id}/remove_shipments", parameters);
+            await Update<Batch>(Utilities.Http.Method.Post, $"batches/{Id}/remove_shipments", parameters);
             return this;
         }
 

--- a/EasyPost/Models/API/CarrierAccount.cs
+++ b/EasyPost/Models/API/CarrierAccount.cs
@@ -5,7 +5,6 @@ using EasyPost._base;
 using EasyPost.Http;
 using EasyPost.Utilities.Annotations;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -45,7 +44,7 @@ namespace EasyPost.Models.API
         public async Task<CarrierAccount> Update(Dictionary<string, object> parameters)
         {
             parameters = parameters.Wrap("carrier_account");
-            await Update<CarrierAccount>(Method.Patch, $"carrier_accounts/{Id}", parameters);
+            await Update<CarrierAccount>(Utilities.Http.Method.Patch, $"carrier_accounts/{Id}", parameters);
             return this;
         }
 

--- a/EasyPost/Models/API/EndShipper.cs
+++ b/EasyPost/Models/API/EndShipper.cs
@@ -5,7 +5,6 @@ using EasyPost.Http;
 using EasyPost.Models.Shared;
 using EasyPost.Utilities.Annotations;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -56,7 +55,7 @@ namespace EasyPost.Models.API
             parameters = parameters.Wrap("address");
 
             // EndShipper needs Put, not Patch
-            await Update<EndShipper>(Method.Put, $"end_shippers/{Id}", parameters);
+            await Update<EndShipper>(Utilities.Http.Method.Put, $"end_shippers/{Id}", parameters);
             return this;
         }
 

--- a/EasyPost/Models/API/Insurance.cs
+++ b/EasyPost/Models/API/Insurance.cs
@@ -5,7 +5,6 @@ using EasyPost._base;
 using EasyPost.Models.Shared;
 using EasyPost.Utilities.Annotations;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -53,7 +52,7 @@ namespace EasyPost.Models.API
         [Obsolete("Use the Retrieve method instead. This method will be removed in a future version.")]
         public async Task<Insurance> Refresh(Dictionary<string, object>? parameters = null)
         {
-            await Update<Insurance>(Method.Get, $"insurances/{Id}");
+            await Update<Insurance>(Utilities.Http.Method.Get, $"insurances/{Id}");
             return this;
         }
 

--- a/EasyPost/Models/API/Order.cs
+++ b/EasyPost/Models/API/Order.cs
@@ -4,7 +4,6 @@ using EasyPost._base;
 using EasyPost.Exceptions.General;
 using EasyPost.Utilities.Annotations;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -64,7 +63,7 @@ namespace EasyPost.Models.API
                 { "service", withService }
             };
 
-            await Update<Order>(Method.Post, $"orders/{Id}/buy", parameters);
+            await Update<Order>(Utilities.Http.Method.Post, $"orders/{Id}/buy", parameters);
             return this;
         }
 
@@ -100,7 +99,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, "Id");
             }
 
-            await Update<Order>(Method.Get, $"orders/{Id}/rates");
+            await Update<Order>(Utilities.Http.Method.Get, $"orders/{Id}/rates");
         }
 
         #endregion

--- a/EasyPost/Models/API/Pickup.cs
+++ b/EasyPost/Models/API/Pickup.cs
@@ -6,7 +6,6 @@ using EasyPost._base;
 using EasyPost.Exceptions.General;
 using EasyPost.Utilities.Annotations;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -75,7 +74,7 @@ namespace EasyPost.Models.API
                 { "service", withService }
             };
 
-            await Update<Pickup>(Method.Post, $"pickups/{Id}/buy", parameters);
+            await Update<Pickup>(Utilities.Http.Method.Post, $"pickups/{Id}/buy", parameters);
             return this;
         }
 
@@ -90,7 +89,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, "Id");
             }
 
-            await Update<Pickup>(Method.Post, $"pickups/{Id}/cancel");
+            await Update<Pickup>(Utilities.Http.Method.Post, $"pickups/{Id}/cancel");
             return this;
         }
 

--- a/EasyPost/Models/API/Shipment.cs
+++ b/EasyPost/Models/API/Shipment.cs
@@ -5,7 +5,6 @@ using EasyPost.Exceptions.General;
 using EasyPost.Models.Shared;
 using EasyPost.Utilities.Annotations;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -92,7 +91,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, "Id");
             }
 
-            return await Request<List<Smartrate>>(Method.Get, $"shipments/{Id}/smartrate", null, "result");
+            return await Request<List<Smartrate>>(Utilities.Http.Method.Get, $"shipments/{Id}/smartrate", null, "result");
         }
 
         /// <summary>
@@ -128,7 +127,7 @@ namespace EasyPost.Models.API
                 parameters.Add("end_shipper", endShipperId);
             }
 
-            await Update<Shipment>(Method.Post, $"shipments/{Id}/buy", parameters);
+            await Update<Shipment>(Utilities.Http.Method.Post, $"shipments/{Id}/buy", parameters);
         }
 
         /// <summary>
@@ -163,7 +162,7 @@ namespace EasyPost.Models.API
 
             Dictionary<string, object> parameters = new Dictionary<string, object> { { "file_format", fileFormat } };
 
-            await Update<Shipment>(Method.Get, $"shipments/{Id}/label", parameters);
+            await Update<Shipment>(Utilities.Http.Method.Get, $"shipments/{Id}/label", parameters);
             return this;
         }
 
@@ -181,7 +180,7 @@ namespace EasyPost.Models.API
 
             Dictionary<string, object> parameters = new Dictionary<string, object> { { "amount", amount } };
 
-            await Update<Shipment>(Method.Post, $"shipments/{Id}/insure", parameters);
+            await Update<Shipment>(Utilities.Http.Method.Post, $"shipments/{Id}/insure", parameters);
             return this;
         }
 
@@ -196,7 +195,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, "Id");
             }
 
-            await Update<Shipment>(Method.Post, $"shipments/{Id}/refund");
+            await Update<Shipment>(Utilities.Http.Method.Post, $"shipments/{Id}/refund");
             return this;
         }
 
@@ -217,7 +216,7 @@ namespace EasyPost.Models.API
 
             parameters.Add("carbon_offset", withCarbonOffset);
 
-            Shipment shipment = await Request<Shipment>(Method.Post, $"shipments/{Id}/rerate", parameters);
+            Shipment shipment = await Request<Shipment>(Utilities.Http.Method.Post, $"shipments/{Id}/rerate", parameters);
             Rates = shipment.Rates;
         }
 

--- a/EasyPost/Models/API/User.cs
+++ b/EasyPost/Models/API/User.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using EasyPost.Http;
 using EasyPost.Models.Shared;
 using EasyPost.Utilities.Annotations;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -34,7 +33,7 @@ namespace EasyPost.Models.API
         public async Task<Brand> UpdateBrand(Dictionary<string, object> parameters)
         {
             parameters = parameters.Wrap("brand");
-            return await Request<Brand>(Method.Patch, $"users/{Id}/brand", parameters);
+            return await Request<Brand>(Utilities.Http.Method.Patch, $"users/{Id}/brand", parameters);
         }
 
         /// <summary>
@@ -55,7 +54,7 @@ namespace EasyPost.Models.API
         [CrudOperations.Update]
         public async Task<User> Update(Dictionary<string, object> parameters)
         {
-            await Update<User>(Method.Patch, $"users/{Id}", parameters);
+            await Update<User>(Utilities.Http.Method.Patch, $"users/{Id}", parameters);
             return this;
         }
 

--- a/EasyPost/Models/API/Webhook.cs
+++ b/EasyPost/Models/API/Webhook.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.Utilities.Annotations;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -37,7 +36,7 @@ namespace EasyPost.Models.API
         [CrudOperations.Update]
         public async Task<Webhook> Update(Dictionary<string, object>? parameters = null)
         {
-            await Update<Webhook>(Method.Patch, $"webhooks/{Id}", parameters);
+            await Update<Webhook>(Utilities.Http.Method.Patch, $"webhooks/{Id}", parameters);
             return this;
         }
 

--- a/EasyPost/Utilities/Http.cs
+++ b/EasyPost/Utilities/Http.cs
@@ -1,10 +1,26 @@
 using System.Net;
-using RestSharp;
+using System.Net.Http;
 
 namespace EasyPost.Utilities
 {
-    internal static class Http
+    public static class Http
     {
+        public class Method
+        {
+            internal HttpMethod HttpMethod { get; }
+
+            public static readonly Method Get = new Method(HttpMethod.Get);
+            public static readonly Method Post = new Method(HttpMethod.Post);
+            public static readonly Method Put = new Method(HttpMethod.Put);
+            public static readonly Method Delete = new Method(HttpMethod.Delete);
+            public static readonly Method Patch = new Method(new HttpMethod("PATCH"));
+
+            private Method(HttpMethod httpMethod)
+            {
+                HttpMethod = httpMethod;
+            }
+        }
+
         /// <summary>
         ///     Return whether the given response has a status code in the given range.
         /// </summary>
@@ -12,7 +28,7 @@ namespace EasyPost.Utilities
         /// <param name="min">Minimum valid status code.</param>
         /// <param name="max">Maximum valid status code.</param>
         /// <returns>Whether the given response has a status code in the given range.</returns>
-        internal static bool HasStatusCodeBetween(this RestResponseBase response, int min, int max)
+        internal static bool HasStatusCodeBetween(this HttpResponseMessage response, int min, int max)
         {
             return StatusCodeBetween(response, min, max);
         }
@@ -84,7 +100,7 @@ namespace EasyPost.Utilities
         /// </summary>
         /// <param name="response">Response to check.</param>
         /// <returns>True if the response code is not in the 200-299 range, false otherwise.</returns>
-        internal static bool ReturnedError(this RestResponse response)
+        internal static bool ReturnedError(this HttpResponseMessage response)
         {
             return !ReturnedNoError(response);
         }
@@ -94,7 +110,7 @@ namespace EasyPost.Utilities
         /// </summary>
         /// <param name="response">Response to check.</param>
         /// <returns>True if the response code is in the 200-299 range, false otherwise.</returns>
-        internal static bool ReturnedNoError(this RestResponse response)
+        internal static bool ReturnedNoError(this HttpResponseMessage response)
         {
             return response.StatusCode.Is2xx();
         }
@@ -130,7 +146,7 @@ namespace EasyPost.Utilities
         /// <param name="min">Minimum valid status code.</param>
         /// <param name="max">Maximum valid status code.</param>
         /// <returns>Whether the given response has a status code in the given range.</returns>
-        internal static bool StatusCodeBetween(RestResponseBase response, int min, int max)
+        internal static bool StatusCodeBetween(HttpResponseMessage response, int min, int max)
         {
             return StatusCodeBetween(response.StatusCode, min, max);
         }

--- a/EasyPost/Utilities/JsonSerialization.cs
+++ b/EasyPost/Utilities/JsonSerialization.cs
@@ -2,10 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
 using EasyPost.Exceptions.General;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using RestSharp;
 
 namespace EasyPost.Utilities
 {
@@ -94,10 +95,10 @@ namespace EasyPost.Utilities
         internal static ExpandoObject ConvertJsonToObject(string? data, JsonSerializerSettings? jsonSerializerSettings = null, List<string>? rootElementKeys = null) => ConvertJsonToObject<ExpandoObject>(data, jsonSerializerSettings, rootElementKeys);
 
         /// <summary>
-        ///     Deserialize data from a RestSharp.RestResponse into a T-type object, using this instance's
+        ///     Deserialize data from an HttpResponseMessage e into a T-type object, using this instance's
         ///     <see cref="JsonSerializerSettings" />
         /// </summary>
-        /// <param name="response">RestSharp.RestResponse object to extract data from.</param>
+        /// <param name="response">HttpResponseMessage object to extract data from.</param>
         /// <param name="jsonSerializerSettings">
         ///     The <see cref="Newtonsoft.Json.JsonSerializerSettings" /> to use for
         ///     deserialization. Defaults to <see cref="DefaultJsonSerializerSettings" /> if not provided.
@@ -105,7 +106,7 @@ namespace EasyPost.Utilities
         /// <param name="rootElementKeys">List, in order, of sub-keys path to follow to deserialization starting position.</param>
         /// <typeparam name="T">Type of object to deserialize to</typeparam>
         /// <returns>A T-type object</returns>
-        internal static T ConvertJsonToObject<T>(RestResponse response, JsonSerializerSettings? jsonSerializerSettings = null, List<string>? rootElementKeys = null) => ConvertJsonToObject<T>(response.Content, jsonSerializerSettings, rootElementKeys);
+        internal static async Task<T> ConvertJsonToObject<T>(HttpResponseMessage response, JsonSerializerSettings? jsonSerializerSettings = null, List<string>? rootElementKeys = null) => ConvertJsonToObject<T>(await response.Content.ReadAsStringAsync(), jsonSerializerSettings, rootElementKeys);
 
         /// <summary>
         ///     Serialize an object into a JSON string, using this instance's <see cref="JsonSerializerSettings" />

--- a/EasyPost/_base/EasyPostClient.cs
+++ b/EasyPost/_base/EasyPostClient.cs
@@ -8,18 +8,16 @@ using System.Threading.Tasks;
 using EasyPost.Exceptions.API;
 using EasyPost.Exceptions.General;
 using EasyPost.Http;
-using EasyPost.Models.API;
 using EasyPost.Models.Shared;
 using EasyPost.Utilities;
-using RestSharp;
 
 namespace EasyPost._base
 {
-    public abstract class EasyPostClient
+    public abstract class EasyPostClient: IDisposable
     {
         public readonly ClientConfiguration Configuration;
 
-        private readonly RestClient _restClient;
+        private readonly HttpClient _httpClient;
 
         /// <summary>
         ///     Constructor for the EasyPost client.
@@ -27,49 +25,30 @@ namespace EasyPost._base
         /// <param name="apiKey">API key to use with this client.</param>
         /// <param name="baseUrl">Base URL to use with this client. This will override `apiVersion`</param>
         /// <param name="customHttpClient">
-        ///     Custom HttpClient to pass into RestSharp if needed. Mostly for debug purposes, not
+        ///     Custom HttpClient to use if needed. Mostly for debug purposes, not
         ///     advised for general use.
         /// </param>
         protected EasyPostClient(string apiKey, string? baseUrl = null, HttpClient? customHttpClient = null)
         {
             ServicePointManager.SecurityProtocol |= Security.GetProtocol();
-            Configuration = new ClientConfiguration(apiKey, baseUrl, customHttpClient);
+            Configuration = new ClientConfiguration(apiKey, baseUrl);
 
-            RestClientOptions clientOptions = new RestClientOptions
-            {
-                MaxTimeout = Configuration.ConnectTimeoutMilliseconds,
-                BaseUrl = new Uri(Configuration.ApiBase),
-                UserAgent = Configuration.UserAgent
-            };
-
-            _restClient = Configuration.HttpClient != null ? new RestClient(Configuration.HttpClient, clientOptions) : new RestClient(clientOptions);
+            _httpClient = customHttpClient ?? new HttpClient();
+            _httpClient.DefaultRequestHeaders.Add("User-Agent", Configuration.UserAgent); // we set the user agent here once so it's not needlessly calculated for every request
+            _httpClient.Timeout = new TimeSpan(0, 0, 0, 0, milliseconds: Configuration.ConnectTimeoutMilliseconds); // set the default timeout for the client
         }
 
         /// <summary>
         ///     Execute an HTTP request.
         /// </summary>
         /// <param name="request">Request to execute</param>
-        /// <typeparam name="T">Type of object to serialize response into.</typeparam>
-        /// <returns>A RestResponse containing a T-type object.</returns>
-        internal virtual async Task<RestResponse<T>> ExecuteRequest<T>(RestRequest request)
+        /// <returns>An HttpResponseMessage object.</returns>
+        internal virtual async Task<HttpResponseMessage> ExecuteRequest(HttpRequestMessage request)
         {
             // This method actually executes the request and returns the response.
             // Everything up to this point has been pre-request, and everything after this point is post-request.
             // This method is "virtual" so it can be overriden (i.e. by a MockClient in testing to avoid making actual HTTP requests).
-            return await _restClient.ExecuteAsync<T>(request);
-        }
-
-        /// <summary>
-        ///     Execute an HTTP request.
-        /// </summary>
-        /// <param name="request">Request to execute</param>
-        /// <returns>A RestResponse object.</returns>
-        internal virtual async Task<RestResponse> ExecuteRequest(RestRequest request)
-        {
-            // This method actually executes the request and returns the response.
-            // Everything up to this point has been pre-request, and everything after this point is post-request.
-            // This method is "virtual" so it can be overriden (i.e. by a MockClient in testing to avoid making actual HTTP requests).
-            return await _restClient.ExecuteAsync(request);
+            return await _httpClient.SendAsync(request);
         }
 
         /// <summary>
@@ -77,30 +56,35 @@ namespace EasyPost._base
         /// </summary>
         /// <typeparam name="T">Type of object to deserialize response data into. Must be subclass of EasyPostObject.</typeparam>
         /// <returns>An instance of a T type object.</returns>
-        internal async Task<T> Request<T>(Method method, string url, ApiVersion apiVersion, Dictionary<string, object>? parameters = null, string? rootElement = null) where T : class
+        internal async Task<T> Request<T>(Utilities.Http.Method method, string endpoint, ApiVersion apiVersion, Dictionary<string, object>? parameters = null, string? rootElement = null) where T : class
         {
             // Build the request
-            Request request = new Request(url, method, apiVersion, parameters, rootElement);
-            RestRequest restRequest = PrepareRequest(request);
+            var headers = new Dictionary<string, string>
+            {
+                // User-Agent is already set as a default header for the HttpClient
+                { "Authorization", $"Bearer {Configuration.ApiKey}" },
+                { "Content-Type", "application/json" }
+            };
+            Request request = new Request(Configuration.ApiBase, endpoint, method, apiVersion, parameters, headers);
 
             // Execute the request
-            RestResponse<T> response = await ExecuteRequest<T>(restRequest);
+            HttpResponseMessage response = await ExecuteRequest(request.AsHttpRequestMessage());
 
             // Check the response's status code
             if (response.ReturnedError())
             {
-                throw ApiError.FromErrorResponse(response);
+                throw await ApiError.FromErrorResponse(response);
             }
 
             // Prepare the list of root elements to use during deserialization
             List<string>? rootElements = null;
-            if (request.RootElement != null)
+            if (rootElement != null)
             {
-                rootElements = new List<string> { request.RootElement };
+                rootElements = new List<string> { rootElement };
             }
 
             // Deserialize the response into an object
-            T resource = JsonSerialization.ConvertJsonToObject<T>(response, null, rootElements);
+            T resource = await JsonSerialization.ConvertJsonToObject<T>(response, null, rootElements);
 
             if (resource is null)
             {
@@ -111,6 +95,28 @@ namespace EasyPost._base
             PassClientToEasyPostObject(resource);
 
             return resource;
+        }
+
+        /// <summary>
+        ///     Execute a request against the EasyPost API.
+        /// </summary>
+        /// <returns>Whether request was successful.</returns>
+        internal async Task<bool> Request(Utilities.Http.Method method, string endpoint, ApiVersion apiVersion, Dictionary<string, object>? parameters = null)
+        {
+            // Build the request
+            var headers = new Dictionary<string, string>
+            {
+                // User-Agent is already set as a default header for the HttpClient
+                { "Authorization", $"Bearer {Configuration.ApiKey}" },
+                { "Content-Type", "application/json" }
+            };
+            Request request = new Request(Configuration.ApiBase, endpoint, method, apiVersion, parameters, headers);
+
+            // Execute the request
+            HttpResponseMessage response = await ExecuteRequest(request.AsHttpRequestMessage());
+
+            // Return whether the HTTP request produced an error (3xx, 4xx or 5xx status code) or not
+            return response.ReturnedNoError();
         }
 
         private void PassClientToAllEasyPostObjectProperties<T>(T? resource) where T : EasyPostObject
@@ -168,24 +174,6 @@ namespace EasyPost._base
         }
 
         /// <summary>
-        ///     Execute a request against the EasyPost API.
-        /// </summary>
-        /// <returns>Whether request was successful.</returns>
-        internal async Task<bool> Request(Method method, string url, ApiVersion apiVersion, Dictionary<string, object>? parameters = null)
-        {
-            // Build the request
-            Request request = new Request(url, method, apiVersion, parameters);
-            RestRequest restRequest = PrepareRequest(request);
-
-            // Execute the request
-            // RestSharp does not throw exception directly (https://restsharp.dev/error-handling.html), we'll need to check the response status code
-            RestResponse response = await ExecuteRequest(restRequest);
-
-            // Return whether the HTTP request produced an error (3xx, 4xx or 5xx status code) or not
-            return response.ReturnedNoError();
-        }
-
-        /// <summary>
         ///     Get a service instance.
         /// </summary>
         /// <typeparam name="T">Type of service class to instantiate.</typeparam>
@@ -195,23 +183,6 @@ namespace EasyPost._base
             // construct a new service
             var cons = typeof(T).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance);
             return (T)cons[0].Invoke(new object[] { this });
-        }
-
-        /// <summary>
-        ///     Prepare a request for execution by attaching required headers.
-        /// </summary>
-        /// <param name="request">EasyPost.Request object instance to prepare.</param>
-        /// <returns>RestSharp.RestRequest object instance to execute.</returns>
-        private RestRequest PrepareRequest(Request request)
-        {
-            request.BuildParameters();
-
-            RestRequest restRequest = (RestRequest)request;
-            restRequest.Timeout = Configuration.RequestTimeoutMilliseconds;
-            restRequest.AddHeader("authorization", $"Bearer {Configuration.ApiKey}");
-            restRequest.AddHeader("content_type", "application/json");
-
-            return restRequest;
         }
 
         public override bool Equals(object? obj) => obj is EasyPostClient client && Configuration.Equals(client.Configuration);
@@ -246,9 +217,10 @@ namespace EasyPost._base
 
             // We need to manually copy over other configuration options
             clone.Configuration.ConnectTimeoutMilliseconds = Configuration.ConnectTimeoutMilliseconds;
-            clone.Configuration.RequestTimeoutMilliseconds = Configuration.RequestTimeoutMilliseconds;
 
             return clone;
         }
+
+        public void Dispose() => _httpClient.Dispose();
     }
 }

--- a/EasyPost/_base/EasyPostObject.cs
+++ b/EasyPost/_base/EasyPostObject.cs
@@ -6,7 +6,6 @@ using System.Reflection;
 using System.Threading.Tasks;
 using EasyPost.Utilities;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost._base
 {
@@ -80,7 +79,7 @@ namespace EasyPost._base
         /// <param name="rootElement">Root element of JSON returned by update call.</param>
         /// <param name="overrideApiVersion">Override the API version used for update call.</param>
         /// <typeparam name="T">Type of object to update.</typeparam>
-        protected async Task Update<T>(Method method, string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class
+        protected async Task Update<T>(Utilities.Http.Method method, string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class
         {
             T updatedObject = await Request<T>(method, url, parameters, rootElement, overrideApiVersion);
 

--- a/EasyPost/_base/WithClient.cs
+++ b/EasyPost/_base/WithClient.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using EasyPost.Utilities.Annotations;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost._base
 {
@@ -12,22 +11,22 @@ namespace EasyPost._base
         internal EasyPostClient? Client { get; set; }
 
         [CrudOperations.Create]
-        protected async Task<T> Create<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class => await Request<T>(Method.Post, url, parameters, rootElement, overrideApiVersion);
+        protected async Task<T> Create<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class => await Request<T>(Utilities.Http.Method.Post, url, parameters, rootElement, overrideApiVersion);
 
         [CrudOperations.Create]
-        protected async Task CreateNoResponse(string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Request(Method.Post, url, parameters, overrideApiVersion);
+        protected async Task CreateNoResponse(string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Request(Utilities.Http.Method.Post, url, parameters, overrideApiVersion);
 
         [CrudOperations.Delete]
-        protected async Task<T> Delete<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class => await Request<T>(Method.Delete, url, parameters, rootElement, overrideApiVersion);
+        protected async Task<T> Delete<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class => await Request<T>(Utilities.Http.Method.Delete, url, parameters, rootElement, overrideApiVersion);
 
         [CrudOperations.Delete]
-        protected async Task DeleteNoResponse(string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Request(Method.Delete, url, parameters, overrideApiVersion);
+        protected async Task DeleteNoResponse(string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Request(Utilities.Http.Method.Delete, url, parameters, overrideApiVersion);
 
         [CrudOperations.Read]
-        protected async Task<T> Get<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class => await Request<T>(Method.Get, url, parameters, rootElement, overrideApiVersion);
+        protected async Task<T> Get<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class => await Request<T>(Utilities.Http.Method.Get, url, parameters, rootElement, overrideApiVersion);
 
         [CrudOperations.Read]
-        protected async Task<T> List<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class => await Request<T>(Method.Get, url, parameters, rootElement, overrideApiVersion);
+        protected async Task<T> List<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class => await Request<T>(Utilities.Http.Method.Get, url, parameters, rootElement, overrideApiVersion);
 
 
         /// <summary>
@@ -40,7 +39,7 @@ namespace EasyPost._base
         /// <param name="overrideApiVersion">Override API version hit for HTTP request. Defaults to general availability.</param>
         /// <typeparam name="T">Type of object to return from request.</typeparam>
         /// <returns>A T-type object.</returns>
-        protected async Task<T> Request<T>(Method method, string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class => await Client!.Request<T>(method, url, overrideApiVersion ?? ApiVersion.Current, parameters, rootElement);
+        protected async Task<T> Request<T>(Utilities.Http.Method method, string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class => await Client!.Request<T>(method, url, overrideApiVersion ?? ApiVersion.Current, parameters, rootElement);
 
         /// <summary>
         ///     Make an HTTP request to the EasyPost API.
@@ -50,12 +49,12 @@ namespace EasyPost._base
         /// <param name="parameters">Optional parameters to include in the request.</param>
         /// <param name="overrideApiVersion">Override API version hit for HTTP request. Defaults to general availability.</param>
         /// <returns>None</returns>
-        protected async Task Request(Method method, string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Client!.Request(method, url, overrideApiVersion ?? ApiVersion.Current, parameters);
+        protected async Task Request(Utilities.Http.Method method, string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Client!.Request(method, url, overrideApiVersion ?? ApiVersion.Current, parameters);
 
         [CrudOperations.Update]
-        protected async Task<T> Update<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class => await Request<T>(Method.Patch, url, parameters, rootElement, overrideApiVersion);
+        protected async Task<T> Update<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null) where T : class => await Request<T>(Utilities.Http.Method.Patch, url, parameters, rootElement, overrideApiVersion);
 
         [CrudOperations.Update]
-        protected async Task UpdateNoResponse(string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Request(Method.Patch, url, parameters, overrideApiVersion);
+        protected async Task UpdateNoResponse(string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Request(Utilities.Http.Method.Patch, url, parameters, overrideApiVersion);
     }
 }

--- a/EasyPost/packages.lock.json
+++ b/EasyPost/packages.lock.json
@@ -7,20 +7,6 @@
         "requested": "[13.0.1, 14.0.0)",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-      },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
-        "dependencies": {
-          "System.Text.Json": "5.0.0"
-        }
-      },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
       }
     },
     ".NETStandard,Version=v2.0": {
@@ -39,82 +25,10 @@
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
-        "dependencies": {
-          "System.Text.Json": "5.0.0"
-        }
-      },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
-        "dependencies": {
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
         "resolved": "1.1.0",
         "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
-      },
-      "System.Buffers": {
-        "type": "Transitive",
-        "resolved": "4.5.1",
-        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
-      },
-      "System.Memory": {
-        "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw==",
-        "dependencies": {
-          "System.Buffers": "4.5.1",
-          "System.Numerics.Vectors": "4.4.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
-        }
-      },
-      "System.Numerics.Vectors": {
-        "type": "Transitive",
-        "resolved": "4.5.0",
-        "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
-      },
-      "System.Runtime.CompilerServices.Unsafe": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZD9TMpsmYJLrxbbmdvhwt9YEgG5WntEnZ/d1eH8JBX9LBp+Ju8BSBhUGbZMNVHHomWo2KVImJhTDl2hIgw/6MA=="
-      },
-      "System.Text.Encodings.Web": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "EEslUvHKll1ftizbn20mX3Ix/l4Ygk/bdJ2LY6/X6FlGaP0RIhKMo9nS6JIGnKKT6KBP2PGj6JC3B9/ZF6ErqQ==",
-        "dependencies": {
-          "System.Memory": "4.5.4"
-        }
-      },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw==",
-        "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
-          "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.4",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "5.0.0",
-          "System.Text.Encodings.Web": "5.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
-      "System.Threading.Tasks.Extensions": {
-        "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
-        }
       }
     },
     ".NETCoreApp,Version=v5.0": {
@@ -123,20 +37,6 @@
         "requested": "[13.0.1, 14.0.0)",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-      },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
-        "dependencies": {
-          "System.Text.Json": "5.0.0"
-        }
-      },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
       }
     },
     "net6.0": {
@@ -145,12 +45,6 @@
         "requested": "[13.0.1, 14.0.0)",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-      },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA=="
       }
     },
     "net7.0": {
@@ -159,12 +53,6 @@
         "requested": "[13.0.1, 14.0.0)",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-      },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA=="
       }
     }
   }


### PR DESCRIPTION
# Description

Inspired by some old issues on this repo (one in particular that I can't seem to find re: our old singleton client re-initializing and exhausting resources) and some personal research on the topic, this is a proposed improvement to our client library's HTTP capabilities, primarily by **dropping RestSharp as a dependency**.

RestSharp is arguably an outdated solution to an underdeveloped built-in HTTP client in .NET that, over the years, has seen improvements that make RestSharp almost redundant (the same way that the built-in JSON serialization capabilities will eventually make Newtonsoft irrelevant).

This library especially has evolved to the point that it no longer needs RestSharp. In fact, since implementing a custom JSON serializer several months ago, it wasn't really even using RestSharp for its JSON serialization capabilities, which is really the whole point of RestSharp in the first place. Because of this, it was relatively easy to simply remove RestSharp (which, as of v107, is effectively a wrapper around HttpClient with some additional functionality that we weren't even using) and replace it with a direct HttpClient instead.

This PR:
- Replaces the RestSharp client under-the-hood with an HttpClient
- Replaces all RestSharp abstractions with their HttpClient equivalent
- BREAKING CHANGE: Removes RequestTimeoutMilliseconds (the only valid timeout is ConnectTimeoutMilliseconds)
- Introduces a new Utilities.Http.Method class used to account for PATCH, which is missing in HttpClient in .NET Standard 2.0
- Updates adjacent JSON serialization and request construction classes to account for the RestSharp drop
- Consolidates the request construction logic, combining two needlessly-separate functions into one
- Makes the Client (the user-facing object, not the internal HttpClient) disposable, allowing users to properly dispose of a Client instance for better memory management in their applications.

There are other improvements slated for potential adoption (e.g. [HttpClientFactory](https://learn.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests)) in later PRs.

This change will remove an extraneous dependency, one whose breaking changes [have caused](https://github.com/EasyPost/easypost-csharp/issues/190) [us issues](https://github.com/EasyPost/easypost-csharp/issues/147) [in the past](https://github.com/EasyPost/easypost-csharp/issues/123), and reduce our library to only one external dependency (Newtonsoft.Json, which currently may still be irreplaceable).

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

- All unit tests pass
  - Slight modifications to asserted values, primarily for exception testing due to a slight change to how exception pretty print messages are created.
  - No cassettes needed to be re-recorded, suggesting that the underlying HTTP requests and responses were constructed and recorded the same as when RestSharp was being used.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
