### PR TITLE
Remove inconsistent `HasMore` assertion from unit tests

### DIFF
--- a/EasyPost.Tests.FSharp/packages.lock.json
+++ b/EasyPost.Tests.FSharp/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[7.0.0, )",
-        "resolved": "7.0.0",
-        "contentHash": "xPww0dhsH7o373ZNFY1Y08WRsJJUUzqGk0AIUxxUxSJkWqul0UwCBXg6UmqJX76VdiSvvEXn4SYwX8lYQaZzuQ=="
+        "requested": "[6.0.5, 7.0.0)",
+        "resolved": "6.0.5",
+        "contentHash": "Bpqxoh/UUTq7fHd0a1Ndv/ml1BEtwqmpruKzIMaNnNXgdBSZOEA7wQtoXyc+eKwxq4TQrbHpAbM6yaZAzqotvw=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",

--- a/EasyPost.Tests.FSharp/packages.lock.json
+++ b/EasyPost.Tests.FSharp/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "FSharp.Core": {
         "type": "Direct",
-        "requested": "[6.0.5, 7.0.0)",
-        "resolved": "6.0.5",
-        "contentHash": "Bpqxoh/UUTq7fHd0a1Ndv/ml1BEtwqmpruKzIMaNnNXgdBSZOEA7wQtoXyc+eKwxq4TQrbHpAbM6yaZAzqotvw=="
+        "requested": "[7.0.0, )",
+        "resolved": "7.0.0",
+        "contentHash": "xPww0dhsH7o373ZNFY1Y08WRsJJUUzqGk0AIUxxUxSJkWqul0UwCBXg6UmqJX76VdiSvvEXn4SYwX8lYQaZzuQ=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",

--- a/EasyPost.Tests/ServicesTests/AddressServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/AddressServiceTest.cs
@@ -114,7 +114,6 @@ namespace EasyPost.Tests.ServicesTests
             AddressCollection addressCollection = await Client.Address.All(new Dictionary<string, object> { { "page_size", Fixtures.PageSize } });
             List<Address> addresses = addressCollection.Addresses;
 
-            Assert.True(addressCollection.HasMore);
             Assert.True(addresses.Count <= Fixtures.PageSize);
             foreach (Address item in addresses)
             {

--- a/EasyPost.Tests/ServicesTests/BatchServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/BatchServiceTest.cs
@@ -57,7 +57,6 @@ namespace EasyPost.Tests.ServicesTests
 
             List<Batch> batches = batchCollection.Batches;
 
-            Assert.True(batchCollection.HasMore);
             Assert.True(batches.Count <= Fixtures.PageSize);
             foreach (Batch item in batches)
             {

--- a/EasyPost.Tests/ServicesTests/EndShipperServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/EndShipperServiceTest.cs
@@ -42,7 +42,6 @@ namespace EasyPost.Tests.ServicesTests
             EndShipperCollection endShipperCollection = await Client.EndShipper.All(new Dictionary<string, object> { { "page_size", Fixtures.PageSize } });
             List<EndShipper> endShippers = endShipperCollection.EndShippers;
 
-            Assert.True(endShipperCollection.HasMore);
             Assert.True(endShippers.Count <= Fixtures.PageSize);
             foreach (EndShipper item in endShippers)
             {

--- a/EasyPost.Tests/ServicesTests/EventServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/EventServiceTest.cs
@@ -42,7 +42,6 @@ namespace EasyPost.Tests.ServicesTests
 
             List<Event> events = eventCollection.Events;
 
-            Assert.True(eventCollection.HasMore);
             Assert.True(events.Count <= Fixtures.PageSize);
             foreach (Event item in events)
             {

--- a/EasyPost.Tests/ServicesTests/InsuranceServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/InsuranceServiceTest.cs
@@ -48,7 +48,6 @@ namespace EasyPost.Tests.ServicesTests
 
             List<Insurance> insurances = insuranceCollection.Insurances;
 
-            Assert.True(insuranceCollection.HasMore);
             Assert.True(insurances.Count <= Fixtures.PageSize);
             foreach (Insurance item in insurances)
             {

--- a/EasyPost.Tests/ServicesTests/PartnerServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/PartnerServiceTest.cs
@@ -48,7 +48,6 @@ namespace EasyPost.Tests.ServicesTests
             ReferralCustomerCollection referralCustomerCollection = await Client.Partner.All(new Dictionary<string, object> { { "page_size", Fixtures.PageSize } });
             List<ReferralCustomer> referralCustomers = referralCustomerCollection.ReferralCustomers;
 
-            Assert.True(referralCustomerCollection.HasMore);
             Assert.True(referralCustomers.Count <= Fixtures.PageSize);
             foreach (ReferralCustomer item in referralCustomers)
             {

--- a/EasyPost.Tests/ServicesTests/PickupServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/PickupServiceTest.cs
@@ -66,7 +66,6 @@ namespace EasyPost.Tests.ServicesTests
 
             List<Pickup> pickups = pickupCollection.Pickups;
 
-            Assert.True(pickupCollection.HasMore);
             Assert.True(pickups.Count <= Fixtures.PageSize);
             foreach (Pickup pickup in pickups)
             {

--- a/EasyPost.Tests/ServicesTests/RefundServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/RefundServiceTest.cs
@@ -55,7 +55,6 @@ namespace EasyPost.Tests.ServicesTests
 
             List<Refund> refunds = refundCollection.Refunds;
 
-            Assert.True(refundCollection.HasMore);
             Assert.True(refunds.Count <= Fixtures.PageSize);
             foreach (Refund item in refunds)
             {

--- a/EasyPost.Tests/ServicesTests/ReportServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/ReportServiceTest.cs
@@ -100,7 +100,6 @@ namespace EasyPost.Tests.ServicesTests
 
             List<Report> reports = reportCollection.Reports;
 
-            Assert.True(reportCollection.HasMore);
             Assert.True(reports.Count <= Fixtures.PageSize);
             foreach (Report report in reports)
             {

--- a/EasyPost.Tests/ServicesTests/ScanFormServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/ScanFormServiceTest.cs
@@ -44,7 +44,6 @@ namespace EasyPost.Tests.ServicesTests
 
             List<ScanForm> scanForms = scanFormCollection.ScanForms;
 
-            Assert.True(scanFormCollection.HasMore);
             Assert.True(scanForms.Count <= Fixtures.PageSize);
             foreach (ScanForm scanForm in scanForms)
             {

--- a/EasyPost.Tests/ServicesTests/ShipmentServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/ShipmentServiceTest.cs
@@ -134,7 +134,6 @@ namespace EasyPost.Tests.ServicesTests
 
             List<Shipment> shipments = shipmentCollection.Shipments;
 
-            Assert.True(shipmentCollection.HasMore);
             Assert.True(shipments.Count <= Fixtures.PageSize);
             foreach (Shipment shipment in shipments)
             {

--- a/EasyPost.Tests/ServicesTests/TrackerServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/TrackerServiceTest.cs
@@ -61,7 +61,6 @@ namespace EasyPost.Tests.ServicesTests
 
             List<Tracker> trackers = trackerCollection.Trackers;
 
-            Assert.True(trackerCollection.HasMore);
             Assert.True(trackers.Count <= Fixtures.PageSize);
             foreach (Tracker tracker in trackers)
             {


### PR DESCRIPTION
# Description

- Remove the assertion that `HasMore` for all collection types is "true", since we can't guarantee that the API will always return "true" for the "has_more" key (that a collection has more than one page of results)

# Testing

- Unit tests updated, no re-recording needed

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
