### PR TITLE
[chore] Fix bad anti-pattern

### DIFF
--- a/EasyPost/Services/PickupService.cs
+++ b/EasyPost/Services/PickupService.cs
@@ -76,7 +76,6 @@ namespace EasyPost.Services
         public async Task<PickupCollection> All(Dictionary<string, object>? parameters = null)
         {
             PickupCollection pickupCollection = await List<PickupCollection>("pickups", parameters);
-            pickupCollection.Client = Client;
             return pickupCollection;
         }
 

--- a/EasyPost/Services/ReportService.cs
+++ b/EasyPost/Services/ReportService.cs
@@ -59,7 +59,6 @@ namespace EasyPost.Services
         {
             ReportCollection reportCollection = await List<ReportCollection>($"reports/{type}", parameters);
             reportCollection.Type = type;
-            reportCollection.Client = Client;
             return reportCollection;
         }
 

--- a/EasyPost/Services/ScanFormService.cs
+++ b/EasyPost/Services/ScanFormService.cs
@@ -54,7 +54,6 @@ namespace EasyPost.Services
         public async Task<ScanFormCollection> All(Dictionary<string, object>? parameters = null)
         {
             ScanFormCollection scanFormCollection = await List<ScanFormCollection>("scan_forms", parameters);
-            scanFormCollection.Client = Client;
             return scanFormCollection;
         }
 

--- a/EasyPost/Services/ShipmentService.cs
+++ b/EasyPost/Services/ShipmentService.cs
@@ -74,7 +74,6 @@ namespace EasyPost.Services
         public async Task<ShipmentCollection> All(Dictionary<string, object>? parameters = null)
         {
             ShipmentCollection shipmentCollection = await List<ShipmentCollection>("shipments", parameters);
-            shipmentCollection.Client = Client;
             return shipmentCollection;
         }
 

--- a/EasyPost/Services/TrackerService.cs
+++ b/EasyPost/Services/TrackerService.cs
@@ -77,7 +77,6 @@ namespace EasyPost.Services
         public async Task<TrackerCollection> All(Dictionary<string, object>? parameters = null)
         {
             TrackerCollection trackerCollection = await List<TrackerCollection>("trackers", parameters);
-            trackerCollection.Client = Client;
             return trackerCollection;
         }
 


### PR DESCRIPTION
# Description

This PR removes an inconsistent anti-pattern of storing a copy of the Client used to retrieve an XCollection inside the collection itself.

This was implemented earlier to cater to the initial concept of instance-based functions in the library. While that pattern still exists (for now), this was applied inconsistently. It's not a bug, but we should remove it to avoid unintended consequences.

Upcoming work for getting the next page of a paginated collection will most likely reintroduce this, but holistically.

This is unlikely to introduce a breaking change for end-users (unless they were stepping outside of expected workflow patterns)

# Testing

- No changes to unit tests or functionality

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
