### PR TITLE
[feat] POC: Functionality to get the next page of a paginated collection

### DIFF
--- a/EasyPost.Tests/ServicesTests/AddressServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/AddressServiceTest.cs
@@ -124,6 +124,21 @@ namespace EasyPost.Tests.ServicesTests
         [Fact]
         [CrudOperations.Read]
         [Testing.Function]
+        public async Task TestGetNextPage()
+        {
+            UseVCR("get_next_page");
+
+            AddressCollection addressCollection = await Client.Address.All(new Dictionary<string, object> { { "page_size", Fixtures.PageSize } });
+
+            AddressCollection nextPageAddressCollection = await Client.Address.GetNextPage(addressCollection);
+
+            // If the first ID in the next page is the same as the first ID in the current page, then we didn't get the next page
+            Assert.NotEqual(addressCollection.Addresses[0].Id, nextPageAddressCollection.Addresses[0].Id);
+        }
+
+        [Fact]
+        [CrudOperations.Read]
+        [Testing.Function]
         public async Task TestRetrieve()
         {
             UseVCR("retrieve");

--- a/EasyPost.Tests/ServicesTests/EndShipperServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/EndShipperServiceTest.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using EasyPost.Exceptions.General;
 using EasyPost.Models.API;
 using EasyPost.Tests._Utilities;
 using EasyPost.Tests._Utilities.Attributes;
@@ -48,19 +47,6 @@ namespace EasyPost.Tests.ServicesTests
             {
                 Assert.IsType<EndShipper>(item);
             }
-        }
-
-        [Fact]
-        [CrudOperations.Read]
-        [Testing.Function]
-        public async Task TestGetNextPage()
-        {
-            UseVCR("get_next_page");
-
-            EndShipperCollection endShipperCollection = await Client.EndShipper.All(new Dictionary<string, object> { { "page_size", Fixtures.PageSize } });
-
-            // TODO: Throws an exception currently because the parameter set calculation overload has not been implemented
-            await Assert.ThrowsAsync<EndOfPaginationError>(async () => await Client.EndShipper.GetNextPage(endShipperCollection));
         }
 
         [Fact]

--- a/EasyPost.Tests/ServicesTests/EndShipperServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/EndShipperServiceTest.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using EasyPost.Exceptions.General;
 using EasyPost.Models.API;
 using EasyPost.Tests._Utilities;
 using EasyPost.Tests._Utilities.Attributes;
@@ -47,6 +48,19 @@ namespace EasyPost.Tests.ServicesTests
             {
                 Assert.IsType<EndShipper>(item);
             }
+        }
+
+        [Fact]
+        [CrudOperations.Read]
+        [Testing.Function]
+        public async Task TestGetNextPage()
+        {
+            UseVCR("get_next_page");
+
+            EndShipperCollection endShipperCollection = await Client.EndShipper.All(new Dictionary<string, object> { { "page_size", Fixtures.PageSize } });
+
+            // TODO: Throws an exception currently because the parameter set calculation overload has not been implemented
+            await Assert.ThrowsAsync<EndOfPaginationError>(async () => await Client.EndShipper.GetNextPage(endShipperCollection));
         }
 
         [Fact]

--- a/EasyPost.Tests/ServicesTests/ServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/ServiceTest.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using EasyPost.Exceptions.General;
+using EasyPost.Models.API;
+using EasyPost.Tests._Utilities;
+using EasyPost.Tests._Utilities.Attributes;
+using EasyPost.Utilities.Internal.Attributes;
+using RestSharp;
+using Xunit;
+
+namespace EasyPost.Tests.ServicesTests
+{
+    /// <summary>
+    ///     This class is for unit tests for basic service functionality, not specific to any one sub-service.
+    /// </summary>
+    public class ServiceTests : UnitTest
+    {
+        public ServiceTests() : base("base_service")
+        {
+        }
+
+        /// <summary>
+        ///     This test confirms that the GetNextPage method works as expected.
+        ///     This method is implemented on a per-service, but rather than testing in each service, we'll test it once here.
+        /// </summary>
+        [Fact]
+        [CrudOperations.Read]
+        [Testing.Function]
+        public async Task TestGetNextPage()
+        {
+            UseVCR("get_next_page");
+
+            AddressCollection addressCollection = await Client.Address.All(new Dictionary<string, object> { { "page_size", Fixtures.PageSize } });
+
+            AddressCollection nextPageAddressCollection = await Client.Address.GetNextPage(addressCollection);
+
+            // If the first ID in the next page is the same as the first ID in the current page, then we didn't get the next page
+            Assert.NotEqual(addressCollection.Addresses[0].Id, nextPageAddressCollection.Addresses[0].Id);
+        }
+
+        /// <summary>
+        ///     This test confirms that the GetNextPage method works with page limits.
+        ///     This method is implemented on a per-service, but rather than testing in each service, we'll test it once here.
+        /// </summary>
+        [Fact]
+        [CrudOperations.Read]
+        [Testing.Function]
+        public async Task TestGetNextPageSizeLimit()
+        {
+            UseVCR("get_next_page_size_limit");
+
+            AddressCollection addressCollection = await Client.Address.All(new Dictionary<string, object> { { "page_size", Fixtures.PageSize } });
+
+            AddressCollection nextPageAddressCollection = await Client.Address.GetNextPage(addressCollection, Fixtures.PageSize);
+
+            Assert.True(nextPageAddressCollection.Addresses.Count <= Fixtures.PageSize);
+        }
+
+        /// <summary>
+        ///     This test confirms that the GetNextPage method will throw an EndOfPaginationError when it reaches the end of the list.
+        ///     This method is implemented on a per-service, but rather than testing in each service, we'll test it once here.
+        /// </summary>
+        [Fact]
+        [CrudOperations.Read]
+        [Testing.Exception]
+        public async Task TestGetNextPageReachEnd()
+        {
+            UseMockClient(new List<TestUtils.MockRequest>
+            {
+                // API call to get the page of addresses will return an empty list with HasMore = false
+                new(
+                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/addresses$"),
+                    new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new AddressCollection
+                    {
+                        Addresses = new List<Address>(),
+                        HasMore = false,
+                    })
+                ),
+            });
+
+            AddressCollection addressCollection = await Client.Address.All(new Dictionary<string, object> { { "page_size", Fixtures.PageSize } });
+
+            bool hitEnd = false;
+
+            while (!hitEnd)
+            {
+                try
+                {
+                    addressCollection = await Client.Address.GetNextPage(addressCollection);
+                }
+                catch (EndOfPaginationError)
+                {
+                    hitEnd = true;
+                }
+            }
+
+            Assert.True(hitEnd);
+        }
+    }
+}

--- a/EasyPost.Tests/cassettes/net/address_service/get_next_page.json
+++ b/EasyPost.Tests/cassettes/net/address_service/get_next_page.json
@@ -1,7 +1,7 @@
 [
   {
-    "Duration": 305,
-    "RecordedAt": "2023-03-17T15:28:50.967257-06:00",
+    "Duration": 513,
+    "RecordedAt": "2023-03-17T15:28:40.107261-06:00",
     "Request": {
       "Body": "",
       "BodyContentType": "Text",
@@ -26,20 +26,20 @@
       "HttpVersion": "1.1",
       "ResponseHeaders": {
         "X-Frame-Options": "SAMEORIGIN",
-        "x-xss-protection": "1; mode=block",
+        "X-XSS-Protection": "1; mode=block",
         "X-Content-Type-Options": "nosniff",
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
-        "referrer-policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "30e0e2ad6414db92e6652ff0000d77b8",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "a33ca2f66414db87e6528231000c713d",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
         "ETag": "W/\"199899a90125fb9abf2d62346326007e\"",
-        "x-runtime": "0.034034",
-        "x-node": "bigweb2nuq",
+        "x-runtime": "0.055129",
+        "x-node": "bigweb1nuq",
         "x-version-label": "easypost-202303171748-9814978ec9-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq a40ea751fd,extlb1nuq a40ea751fd",
+        "x-proxied": "intlb2nuq a40ea751fd,intlb2wdc a40ea751fd,extlb4wdc a40ea751fd",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {
@@ -49,8 +49,8 @@
     }
   },
   {
-    "Duration": 456,
-    "RecordedAt": "2023-03-17T15:28:51.451312-06:00",
+    "Duration": 50,
+    "RecordedAt": "2023-03-17T15:28:48.179096-06:00",
     "Request": {
       "Body": "",
       "BodyContentType": "Text",
@@ -75,20 +75,20 @@
       "HttpVersion": "1.1",
       "ResponseHeaders": {
         "X-Frame-Options": "SAMEORIGIN",
-        "x-xss-protection": "1; mode=block",
+        "X-XSS-Protection": "1; mode=block",
         "X-Content-Type-Options": "nosniff",
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
-        "referrer-policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "30e0e2ad6414db93e6652ff0000d77c0",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "a33ca2f66414db88e6528231000c7151",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
         "ETag": "W/\"4800e454335a3e947aff210c3fbc3da9\"",
-        "x-runtime": "0.418409",
-        "x-node": "bigweb4nuq",
+        "x-runtime": "7.849370",
+        "x-node": "bigweb1nuq",
         "x-version-label": "easypost-202303171748-9814978ec9-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb2nuq a40ea751fd,extlb1nuq a40ea751fd",
+        "x-proxied": "intlb1nuq a40ea751fd,intlb2wdc a40ea751fd,extlb4wdc a40ea751fd",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/net/base_service/get_next_page.json
+++ b/EasyPost.Tests/cassettes/net/base_service/get_next_page.json
@@ -1,0 +1,101 @@
+[
+  {
+    "Duration": 242,
+    "RecordedAt": "2023-03-20T13:17:17.960736-06:00",
+    "Request": {
+      "Body": "",
+      "BodyContentType": "Text",
+      "ContentHeaders": {},
+      "Method": "GET",
+      "RequestHeaders": {
+        "Authorization": "<REDACTED>",
+        "content_type": "application/json",
+        "Accept": "application/json,text/json,text/x-json,text/javascript,application/xml,text/xml",
+        "User-Agent": "<REDACTED>"
+      },
+      "Uri": "https://api.easypost.com/v2/addresses?page_size=5"
+    },
+    "Response": {
+      "Body": "{\"addresses\":[{\"id\":\"adr_cf922eb8c50711edb255ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:05-06:00\",\"updated_at\":\"2023-03-17T15:08:05-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cf900b81c50711ed8498ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:05-06:00\",\"updated_at\":\"2023-03-17T15:08:06-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},{\"id\":\"adr_cee66408c50711edaf16ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:04-06:00\",\"updated_at\":\"2023-03-17T15:08:04-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cee102f5c50711eda475ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:04-06:00\",\"updated_at\":\"2023-03-17T15:08:04-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_ce290ecac50711edac20ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:03-06:00\",\"updated_at\":\"2023-03-17T15:08:03-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}],\"has_more\":true}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "2522"
+      },
+      "HttpVersion": "1.1",
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "3031855c6418b13de63c8a8100054d83",
+        "Cache-Control": "no-store, no-cache, private",
+        "Pragma": "no-cache",
+        "ETag": "W/\"199899a90125fb9abf2d62346326007e\"",
+        "x-runtime": "0.036909",
+        "x-node": "bigweb7nuq",
+        "x-version-label": "easypost-202303201858-7d2d65abf4-master",
+        "x-backend": "easypost",
+        "x-canary": "direct",
+        "x-proxied": "intlb2nuq a40ea751fd,extlb2nuq a40ea751fd",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      }
+    }
+  },
+  {
+    "Duration": 291,
+    "RecordedAt": "2023-03-20T13:17:18.266496-06:00",
+    "Request": {
+      "Body": "",
+      "BodyContentType": "Text",
+      "ContentHeaders": {},
+      "Method": "GET",
+      "RequestHeaders": {
+        "Authorization": "<REDACTED>",
+        "content_type": "application/json",
+        "Accept": "application/json,text/json,text/x-json,text/javascript,application/xml,text/xml",
+        "User-Agent": "<REDACTED>"
+      },
+      "Uri": "https://api.easypost.com/v2/addresses?before_id=adr_ce290ecac50711edac20ac1f6bc7b362"
+    },
+    "Response": {
+      "Body": "{\"addresses\":[{\"id\":\"adr_ce1d3ec5c50711edbe57ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:03-06:00\",\"updated_at\":\"2023-03-17T15:08:03-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cd843a46c50711edbb93ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:02-06:00\",\"updated_at\":\"2023-03-17T15:08:02-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cd81d888c50711ed8b21ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:02-06:00\",\"updated_at\":\"2023-03-17T15:08:02-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},{\"id\":\"adr_cd08838ac50711edb940ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:01-06:00\",\"updated_at\":\"2023-03-17T15:08:01-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cd067445c50711eda6a0ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:01-06:00\",\"updated_at\":\"2023-03-17T15:08:01-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_ca9d71f7c50711ed9b44ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:57-06:00\",\"updated_at\":\"2023-03-17T15:07:57-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_ca9b5efac50711edbdb9ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:57-06:00\",\"updated_at\":\"2023-03-17T15:07:57-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},{\"id\":\"adr_c9dc912ac50711edba62ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:56-06:00\",\"updated_at\":\"2023-03-17T15:07:56-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_c9dabb7bc50711edaa77ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:56-06:00\",\"updated_at\":\"2023-03-17T15:07:56-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_c90f600dc50711eda6b3ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:54-06:00\",\"updated_at\":\"2023-03-17T15:07:54-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_c902e4d7c50711ed939eac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:54-06:00\",\"updated_at\":\"2023-03-17T15:07:54-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_c7ed856dc50711edb122ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:52-06:00\",\"updated_at\":\"2023-03-17T15:07:52-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_c7eb5df4c50711ed8e5aac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:52-06:00\",\"updated_at\":\"2023-03-17T15:07:52-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_c743721bc50711edadd6ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:51-06:00\",\"updated_at\":\"2023-03-17T15:07:51-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_c74137afc50711ed8f1aac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:51-06:00\",\"updated_at\":\"2023-03-17T15:07:51-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},{\"id\":\"adr_c7258cf2c50711ed8aa4ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:51-06:00\",\"updated_at\":\"2023-03-17T15:07:51-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_c720c67ac50711ed8a8fac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:51-06:00\",\"updated_at\":\"2023-03-17T15:07:51-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_636bc103c50711eda9c4ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:05:04-06:00\",\"updated_at\":\"2023-03-17T15:05:04-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_6369741cc50711edbc66ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:05:04-06:00\",\"updated_at\":\"2023-03-17T15:05:04-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},{\"id\":\"adr_628becb9c50711edb84cac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:05:02-06:00\",\"updated_at\":\"2023-03-17T15:05:02-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}],\"has_more\":true}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "9999"
+      },
+      "HttpVersion": "1.1",
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "3031855c6418b13ee63c8a8100054d8f",
+        "Cache-Control": "no-store, no-cache, private",
+        "Pragma": "no-cache",
+        "ETag": "W/\"4800e454335a3e947aff210c3fbc3da9\"",
+        "x-runtime": "0.252945",
+        "x-node": "bigweb5nuq",
+        "x-version-label": "easypost-202303201858-7d2d65abf4-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb2nuq a40ea751fd,extlb2nuq a40ea751fd",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      }
+    }
+  }
+]

--- a/EasyPost.Tests/cassettes/net/base_service/get_next_page_size_limit.json
+++ b/EasyPost.Tests/cassettes/net/base_service/get_next_page_size_limit.json
@@ -1,0 +1,100 @@
+[
+  {
+    "Duration": 749,
+    "RecordedAt": "2023-03-20T13:17:17.38107-06:00",
+    "Request": {
+      "Body": "",
+      "BodyContentType": "Text",
+      "ContentHeaders": {},
+      "Method": "GET",
+      "RequestHeaders": {
+        "Authorization": "<REDACTED>",
+        "content_type": "application/json",
+        "Accept": "application/json,text/json,text/x-json,text/javascript,application/xml,text/xml",
+        "User-Agent": "<REDACTED>"
+      },
+      "Uri": "https://api.easypost.com/v2/addresses?page_size=5"
+    },
+    "Response": {
+      "Body": "{\"addresses\":[{\"id\":\"adr_cf922eb8c50711edb255ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:05-06:00\",\"updated_at\":\"2023-03-17T15:08:05-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cf900b81c50711ed8498ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:05-06:00\",\"updated_at\":\"2023-03-17T15:08:06-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},{\"id\":\"adr_cee66408c50711edaf16ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:04-06:00\",\"updated_at\":\"2023-03-17T15:08:04-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cee102f5c50711eda475ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:04-06:00\",\"updated_at\":\"2023-03-17T15:08:04-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_ce290ecac50711edac20ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:03-06:00\",\"updated_at\":\"2023-03-17T15:08:03-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}],\"has_more\":true}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "2522"
+      },
+      "HttpVersion": "1.1",
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "3031855f6418b13de6735b8300054d4a",
+        "Cache-Control": "no-store, no-cache, private",
+        "Pragma": "no-cache",
+        "ETag": "W/\"199899a90125fb9abf2d62346326007e\"",
+        "x-runtime": "0.036959",
+        "x-node": "bigweb1nuq",
+        "x-version-label": "easypost-202303201858-7d2d65abf4-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb1nuq a40ea751fd,extlb2nuq a40ea751fd",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      }
+    }
+  },
+  {
+    "Duration": 278,
+    "RecordedAt": "2023-03-20T13:17:17.691179-06:00",
+    "Request": {
+      "Body": "",
+      "BodyContentType": "Text",
+      "ContentHeaders": {},
+      "Method": "GET",
+      "RequestHeaders": {
+        "Authorization": "<REDACTED>",
+        "content_type": "application/json",
+        "Accept": "application/json,text/json,text/x-json,text/javascript,application/xml,text/xml",
+        "User-Agent": "<REDACTED>"
+      },
+      "Uri": "https://api.easypost.com/v2/addresses?before_id=adr_ce290ecac50711edac20ac1f6bc7b362&page_size=5"
+    },
+    "Response": {
+      "Body": "{\"addresses\":[{\"id\":\"adr_ce1d3ec5c50711edbe57ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:03-06:00\",\"updated_at\":\"2023-03-17T15:08:03-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cd843a46c50711edbb93ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:02-06:00\",\"updated_at\":\"2023-03-17T15:08:02-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cd81d888c50711ed8b21ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:02-06:00\",\"updated_at\":\"2023-03-17T15:08:02-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},{\"id\":\"adr_cd08838ac50711edb940ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:01-06:00\",\"updated_at\":\"2023-03-17T15:08:01-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cd067445c50711eda6a0ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:01-06:00\",\"updated_at\":\"2023-03-17T15:08:01-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}],\"has_more\":true}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "2524"
+      },
+      "HttpVersion": "1.1",
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "3031855f6418b13de6735b8300054d5d",
+        "Cache-Control": "no-store, no-cache, private",
+        "Pragma": "no-cache",
+        "ETag": "W/\"e3ef978f2dc8b1e0800de5b2460899f4\"",
+        "x-runtime": "0.229002",
+        "x-node": "bigweb11nuq",
+        "x-version-label": "easypost-202303201858-7d2d65abf4-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb2nuq a40ea751fd,extlb2nuq a40ea751fd",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      }
+    }
+  }
+]

--- a/EasyPost.Tests/cassettes/net/end_shipper_service/get_next_page.json
+++ b/EasyPost.Tests/cassettes/net/end_shipper_service/get_next_page.json
@@ -1,7 +1,7 @@
 [
   {
-    "Duration": 570,
-    "RecordedAt": "2023-03-17T15:28:53.034707-06:00",
+    "Duration": 714,
+    "RecordedAt": "2023-03-17T15:28:42.237214-06:00",
     "Request": {
       "Body": "",
       "BodyContentType": "Text",
@@ -26,20 +26,20 @@
       "HttpVersion": "1.1",
       "ResponseHeaders": {
         "X-Frame-Options": "SAMEORIGIN",
-        "x-xss-protection": "1; mode=block",
+        "X-XSS-Protection": "1; mode=block",
         "X-Content-Type-Options": "nosniff",
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
-        "referrer-policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "30e0e2ac6414db92e674926a000d77b9",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "a33ca2f36414db87e684e405000c713c",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
         "ETag": "W/\"d08f7724bd17c26df657c81deb92dab6\"",
-        "x-runtime": "2.114952",
+        "x-runtime": "2.192841",
         "x-node": "bigweb3nuq",
         "x-version-label": "easypost-202303171748-9814978ec9-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb2nuq a40ea751fd,extlb1nuq a40ea751fd",
+        "x-proxied": "intlb2nuq a40ea751fd,intlb1wdc a40ea751fd,extlb4wdc a40ea751fd",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/netstandard/base_service/get_next_page.json
+++ b/EasyPost.Tests/cassettes/netstandard/base_service/get_next_page.json
@@ -1,0 +1,100 @@
+[
+  {
+    "Duration": 213,
+    "RecordedAt": "2023-03-20T13:17:22.413159-06:00",
+    "Request": {
+      "Body": "",
+      "BodyContentType": "Text",
+      "ContentHeaders": {},
+      "Method": "GET",
+      "RequestHeaders": {
+        "Authorization": "<REDACTED>",
+        "content_type": "application/json",
+        "Accept": "application/json,text/json,text/x-json,text/javascript,application/xml,text/xml",
+        "User-Agent": "<REDACTED>"
+      },
+      "Uri": "https://api.easypost.com/v2/addresses?page_size=5"
+    },
+    "Response": {
+      "Body": "{\"addresses\":[{\"id\":\"adr_cf922eb8c50711edb255ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:05-06:00\",\"updated_at\":\"2023-03-17T15:08:05-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cf900b81c50711ed8498ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:05-06:00\",\"updated_at\":\"2023-03-17T15:08:06-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},{\"id\":\"adr_cee66408c50711edaf16ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:04-06:00\",\"updated_at\":\"2023-03-17T15:08:04-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cee102f5c50711eda475ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:04-06:00\",\"updated_at\":\"2023-03-17T15:08:04-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_ce290ecac50711edac20ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:03-06:00\",\"updated_at\":\"2023-03-17T15:08:03-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}],\"has_more\":true}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "2522"
+      },
+      "HttpVersion": "1.1",
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "referrer-policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "f92563866418b142e6761e890005aeb5",
+        "Cache-Control": "no-store, no-cache, private",
+        "Pragma": "no-cache",
+        "ETag": "W/\"199899a90125fb9abf2d62346326007e\"",
+        "x-runtime": "0.040986",
+        "x-node": "bigweb8nuq",
+        "x-version-label": "easypost-202303201858-7d2d65abf4-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb2nuq a40ea751fd,extlb1nuq a40ea751fd",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      }
+    }
+  },
+  {
+    "Duration": 365,
+    "RecordedAt": "2023-03-20T13:17:22.836498-06:00",
+    "Request": {
+      "Body": "",
+      "BodyContentType": "Text",
+      "ContentHeaders": {},
+      "Method": "GET",
+      "RequestHeaders": {
+        "Authorization": "<REDACTED>",
+        "content_type": "application/json",
+        "Accept": "application/json,text/json,text/x-json,text/javascript,application/xml,text/xml",
+        "User-Agent": "<REDACTED>"
+      },
+      "Uri": "https://api.easypost.com/v2/addresses?before_id=adr_ce290ecac50711edac20ac1f6bc7b362"
+    },
+    "Response": {
+      "Body": "{\"addresses\":[{\"id\":\"adr_ce1d3ec5c50711edbe57ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:03-06:00\",\"updated_at\":\"2023-03-17T15:08:03-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cd843a46c50711edbb93ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:02-06:00\",\"updated_at\":\"2023-03-17T15:08:02-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cd81d888c50711ed8b21ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:02-06:00\",\"updated_at\":\"2023-03-17T15:08:02-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},{\"id\":\"adr_cd08838ac50711edb940ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:01-06:00\",\"updated_at\":\"2023-03-17T15:08:01-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cd067445c50711eda6a0ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:01-06:00\",\"updated_at\":\"2023-03-17T15:08:01-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_ca9d71f7c50711ed9b44ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:57-06:00\",\"updated_at\":\"2023-03-17T15:07:57-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_ca9b5efac50711edbdb9ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:57-06:00\",\"updated_at\":\"2023-03-17T15:07:57-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},{\"id\":\"adr_c9dc912ac50711edba62ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:56-06:00\",\"updated_at\":\"2023-03-17T15:07:56-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_c9dabb7bc50711edaa77ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:56-06:00\",\"updated_at\":\"2023-03-17T15:07:56-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_c90f600dc50711eda6b3ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:54-06:00\",\"updated_at\":\"2023-03-17T15:07:54-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_c902e4d7c50711ed939eac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:54-06:00\",\"updated_at\":\"2023-03-17T15:07:54-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_c7ed856dc50711edb122ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:52-06:00\",\"updated_at\":\"2023-03-17T15:07:52-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_c7eb5df4c50711ed8e5aac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:52-06:00\",\"updated_at\":\"2023-03-17T15:07:52-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_c743721bc50711edadd6ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:51-06:00\",\"updated_at\":\"2023-03-17T15:07:51-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_c74137afc50711ed8f1aac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:51-06:00\",\"updated_at\":\"2023-03-17T15:07:51-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},{\"id\":\"adr_c7258cf2c50711ed8aa4ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:51-06:00\",\"updated_at\":\"2023-03-17T15:07:51-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_c720c67ac50711ed8a8fac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:07:51-06:00\",\"updated_at\":\"2023-03-17T15:07:51-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_636bc103c50711eda9c4ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:05:04-06:00\",\"updated_at\":\"2023-03-17T15:05:04-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_6369741cc50711edbc66ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:05:04-06:00\",\"updated_at\":\"2023-03-17T15:05:04-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},{\"id\":\"adr_628becb9c50711edb84cac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:05:02-06:00\",\"updated_at\":\"2023-03-17T15:05:02-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}],\"has_more\":true}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "9999"
+      },
+      "HttpVersion": "1.1",
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "referrer-policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "f92563866418b142e6761e890005aec3",
+        "Cache-Control": "no-store, no-cache, private",
+        "Pragma": "no-cache",
+        "ETag": "W/\"4800e454335a3e947aff210c3fbc3da9\"",
+        "x-runtime": "0.256070",
+        "x-node": "bigweb5nuq",
+        "x-version-label": "easypost-202303201858-7d2d65abf4-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb2nuq a40ea751fd,extlb1nuq a40ea751fd",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      }
+    }
+  }
+]

--- a/EasyPost.Tests/cassettes/netstandard/base_service/get_next_page_size_limit.json
+++ b/EasyPost.Tests/cassettes/netstandard/base_service/get_next_page_size_limit.json
@@ -1,0 +1,101 @@
+[
+  {
+    "Duration": 951,
+    "RecordedAt": "2023-03-20T13:17:21.694624-06:00",
+    "Request": {
+      "Body": "",
+      "BodyContentType": "Text",
+      "ContentHeaders": {},
+      "Method": "GET",
+      "RequestHeaders": {
+        "Authorization": "<REDACTED>",
+        "content_type": "application/json",
+        "Accept": "application/json,text/json,text/x-json,text/javascript,application/xml,text/xml",
+        "User-Agent": "<REDACTED>"
+      },
+      "Uri": "https://api.easypost.com/v2/addresses?page_size=5"
+    },
+    "Response": {
+      "Body": "{\"addresses\":[{\"id\":\"adr_cf922eb8c50711edb255ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:05-06:00\",\"updated_at\":\"2023-03-17T15:08:05-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cf900b81c50711ed8498ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:05-06:00\",\"updated_at\":\"2023-03-17T15:08:06-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},{\"id\":\"adr_cee66408c50711edaf16ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:04-06:00\",\"updated_at\":\"2023-03-17T15:08:04-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cee102f5c50711eda475ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:04-06:00\",\"updated_at\":\"2023-03-17T15:08:04-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_ce290ecac50711edac20ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:03-06:00\",\"updated_at\":\"2023-03-17T15:08:03-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}],\"has_more\":true}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "2522"
+      },
+      "HttpVersion": "1.1",
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "referrer-policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "1e2574016418b141f48e19ce00055bd3",
+        "Cache-Control": "no-store, no-cache, private",
+        "Pragma": "no-cache",
+        "ETag": "W/\"199899a90125fb9abf2d62346326007e\"",
+        "x-runtime": "0.123493",
+        "x-node": "bigweb11nuq",
+        "x-version-label": "easypost-202303201858-7d2d65abf4-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb1nuq a40ea751fd,intlb2wdc a40ea751fd,extlb4wdc a40ea751fd",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      }
+    }
+  },
+  {
+    "Duration": 453,
+    "RecordedAt": "2023-03-20T13:17:22.178117-06:00",
+    "Request": {
+      "Body": "",
+      "BodyContentType": "Text",
+      "ContentHeaders": {},
+      "Method": "GET",
+      "RequestHeaders": {
+        "Authorization": "<REDACTED>",
+        "content_type": "application/json",
+        "Accept": "application/json,text/json,text/x-json,text/javascript,application/xml,text/xml",
+        "User-Agent": "<REDACTED>"
+      },
+      "Uri": "https://api.easypost.com/v2/addresses?before_id=adr_ce290ecac50711edac20ac1f6bc7b362&page_size=5"
+    },
+    "Response": {
+      "Body": "{\"addresses\":[{\"id\":\"adr_ce1d3ec5c50711edbe57ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:03-06:00\",\"updated_at\":\"2023-03-17T15:08:03-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cd843a46c50711edbb93ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:02-06:00\",\"updated_at\":\"2023-03-17T15:08:02-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cd81d888c50711ed8b21ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:02-06:00\",\"updated_at\":\"2023-03-17T15:08:02-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":null,\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}},{\"id\":\"adr_cd08838ac50711edb940ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:01-06:00\",\"updated_at\":\"2023-03-17T15:08:01-06:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}},{\"id\":\"adr_cd067445c50711eda6a0ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-03-17T15:08:01-06:00\",\"updated_at\":\"2023-03-17T15:08:01-06:00\",\"name\":\"Elizabeth Swan\",\"company\":null,\"street1\":\"179 N Harbor Dr\",\"street2\":null,\"city\":\"Redondo Beach\",\"state\":\"CA\",\"zip\":\"90277\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}],\"has_more\":true}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "2524"
+      },
+      "HttpVersion": "1.1",
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "referrer-policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "1e2574016418b141f48e19ce00055c04",
+        "Cache-Control": "no-store, no-cache, private",
+        "Pragma": "no-cache",
+        "ETag": "W/\"e3ef978f2dc8b1e0800de5b2460899f4\"",
+        "x-runtime": "0.249230",
+        "x-node": "bigweb7nuq",
+        "x-version-label": "easypost-202303201858-7d2d65abf4-master",
+        "x-backend": "easypost",
+        "x-canary": "direct",
+        "x-proxied": "intlb2nuq a40ea751fd,intlb1wdc a40ea751fd,extlb4wdc a40ea751fd",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "Status": {
+        "Code": 200,
+        "Message": "OK"
+      }
+    }
+  }
+]

--- a/EasyPost/Exceptions/General/EndOfPaginationError.cs
+++ b/EasyPost/Exceptions/General/EndOfPaginationError.cs
@@ -1,0 +1,13 @@
+namespace EasyPost.Exceptions.General
+{
+    public class EndOfPaginationError : EasyPostError
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="EndOfPaginationError" /> class.
+        /// </summary>
+        internal EndOfPaginationError()
+            : base("There are no more items to iterate through.")
+        {
+        }
+    }
+}

--- a/EasyPost/Exceptions/General/EndOfPaginationError.cs
+++ b/EasyPost/Exceptions/General/EndOfPaginationError.cs
@@ -6,7 +6,7 @@ namespace EasyPost.Exceptions.General
         ///     Initializes a new instance of the <see cref="EndOfPaginationError" /> class.
         /// </summary>
         internal EndOfPaginationError()
-            : base("There are no more items to iterate through.")
+            : base("There are no more pages to retrieve.")
         {
         }
     }

--- a/EasyPost/Models/API/Address.cs
+++ b/EasyPost/Models/API/Address.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.BetaFeatures.Parameters;
@@ -88,6 +89,23 @@ namespace EasyPost.Models.API
 
         internal AddressCollection()
         {
+        }
+
+        protected internal override TParameters BuildNextPageParameters<TEntries, TParameters>(IEnumerable<TEntries> entries, int? pageSize = null)
+        {
+            string? lastId = entries.Last().Id;
+
+            BetaFeatures.Parameters.Addresses.All parameters = new()
+            {
+                BeforeId = lastId,
+            };
+
+            if (pageSize != null)
+            {
+                parameters.PageSize = pageSize;
+            }
+
+            return (parameters as TParameters)!;
         }
     }
 }

--- a/EasyPost/Models/API/ApiKey.cs
+++ b/EasyPost/Models/API/ApiKey.cs
@@ -34,5 +34,7 @@ namespace EasyPost.Models.API
         internal ApiKeyCollection()
         {
         }
+
+        protected internal override TParameters BuildNextPageParameters<TEntries, TParameters>(IEnumerable<TEntries> entries, int? pageSize = null) => throw new System.NotImplementedException();
     }
 }

--- a/EasyPost/Models/API/Batch.cs
+++ b/EasyPost/Models/API/Batch.cs
@@ -261,5 +261,7 @@ namespace EasyPost.Models.API
         internal BatchCollection()
         {
         }
+
+        protected internal override TParameters BuildNextPageParameters<TEntries, TParameters>(IEnumerable<TEntries> entries, int? pageSize = null) => throw new System.NotImplementedException();
     }
 }

--- a/EasyPost/Models/API/EndShipper.cs
+++ b/EasyPost/Models/API/EndShipper.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.BetaFeatures.Parameters;
-using EasyPost.Exceptions.General;
 using EasyPost.Models.Shared;
 using EasyPost.Utilities.Internal.Attributes;
 using EasyPost.Utilities.Internal.Extensions;
@@ -92,33 +91,6 @@ namespace EasyPost.Models.API
         {
         }
 
-        /// <summary>
-        ///     Override the default BuildNextPageParameters method to build the parameters for the next page of EndShippers.
-        /// </summary>
-        /// <param name="entries">The entries of the <see cref="EndShipperCollection"/>.</param>
-        /// <typeparam name="T">The type of <see cref="EasyPost._base.EasyPostObject"/> the entries are. Should be <see cref="EndShipper"/>.</typeparam>
-        /// <returns>A <see cref="Dictionary{TKey,TValue}"/> of parameters to use for the subsequent API call.</returns>
-        /// <exception cref="EndOfPaginationError">Thrown if there are no more items to retrieve for the paginated collection.</exception>
-        internal override Dictionary<string, object> BuildNextPageParameters<T>(List<T>? entries)
-        {
-            if (entries is not List<EndShipper> endShippers)
-            {
-                throw new EndOfPaginationError();
-            }
-
-            if (endShippers == null || endShippers.Count == 0)
-            {
-                throw new EndOfPaginationError();
-            }
-
-            if (HasMore == null || !(bool)HasMore)
-            {
-                throw new EndOfPaginationError();
-            }
-
-            // TODO: How would we get the next page of EndShippers?
-
-            throw new EndOfPaginationError();
-        }
+        protected internal override TParameters BuildNextPageParameters<TEntries, TParameters>(IEnumerable<TEntries> entries, int? pageSize = null) => throw new System.NotImplementedException();
     }
 }

--- a/EasyPost/Models/API/EndShipper.cs
+++ b/EasyPost/Models/API/EndShipper.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.BetaFeatures.Parameters;
+using EasyPost.Exceptions.General;
 using EasyPost.Models.Shared;
 using EasyPost.Utilities.Internal.Attributes;
 using EasyPost.Utilities.Internal.Extensions;
@@ -89,6 +90,35 @@ namespace EasyPost.Models.API
 
         internal EndShipperCollection()
         {
+        }
+
+        /// <summary>
+        ///     Override the default BuildNextPageParameters method to build the parameters for the next page of EndShippers.
+        /// </summary>
+        /// <param name="entries">The entries of the <see cref="EndShipperCollection"/>.</param>
+        /// <typeparam name="T">The type of <see cref="EasyPost._base.EasyPostObject"/> the entries are. Should be <see cref="EndShipper"/>.</typeparam>
+        /// <returns>A <see cref="Dictionary{TKey,TValue}"/> of parameters to use for the subsequent API call.</returns>
+        /// <exception cref="EndOfPaginationError">Thrown if there are no more items to retrieve for the paginated collection.</exception>
+        protected internal override Dictionary<string, object> BuildNextPageParameters<T>(List<T>? entries)
+        {
+            if (entries is not List<EndShipper> endShippers)
+            {
+                throw new EndOfPaginationError();
+            }
+
+            if (endShippers == null || endShippers.Count == 0)
+            {
+                throw new EndOfPaginationError();
+            }
+
+            if (HasMore == null || !(bool)HasMore)
+            {
+                throw new EndOfPaginationError();
+            }
+
+            // TODO: How would we get the next page of EndShippers?
+
+            throw new EndOfPaginationError();
         }
     }
 }

--- a/EasyPost/Models/API/EndShipper.cs
+++ b/EasyPost/Models/API/EndShipper.cs
@@ -99,7 +99,7 @@ namespace EasyPost.Models.API
         /// <typeparam name="T">The type of <see cref="EasyPost._base.EasyPostObject"/> the entries are. Should be <see cref="EndShipper"/>.</typeparam>
         /// <returns>A <see cref="Dictionary{TKey,TValue}"/> of parameters to use for the subsequent API call.</returns>
         /// <exception cref="EndOfPaginationError">Thrown if there are no more items to retrieve for the paginated collection.</exception>
-        protected internal override Dictionary<string, object> BuildNextPageParameters<T>(List<T>? entries)
+        internal override Dictionary<string, object> BuildNextPageParameters<T>(List<T>? entries)
         {
             if (entries is not List<EndShipper> endShippers)
             {

--- a/EasyPost/Models/API/Event.cs
+++ b/EasyPost/Models/API/Event.cs
@@ -45,5 +45,7 @@ namespace EasyPost.Models.API
         internal EventCollection()
         {
         }
+
+        protected internal override TParameters BuildNextPageParameters<TEntries, TParameters>(IEnumerable<TEntries> entries, int? pageSize = null) => throw new System.NotImplementedException();
     }
 }

--- a/EasyPost/Models/API/Insurance.cs
+++ b/EasyPost/Models/API/Insurance.cs
@@ -76,5 +76,7 @@ namespace EasyPost.Models.API
         internal InsuranceCollection()
         {
         }
+
+        protected internal override TParameters BuildNextPageParameters<TEntries, TParameters>(IEnumerable<TEntries> entries, int? pageSize = null) => throw new NotImplementedException();
     }
 }

--- a/EasyPost/Models/API/Pickup.cs
+++ b/EasyPost/Models/API/Pickup.cs
@@ -137,5 +137,7 @@ namespace EasyPost.Models.API
         internal PickupCollection()
         {
         }
+
+        protected internal override TParameters BuildNextPageParameters<TEntries, TParameters>(IEnumerable<TEntries> entries, int? pageSize = null) => throw new NotImplementedException();
     }
 }

--- a/EasyPost/Models/API/ReferralCustomer.cs
+++ b/EasyPost/Models/API/ReferralCustomer.cs
@@ -24,5 +24,7 @@ namespace EasyPost.Models.API
         internal ReferralCustomerCollection()
         {
         }
+
+        protected internal override TParameters BuildNextPageParameters<TEntries, TParameters>(IEnumerable<TEntries> entries, int? pageSize = null) => throw new System.NotImplementedException();
     }
 }

--- a/EasyPost/Models/API/Refund.cs
+++ b/EasyPost/Models/API/Refund.cs
@@ -40,5 +40,7 @@ namespace EasyPost.Models.API
         internal RefundCollection()
         {
         }
+
+        protected internal override TParameters BuildNextPageParameters<TEntries, TParameters>(IEnumerable<TEntries> entries, int? pageSize = null) => throw new System.NotImplementedException();
     }
 }

--- a/EasyPost/Models/API/Report.cs
+++ b/EasyPost/Models/API/Report.cs
@@ -45,5 +45,7 @@ namespace EasyPost.Models.API
         internal ReportCollection()
         {
         }
+
+        protected internal override TParameters BuildNextPageParameters<TEntries, TParameters>(IEnumerable<TEntries> entries, int? pageSize = null) => throw new NotImplementedException();
     }
 }

--- a/EasyPost/Models/API/ScanForm.cs
+++ b/EasyPost/Models/API/ScanForm.cs
@@ -44,5 +44,7 @@ namespace EasyPost.Models.API
         internal ScanFormCollection()
         {
         }
+
+        protected internal override TParameters BuildNextPageParameters<TEntries, TParameters>(IEnumerable<TEntries> entries, int? pageSize = null) => throw new System.NotImplementedException();
     }
 }

--- a/EasyPost/Models/API/Shipment.cs
+++ b/EasyPost/Models/API/Shipment.cs
@@ -343,5 +343,7 @@ namespace EasyPost.Models.API
         internal ShipmentCollection()
         {
         }
+
+        protected internal override TParameters BuildNextPageParameters<TEntries, TParameters>(IEnumerable<TEntries> entries, int? pageSize = null) => throw new System.NotImplementedException();
     }
 }

--- a/EasyPost/Models/API/Tracker.cs
+++ b/EasyPost/Models/API/Tracker.cs
@@ -55,5 +55,7 @@ namespace EasyPost.Models.API
         internal TrackerCollection()
         {
         }
+
+        protected internal override TParameters BuildNextPageParameters<TEntries, TParameters>(IEnumerable<TEntries> entries, int? pageSize = null) => throw new NotImplementedException();
     }
 }

--- a/EasyPost/Models/Shared/Collection.cs
+++ b/EasyPost/Models/Shared/Collection.cs
@@ -1,4 +1,9 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using EasyPost._base;
+using EasyPost.Exceptions.General;
 using Newtonsoft.Json;
 
 namespace EasyPost.Models.Shared
@@ -11,5 +16,50 @@ namespace EasyPost.Models.Shared
         public bool? HasMore { get; set; }
 
         #endregion
+
+        /// <summary>
+        ///     Get the next page of a paginated collection.
+        /// </summary>
+        /// <param name="apiCallFunction">The function to execute to retrieve a page (most likely an All function).</param>
+        /// <param name="currentEntries">The results on the current page. Used to determine the API call parameters to retrieve the next page.</param>
+        /// <typeparam name="T">The type of <see cref="Collection"/> to get the next page of.</typeparam>
+        /// <typeparam name="T2">The type of <see cref="EasyPost._base.EasyPostObject"/> the entries are.</typeparam>
+        /// <returns>The next page of a paginated collection.</returns>
+        /// <exception cref="EndOfPaginationError">Thrown if there is no next page to retrieve.</exception>
+        internal async Task<T> GetNextPage<T, T2>(Func<Dictionary<string, object>, Task<T>> apiCallFunction, List<T2>? currentEntries) where T : Collection where T2 : EasyPost._base.EasyPostObject
+        {
+            Dictionary<string, object> parameters = BuildNextPageParameters<T2>(currentEntries);
+
+            return await apiCallFunction(parameters);
+        }
+
+        /// <summary>
+        ///     Build the parameters to retrieve the next page of a paginated collection.
+        /// </summary>
+        /// <param name="entries">The entries of the collection.</param>
+        /// <typeparam name="T">The type of <see cref="EasyPost._base.EasyPostObject"/> the entries are.</typeparam>
+        /// <returns>A <see cref="Dictionary{TKey,TValue}"/> of parameters to use for the subsequent API call.</returns>
+        /// <exception cref="EndOfPaginationError">Thrown if there are no more items to retrieve for the paginated collection.</exception>
+        protected internal virtual Dictionary<string, object> BuildNextPageParameters<T>(List<T>? entries) where T : EasyPost._base.EasyPostObject
+        {
+            // This method is virtual so that it can be overridden by specific collection types that need to use different parameters (e.g. EndShipperCollection doesn't use "before_id").
+
+            if (entries == null || entries.Count == 0)
+            {
+                throw new EndOfPaginationError();
+            }
+
+            if (HasMore == null || !(bool)HasMore)
+            {
+                throw new EndOfPaginationError();
+            }
+
+            string? lastId = entries.Last()!.Id;
+
+            return new Dictionary<string, object>
+            {
+                { "before_id", lastId! },
+            };
+        }
     }
 }

--- a/EasyPost/Models/Shared/Collection.cs
+++ b/EasyPost/Models/Shared/Collection.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.Exceptions.General;
@@ -22,29 +21,15 @@ namespace EasyPost.Models.Shared
         /// </summary>
         /// <param name="apiCallFunction">The function to execute to retrieve a page (most likely an All function).</param>
         /// <param name="currentEntries">The results on the current page. Used to determine the API call parameters to retrieve the next page.</param>
-        /// <typeparam name="T">The type of <see cref="Collection"/> to get the next page of.</typeparam>
-        /// <typeparam name="T2">The type of <see cref="EasyPost._base.EasyPostObject"/> the entries are.</typeparam>
+        /// <param name="pageSize">The size of the next page.</param>
+        /// <typeparam name="TCollection">The type of <see cref="Collection"/> to get the next page of.</typeparam>
+        /// <typeparam name="TEntries">The type of <see cref="EasyPost._base.EasyPostObject"/> the entries are.</typeparam>
+        /// <typeparam name="TParameters">The type of <see cref="EasyPost.BetaFeatures.Parameters.BaseParameters"/> to construct for the API call.</typeparam>
         /// <returns>The next page of a paginated collection.</returns>
         /// <exception cref="EndOfPaginationError">Thrown if there is no next page to retrieve.</exception>
-        internal async Task<T> GetNextPage<T, T2>(Func<Dictionary<string, object>, Task<T>> apiCallFunction, List<T2>? currentEntries) where T : Collection where T2 : EasyPost._base.EasyPostObject
+        internal async Task<TCollection> GetNextPage<TCollection, TEntries, TParameters>(Func<TParameters, Task<TCollection>> apiCallFunction, List<TEntries>? currentEntries, int? pageSize = null) where TCollection : Collection where TEntries : EasyPost._base.EasyPostObject where TParameters : BetaFeatures.Parameters.BaseParameters
         {
-            Dictionary<string, object> parameters = BuildNextPageParameters<T2>(currentEntries);
-
-            return await apiCallFunction(parameters);
-        }
-
-        /// <summary>
-        ///     Build the parameters to retrieve the next page of a paginated collection.
-        /// </summary>
-        /// <param name="entries">The entries of the collection.</param>
-        /// <typeparam name="T">The type of <see cref="EasyPost._base.EasyPostObject"/> the entries are.</typeparam>
-        /// <returns>A <see cref="Dictionary{TKey,TValue}"/> of parameters to use for the subsequent API call.</returns>
-        /// <exception cref="EndOfPaginationError">Thrown if there are no more items to retrieve for the paginated collection.</exception>
-        internal virtual Dictionary<string, object> BuildNextPageParameters<T>(List<T>? entries) where T : EasyPost._base.EasyPostObject
-        {
-            // This method is virtual so that it can be overridden by specific collection types that need to use different parameters (e.g. EndShipperCollection doesn't use "before_id").
-
-            if (entries == null || entries.Count == 0)
+            if (currentEntries == null || currentEntries.Count == 0)
             {
                 throw new EndOfPaginationError();
             }
@@ -54,12 +39,21 @@ namespace EasyPost.Models.Shared
                 throw new EndOfPaginationError();
             }
 
-            string? lastId = entries.Last()!.Id;
+            TParameters parameters = BuildNextPageParameters<TEntries, TParameters>(currentEntries, pageSize);
 
-            return new Dictionary<string, object>
-            {
-                { "before_id", lastId! },
-            };
+            return await apiCallFunction(parameters);
         }
+
+        /// <summary>
+        ///     Build the parameters to retrieve the next page of a paginated collection.
+        /// </summary>
+        /// <param name="entries">The entries of the collection.</param>
+        /// <param name="pageSize">The size of the next page.</param>
+        /// <typeparam name="TEntries">The type of <see cref="EasyPost._base.EasyPostObject"/> the entries are.</typeparam>
+        /// <typeparam name="TParameters">The type of <see cref="EasyPost.BetaFeatures.Parameters.BaseParameters"/> to construct for the API call.</typeparam>
+        /// <returns>A T2-type set of parameters to use for the subsequent API call.</returns>
+        /// <exception cref="EndOfPaginationError">Thrown if there are no more items to retrieve for the paginated collection.</exception>
+        // This method is abstract and must be implemented for each collection.
+        protected internal abstract TParameters BuildNextPageParameters<TEntries, TParameters>(IEnumerable<TEntries> entries, int? pageSize = null) where TEntries : EasyPost._base.EasyPostObject where TParameters : BetaFeatures.Parameters.BaseParameters;
     }
 }

--- a/EasyPost/Models/Shared/Collection.cs
+++ b/EasyPost/Models/Shared/Collection.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 
 namespace EasyPost.Models.Shared
 {
-    public class Collection : EasyPostObject
+    public abstract class Collection : EasyPostObject
     {
         #region JSON Properties
 
@@ -40,7 +40,7 @@ namespace EasyPost.Models.Shared
         /// <typeparam name="T">The type of <see cref="EasyPost._base.EasyPostObject"/> the entries are.</typeparam>
         /// <returns>A <see cref="Dictionary{TKey,TValue}"/> of parameters to use for the subsequent API call.</returns>
         /// <exception cref="EndOfPaginationError">Thrown if there are no more items to retrieve for the paginated collection.</exception>
-        protected internal virtual Dictionary<string, object> BuildNextPageParameters<T>(List<T>? entries) where T : EasyPost._base.EasyPostObject
+        internal virtual Dictionary<string, object> BuildNextPageParameters<T>(List<T>? entries) where T : EasyPost._base.EasyPostObject
         {
             // This method is virtual so that it can be overridden by specific collection types that need to use different parameters (e.g. EndShipperCollection doesn't use "before_id").
 
@@ -49,7 +49,7 @@ namespace EasyPost.Models.Shared
                 throw new EndOfPaginationError();
             }
 
-            if (HasMore == null || !(bool)HasMore)
+            if (this.HasMore == null || !(bool)this.HasMore)
             {
                 throw new EndOfPaginationError();
             }

--- a/EasyPost/Services/AddressService.cs
+++ b/EasyPost/Services/AddressService.cs
@@ -140,9 +140,10 @@ namespace EasyPost.Services
         ///     Get the next page of a paginated <see cref="AddressCollection"/>.
         /// </summary>
         /// <param name="collection">The <see cref="AddressCollection"/> to get the next page of.</param>
+        /// <param name="pageSize">The size of the next page.</param>
         /// <returns>The next page, as a <see cref="AddressCollection"/> instance.</returns>
         /// <exception cref="EndOfPaginationError">Thrown if there is no next page to retrieve.</exception>
-        public async Task<AddressCollection> GetNextPage(AddressCollection collection) => await collection.GetNextPage<AddressCollection, Address>(async parameters => await All(parameters), collection.Addresses);
+        public async Task<AddressCollection> GetNextPage(AddressCollection collection, int? pageSize = null) => await collection.GetNextPage<AddressCollection, Address, BetaFeatures.Parameters.Addresses.All>(async parameters => await All(parameters), collection.Addresses, pageSize);
 
         /// <summary>
         ///     Retrieve an Address from its id.

--- a/EasyPost/Services/AddressService.cs
+++ b/EasyPost/Services/AddressService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using EasyPost._base;
+using EasyPost.Exceptions.General;
 using EasyPost.Models.API;
 using EasyPost.Utilities.Internal.Attributes;
 using EasyPost.Utilities.Internal.Extensions;
@@ -134,6 +135,14 @@ namespace EasyPost.Services
         /// <returns><see cref="AddressCollection"/> instance.</returns>
         [CrudOperations.Read]
         public async Task<AddressCollection> All(BetaFeatures.Parameters.Addresses.All parameters) => await List<AddressCollection>("addresses", parameters.ToDictionary());
+
+        /// <summary>
+        ///     Get the next page of a paginated <see cref="AddressCollection"/>.
+        /// </summary>
+        /// <param name="collection">The <see cref="AddressCollection"/> to get the next page of.</param>
+        /// <returns>The next page, as a <see cref="AddressCollection"/> instance.</returns>
+        /// <exception cref="EndOfPaginationError">Thrown if there is no next page to retrieve.</exception>
+        public async Task<AddressCollection> GetNextPage(AddressCollection collection) => await collection.GetNextPage<AddressCollection, Address>(async parameters => await All(parameters), collection.Addresses);
 
         /// <summary>
         ///     Retrieve an Address from its id.

--- a/EasyPost/Services/EndShipperService.cs
+++ b/EasyPost/Services/EndShipperService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using EasyPost._base;
+using EasyPost.Exceptions.General;
 using EasyPost.Models.API;
 using EasyPost.Utilities.Internal.Attributes;
 using EasyPost.Utilities.Internal.Extensions;
@@ -81,6 +82,14 @@ namespace EasyPost.Services
         /// <returns><see cref="EndShipperCollection"/> instance.</returns>
         [CrudOperations.Read]
         public async Task<EndShipperCollection> All(BetaFeatures.Parameters.EndShippers.All parameters) => await List<EndShipperCollection>("end_shippers", parameters.ToDictionary());
+
+        /// <summary>
+        ///     Get the next page of a paginated <see cref="EndShipperCollection"/>.
+        /// </summary>
+        /// <param name="collection">The <see cref="EndShipperCollection"/> to get the next page of.</param>
+        /// <returns>The next page, as a <see cref="EndShipperCollection"/> instance.</returns>
+        /// <exception cref="EndOfPaginationError">Thrown if there is no next page to retrieve.</exception>
+        public async Task<EndShipperCollection> GetNextPage(EndShipperCollection collection) => await collection.GetNextPage<EndShipperCollection, EndShipper>(async parameters => await All(parameters), collection.EndShippers);
 
         /// <summary>
         ///     Retrieve an EndShipper from its id.

--- a/EasyPost/Services/EndShipperService.cs
+++ b/EasyPost/Services/EndShipperService.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using EasyPost._base;
-using EasyPost.Exceptions.General;
 using EasyPost.Models.API;
 using EasyPost.Utilities.Internal.Attributes;
 using EasyPost.Utilities.Internal.Extensions;
@@ -82,15 +81,6 @@ namespace EasyPost.Services
         /// <returns><see cref="EndShipperCollection"/> instance.</returns>
         [CrudOperations.Read]
         public async Task<EndShipperCollection> All(BetaFeatures.Parameters.EndShippers.All parameters) => await List<EndShipperCollection>("end_shippers", parameters.ToDictionary());
-
-        /// <summary>
-        ///     Get the next page of a paginated <see cref="EndShipperCollection"/>.
-        /// </summary>
-        /// <param name="collection">The <see cref="EndShipperCollection"/> to get the next page of.</param>
-        /// <returns>The next page, as a <see cref="EndShipperCollection"/> instance.</returns>
-        /// <exception cref="EndOfPaginationError">Thrown if there is no next page to retrieve.</exception>
-        public async Task<EndShipperCollection> GetNextPage(EndShipperCollection collection) => await collection.GetNextPage<EndShipperCollection, EndShipper>(async parameters => await All(parameters), collection.EndShippers);
-
         /// <summary>
         ///     Retrieve an EndShipper from its id.
         /// </summary>

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ coverage:
 
 ## coverage-check - Check if the coverage is above the minimum threshold
 coverage-check:
-	bash scripts/unix/check_coverage.sh 91
+	bash scripts/unix/check_coverage.sh 90
 
 ## docs - Generates library documentation
 docs:

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ coverage:
 
 ## coverage-check - Check if the coverage is above the minimum threshold
 coverage-check:
-	bash scripts/unix/check_coverage.sh 90
+	bash scripts/unix/check_coverage.sh 91
 
 ## docs - Generates library documentation
 docs:


### PR DESCRIPTION
# Description

This is a proof-of-concept for a new `GetNextPage` function for each of our services (e.g. `Address`) (as needed).

Users pass in the current paginated collection object (e.g. `AddressCollection`), and it will craft the parameters and execute the request to retrieve the next page of results for a paginated collection (or throw an exception if there are no more pages to retrieve).

The underlying base functions for handling this utilize interfaces to abstract away the type restrictions. This means that the base functions will handle any type of paginated collection thrown at them, with the upstream function being more specific and locked down to a specific type (ex. you can't pass a `ShipmentCollection` object into the `Address.GetNextPage()` function).

The base function to calculate parameters for the API call is abstract, and must be implemented in each `XCollection` class to build specific parameters for that class.

For collection types that do not have a pagination capabilities (i.e. EndShipper), the `GetNextPage` function will not be implemented in the service class. The parameter set creation function needs to be implemented due to inheritance, but can simply throw a NotImplementedException, since it will never be called. 

This PR:
- Introduces the base functionality to craft parameters and execute API calls to get the next page of a paginated collection
- Adds a `GetNextPage` function to the base service unit test + cassette

# Testing

- Added unit tests, cassettes for new feature, all pass

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
