### PR TITLE
Account for special parameters for All and GetNextPage for shipments and trackers

### DIFF
--- a/EasyPost.Tests/BetaFeaturesTests/ServicesTests/ReportServiceTest.cs
+++ b/EasyPost.Tests/BetaFeaturesTests/ServicesTests/ReportServiceTest.cs
@@ -121,6 +121,26 @@ namespace EasyPost.Tests.BetaFeaturesTests.ServicesTests
             }
         }
 
+        /// <summary>
+        ///     This test confirms that the parameters used to filter the results of the All() method are passed through to the resulting collection object.
+        /// </summary>
+        [Fact]
+        [CrudOperations.Read]
+        [Testing.Parameters]
+        public async Task TestAllParameterHandOff() {
+            UseVCR("all_parameter_hand_off");
+
+            const string type = "shipment";
+
+            Dictionary<string, object> data = new Dictionary<string, object>() { { "page_size", Fixtures.PageSize } };
+
+            BetaFeatures.Parameters.Reports.All parameters = Fixtures.Parameters.Reports.All(data);
+
+            ReportCollection reportCollection = await Client.Report.All(type, parameters);
+
+            Assert.Equal(type, reportCollection.Type);
+        }
+
         #endregion
 
         #endregion

--- a/EasyPost.Tests/BetaFeaturesTests/ServicesTests/ShipmentServiceTest.cs
+++ b/EasyPost.Tests/BetaFeaturesTests/ServicesTests/ShipmentServiceTest.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using EasyPost.BetaFeatures.Parameters.Shipments;
 using EasyPost.Models.API;
 using EasyPost.Tests._Utilities;
 using EasyPost.Tests._Utilities.Attributes;
@@ -161,6 +162,27 @@ namespace EasyPost.Tests.BetaFeaturesTests.ServicesTests
             {
                 Assert.IsType<Shipment>(shipment);
             }
+        }
+
+        /// <summary>
+        ///     This test confirms that the parameters used to filter the results of the All() method are passed through to the resulting collection object.
+        /// </summary>
+        [Fact]
+        [CrudOperations.Read]
+        [Testing.Parameters]
+        public async Task TestAllParameterHandOff() {
+            UseVCR("all_parameter_hand_off");
+
+            BetaFeatures.Parameters.Shipments.All filters = new All
+            {
+                IncludeChildren = true,
+                Purchased = false,
+            };
+
+            ShipmentCollection shipmentCollection = await Client.Shipment.All(filters);
+
+            Assert.Equal(filters.IncludeChildren, shipmentCollection.IncludeChildren);
+            Assert.Equal(filters.Purchased, shipmentCollection.Purchased);
         }
 
         #endregion

--- a/EasyPost.Tests/BetaFeaturesTests/ServicesTests/TrackerServiceTest.cs
+++ b/EasyPost.Tests/BetaFeaturesTests/ServicesTests/TrackerServiceTest.cs
@@ -78,6 +78,35 @@ namespace EasyPost.Tests.BetaFeaturesTests.ServicesTests
             }
         }
 
+        /// <summary>
+        ///     This test confirms that the parameters used to filter the results of the All() method are passed through to the resulting collection object.
+        /// </summary>
+        [Fact]
+        [CrudOperations.Read]
+        [Testing.Parameters]
+        public async Task TestAllParameterHandOff() {
+            UseVCR("all_parameter_hand_off");
+
+            BetaFeatures.Parameters.Trackers.All filters = new BetaFeatures.Parameters.Trackers.All
+            {
+                TrackingCode = "0",
+                Carrier = "test_carrier",
+            };
+
+            TrackerCollection trackerCollection = await Client.Tracker.All(filters);
+
+            // No trackers will match the filters, so the collection will be empty
+            // Need to make a fake tracker temporarily to get the next page parameters
+            Tracker fakeTracker = new Tracker {
+                TrackingCode = "0",
+                Carrier = "does_not_matter",
+            };
+            trackerCollection.Trackers.Add(fakeTracker);
+
+            Assert.Equal(filters.TrackingCode, trackerCollection.TrackingCode);
+            Assert.Equal(filters.Carrier, trackerCollection.Carrier);
+        }
+
         #endregion
 
         #endregion

--- a/EasyPost.Tests/Fixture.cs
+++ b/EasyPost.Tests/Fixture.cs
@@ -634,6 +634,8 @@ namespace EasyPost.Tests._Utilities
                         AfterId = fixture.GetOrNull<string>("after_id"),
                         StartDatetime = fixture.GetOrNull<string>("start_datetime"),
                         EndDatetime = fixture.GetOrNull<string>("end_datetime"),
+                        IncludeChildren = fixture.GetOrNullBoolean("include_children"),
+                        Purchased = fixture.GetOrNullBoolean("purchased"),
                     };
                 }
             }
@@ -667,6 +669,8 @@ namespace EasyPost.Tests._Utilities
                         AfterId = fixture.GetOrNull<string>("after_id"),
                         StartDatetime = fixture.GetOrNull<string>("start_datetime"),
                         EndDatetime = fixture.GetOrNull<string>("end_datetime"),
+                        TrackingCode = fixture.GetOrNull<string>("tracking_code"),
+                        Carrier = fixture.GetOrNull<string>("carrier"),
                     };
                 }
             }

--- a/EasyPost.Tests/ServicesTests/ReportServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/ReportServiceTest.cs
@@ -108,6 +108,24 @@ namespace EasyPost.Tests.ServicesTests
             }
         }
 
+        /// <summary>
+        ///     This test confirms that the parameters used to filter the results of the All() method are passed through to the resulting collection object.
+        /// </summary>
+        [Fact]
+        [CrudOperations.Read]
+        [Testing.Parameters]
+        public async Task TestAllParameterHandOff() {
+            UseVCR("all_parameter_hand_off");
+
+            const string type = "shipment";
+
+            Dictionary<string, object> filters = new Dictionary<string, object> { { "page_size", Fixtures.PageSize } };
+
+            ReportCollection reportCollection = await Client.Report.All(type, filters);
+
+            Assert.Equal(type, reportCollection.Type);
+        }
+
         [Fact]
         [CrudOperations.Read]
         [Testing.Function]

--- a/EasyPost.Tests/ServicesTests/ShipmentServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/ShipmentServiceTest.cs
@@ -140,6 +140,26 @@ namespace EasyPost.Tests.ServicesTests
             }
         }
 
+        /// <summary>
+        ///     This test confirms that the parameters used to filter the results of the All() method are passed through to the resulting collection object.
+        /// </summary>
+        [Fact]
+        [CrudOperations.Read]
+        [Testing.Parameters]
+        public async Task TestAllParameterHandOff() {
+            UseVCR("all_parameter_hand_off");
+
+            Dictionary<string, object> filters = new Dictionary<string, object> {
+                { "include_children", true },
+                { "purchased", false },
+            };
+
+            ShipmentCollection shipmentCollection = await Client.Shipment.All(filters);
+
+            Assert.Equal(filters["include_children"], shipmentCollection.IncludeChildren);
+            Assert.Equal(filters["purchased"], shipmentCollection.Purchased);
+        }
+
         [Fact]
         [CrudOperations.Read]
         [Testing.Function]
@@ -164,6 +184,28 @@ namespace EasyPost.Tests.ServicesTests
             {
                 Assert.True(false);
             }
+        }
+
+        /// <summary>
+        ///     This test confirms that the parameters used to filter the results of the All() method are used to filter the results of the GetNextPage() method.
+        /// </summary>
+        [Fact]
+        [CrudOperations.Read]
+        [Testing.Parameters]
+        public async Task TestGetNextPageParameterHandOff() {
+            UseVCR("get_next_page_parameter_hand_off");
+
+            Dictionary<string, object> filters = new Dictionary<string, object> {
+                { "include_children", true },
+                { "purchased", false },
+            };
+
+            ShipmentCollection shipmentCollection = await Client.Shipment.All(filters);
+
+            BetaFeatures.Parameters.Shipments.All filtersForNextPage = shipmentCollection.BuildNextPageParameters<BetaFeatures.Parameters.Shipments.All>(shipmentCollection.Shipments);
+
+            Assert.Equal(shipmentCollection.IncludeChildren, filtersForNextPage.IncludeChildren);
+            Assert.Equal(shipmentCollection.Purchased, filtersForNextPage.Purchased);
         }
 
         [Fact]

--- a/EasyPost.Tests/ServicesTests/TrackerServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/TrackerServiceTest.cs
@@ -69,6 +69,26 @@ namespace EasyPost.Tests.ServicesTests
             }
         }
 
+        /// <summary>
+        ///     This test confirms that the parameters used to filter the results of the All() method are passed through to the resulting collection object.
+        /// </summary>
+        [Fact]
+        [CrudOperations.Read]
+        [Testing.Parameters]
+        public async Task TestAllParameterHandOff() {
+            UseVCR("all_parameter_hand_off");
+
+            Dictionary<string, object> filters = new Dictionary<string, object> {
+                { "tracking_code", "0" },
+                { "carrier", "test_carrier" },
+            };
+
+            TrackerCollection trackerCollection = await Client.Tracker.All(filters);
+
+            Assert.Equal(filters["tracking_code"], trackerCollection.TrackingCode);
+            Assert.Equal(filters["carrier"], trackerCollection.Carrier);
+        }
+
         [Fact]
         [CrudOperations.Read]
         [Testing.Function]
@@ -93,6 +113,36 @@ namespace EasyPost.Tests.ServicesTests
             {
                 Assert.True(false);
             }
+        }
+
+        /// <summary>
+        ///     This test confirms that the parameters used to filter the results of the All() method are used to filter the results of the GetNextPage() method.
+        /// </summary>
+        [Fact]
+        [CrudOperations.Read]
+        [Testing.Parameters]
+        public async Task TestGetNextPageParameterHandOff() {
+            UseVCR("get_next_page_parameter_hand_off");
+
+            Dictionary<string, object> filters = new Dictionary<string, object> {
+                { "tracking_code", "0" },
+                { "carrier", "test_carrier" },
+            };
+
+            TrackerCollection trackerCollection = await Client.Tracker.All(filters);
+
+            // No trackers will match the filters, so the collection will be empty
+            // Need to make a fake tracker temporarily to get the next page parameters
+            Tracker fakeTracker = new Tracker {
+                TrackingCode = "0",
+                Carrier = "does_not_matter",
+            };
+            trackerCollection.Trackers.Add(fakeTracker);
+
+            BetaFeatures.Parameters.Trackers.All filtersForNextPage = trackerCollection.BuildNextPageParameters<BetaFeatures.Parameters.Trackers.All>(trackerCollection.Trackers);
+
+            Assert.Equal(trackerCollection.TrackingCode, filtersForNextPage.TrackingCode);
+            Assert.Equal(trackerCollection.Carrier, filtersForNextPage.Carrier);
         }
 
         [Fact]

--- a/EasyPost/BetaFeatures/Parameters/Shipments/All.cs
+++ b/EasyPost/BetaFeatures/Parameters/Shipments/All.cs
@@ -42,6 +42,18 @@ namespace EasyPost.BetaFeatures.Parameters.Shipments
         [TopLevelRequestParameter(Necessity.Optional, "start_datetime")]
         public string? StartDatetime { get; set; }
 
+        /// <summary>
+        ///     If true, only return purchased shipments. Defaults to true.
+        /// </summary>
+        [TopLevelRequestParameter(Necessity.Optional, "purchased")]
+        public bool? Purchased { get; set; } = true;
+
+        /// <summary>
+        ///     If true, also include shipments created by child users.
+        /// </summary>
+        [TopLevelRequestParameter(Necessity.Optional, "include_children")]
+        public bool? IncludeChildren { get; set; }
+
         #endregion
     }
 }

--- a/EasyPost/Models/API/Report.cs
+++ b/EasyPost/Models/API/Report.cs
@@ -38,8 +38,8 @@ namespace EasyPost.Models.API
 
         [JsonProperty("reports")]
         public List<Report>? Reports { get; set; }
-        [JsonProperty("type")]
-        public string? Type { get; set; }
+
+        internal string? Type { get; set; }
 
         #endregion
 

--- a/EasyPost/Models/API/Shipment.cs
+++ b/EasyPost/Models/API/Shipment.cs
@@ -339,6 +339,10 @@ namespace EasyPost.Models.API
         [JsonProperty("shipments")]
         public List<Shipment>? Shipments { get; set; }
 
+        internal bool? Purchased { get; set; }
+
+        internal bool? IncludeChildren { get; set; }
+
         #endregion
 
         internal ShipmentCollection()
@@ -352,6 +356,8 @@ namespace EasyPost.Models.API
             BetaFeatures.Parameters.Shipments.All parameters = new()
             {
                 BeforeId = lastId,
+                Purchased = Purchased,
+                IncludeChildren = IncludeChildren,
             };
 
             if (pageSize != null)

--- a/EasyPost/Models/API/Tracker.cs
+++ b/EasyPost/Models/API/Tracker.cs
@@ -51,6 +51,10 @@ namespace EasyPost.Models.API
         [JsonProperty("trackers")]
         public List<Tracker>? Trackers { get; set; }
 
+        internal string? TrackingCode { get; set; }
+
+        internal string? Carrier { get; set; }
+
         #endregion
 
         internal TrackerCollection()
@@ -64,6 +68,8 @@ namespace EasyPost.Models.API
             BetaFeatures.Parameters.Trackers.All parameters = new()
             {
                 BeforeId = lastId,
+                TrackingCode = TrackingCode,
+                Carrier = Carrier,
             };
 
             if (pageSize != null)

--- a/EasyPost/Services/ShipmentService.cs
+++ b/EasyPost/Services/ShipmentService.cs
@@ -80,6 +80,8 @@ namespace EasyPost.Services
         public async Task<ShipmentCollection> All(Dictionary<string, object>? parameters = null)
         {
             ShipmentCollection shipmentCollection = await List<ShipmentCollection>("shipments", parameters);
+            shipmentCollection.Purchased = parameters?.GetOrNullBoolean("purchased");
+            shipmentCollection.IncludeChildren = parameters?.GetOrNullBoolean("include_children");
             return shipmentCollection;
         }
 
@@ -91,7 +93,10 @@ namespace EasyPost.Services
         [CrudOperations.Read]
         public async Task<ShipmentCollection> All(BetaFeatures.Parameters.Shipments.All parameters)
         {
-            return await List<ShipmentCollection>("shipments", parameters.ToDictionary());
+            ShipmentCollection shipmentCollection = await List<ShipmentCollection>("shipments", parameters.ToDictionary());
+            shipmentCollection.Purchased = parameters.Purchased;
+            shipmentCollection.IncludeChildren = parameters.IncludeChildren;
+            return shipmentCollection;
         }
 
         /// <summary>

--- a/EasyPost/Services/TrackerService.cs
+++ b/EasyPost/Services/TrackerService.cs
@@ -97,6 +97,8 @@ namespace EasyPost.Services
         public async Task<TrackerCollection> All(Dictionary<string, object>? parameters = null)
         {
             TrackerCollection trackerCollection = await List<TrackerCollection>("trackers", parameters);
+            trackerCollection.TrackingCode = parameters?.GetOrNull<string>("tracking_code");
+            trackerCollection.Carrier = parameters?.GetOrNull<string>("carrier");
             return trackerCollection;
         }
 
@@ -108,7 +110,10 @@ namespace EasyPost.Services
         [CrudOperations.Read]
         public async Task<TrackerCollection> All(BetaFeatures.Parameters.Trackers.All parameters)
         {
-            return await List<TrackerCollection>("trackers", parameters.ToDictionary());
+            TrackerCollection trackerCollection = await List<TrackerCollection>("trackers", parameters.ToDictionary());
+            trackerCollection.TrackingCode = parameters.TrackingCode;
+            trackerCollection.Carrier = parameters.Carrier;
+            return trackerCollection;
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

The List endpoints for [Shipments](https://www.easypost.com/docs/api#retrieve-a-list-of-shipments) and [Trackers](https://www.easypost.com/docs/api#retrieve-a-list-of-trackers) take special parameters in addition to the typical `before_id`, `after_id`, etc. parameters.

This PR:
- Captures those unique parameters (both from legacy dictionary and new parameter object flows) and stores them in the resultant `ShipmentCollection` and `TrackerCollection` objects, respectively (internal; cannot be viewed by end-user)
- Reuses these parameters on GetNextPage parameter construction, to ensure any parameters included on the first request for an XCollection will be reused when getting the subsequent pages

This was already in effect for `ReportCollection`, which needed to store the `type` to reuse for the GetNextPage function.

# Testing

- Adds unit tests to ensure that parameters are being captured from dictionary/parameter objects and stored in the XCollection objects
- Adds unit tests to ensure that parameters are being extracted from XCollection objects and reused in GetNextPage parameter construction

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
