### PR TITLE
Handle any potential type of "message" in an Error 

### DIFF
--- a/EasyPost.Tests/ExceptionsTests/ExceptionsTest.cs
+++ b/EasyPost.Tests/ExceptionsTests/ExceptionsTest.cs
@@ -227,7 +227,7 @@ namespace EasyPost.Tests.ExceptionsTests
 
             error = ApiError.FromErrorResponse(response);
             Assert.Equal("ERROR_MESSAGE_1, ERROR_MESSAGE_2", error.Message);
-            
+
             // Test that it can go down multiple levels into sub-dictionaries and collect multiple key-value pairs across multiple levels
             const string errorMessageDictJson = "{\"error\": {\"code\": \"ERROR_CODE\", \"message\": {\"errors\": {\"errors\": {\"errors\": {\"errors\": [\"ERROR_MESSAGE_1\", \"ERROR_MESSAGE_2\"], \"second_element\": \"ERROR_MESSAGE_3\"}}, \"third_element\": \"ERROR_MESSAGE_4\"}}, \"errors\": []}}";
             response = new RestResponse

--- a/EasyPost.Tests/ExceptionsTests/ExceptionsTest.cs
+++ b/EasyPost.Tests/ExceptionsTests/ExceptionsTest.cs
@@ -59,7 +59,7 @@ namespace EasyPost.Tests.ExceptionsTests
 
             // Now test with some error-related JSON inside the response with sub-errors
             errorMessageStringJson = "{\"error\": {\"code\": \"ERROR_CODE\", \"message\": \"ERROR_MESSAGE\", \"errors\": [{\"field\": \"SUB_ERROR_FIELD\", \"message\": \"SUB_ERROR_MESSAGE\"}]}}";
-            List<Error> subErrors = new() { new Error { Field = "SUB_ERROR_FIELD", Message = "SUB_ERROR_MESSAGE" } };
+            List<Error> subErrors = new() { new Error { Field = "SUB_ERROR_FIELD", RawMessage = "SUB_ERROR_MESSAGE" } };
 
             // Generate a dummy RestResponse with the given status code to parse
             httpStatusCode = (HttpStatusCode)Enum.Parse(typeof(HttpStatusCode), statusCode.ToString(CultureInfo.InvariantCulture));
@@ -211,7 +211,7 @@ namespace EasyPost.Tests.ExceptionsTests
             RestResponse response = new()
             {
                 StatusCode = HttpStatusCode.BadRequest,
-                Content = errorMessageStringJson
+                Content = errorMessageStringJson,
             };
 
             ApiError error = ApiError.FromErrorResponse(response);
@@ -222,17 +222,28 @@ namespace EasyPost.Tests.ExceptionsTests
             response = new RestResponse
             {
                 StatusCode = HttpStatusCode.BadRequest,
-                Content = errorMessageArrayJson
+                Content = errorMessageArrayJson,
             };
 
             error = ApiError.FromErrorResponse(response);
             Assert.Equal("ERROR_MESSAGE_1, ERROR_MESSAGE_2", error.Message);
-
-            const string errorMessageBadFormatJson = "{\"error\": {\"code\": \"ERROR_CODE\", \"message\": {\"bad_key\": \"bad_value\"}, \"ERROR_MESSAGE_2\"], \"errors\": []}}";
+            
+            // Test that it can go down multiple levels into sub-dictionaries and collect multiple key-value pairs across multiple levels
+            const string errorMessageDictJson = "{\"error\": {\"code\": \"ERROR_CODE\", \"message\": {\"errors\": {\"errors\": {\"errors\": {\"errors\": [\"ERROR_MESSAGE_1\", \"ERROR_MESSAGE_2\"], \"second_element\": \"ERROR_MESSAGE_3\"}}, \"third_element\": \"ERROR_MESSAGE_4\"}}, \"errors\": []}}";
             response = new RestResponse
             {
                 StatusCode = HttpStatusCode.BadRequest,
-                Content = errorMessageBadFormatJson
+                Content = errorMessageDictJson,
+            };
+
+            error = ApiError.FromErrorResponse(response);
+            Assert.Equal("ERROR_MESSAGE_1, ERROR_MESSAGE_2, ERROR_MESSAGE_3, ERROR_MESSAGE_4", error.Message);
+
+            const string errorMessageBadFormatJson = "{\"error\": {\"code\": \"ERROR_CODE\", \"message\": {bad_key\": \"bad_value\"}, \"ERROR_MESSAGE_2\"], \"errors\": []}}";
+            response = new RestResponse
+            {
+                StatusCode = HttpStatusCode.BadRequest,
+                Content = errorMessageBadFormatJson,
             };
 
             error = ApiError.FromErrorResponse(response);

--- a/EasyPost.Tests/packages.lock.json
+++ b/EasyPost.Tests/packages.lock.json
@@ -293,11 +293,11 @@
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",
-        "requested": "[1.0.3, )",
-        "resolved": "1.0.3",
-        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "requested": "[1.0.2, )",
+        "resolved": "1.0.2",
+        "contentHash": "5/cSEVld+px/CuRrbohO/djfg6++eR6zGpy88MgqloXvkj//WXWpFZyu/OpkXPN0u5m+dN/EVwLNYFUxD4h2+A==",
         "dependencies": {
-          "Microsoft.NETFramework.ReferenceAssemblies.net462": "1.0.3"
+          "Microsoft.NETFramework.ReferenceAssemblies.net462": "1.0.2"
         }
       },
       "Microsoft.VisualStudio.TestPlatform.ObjectModel": {
@@ -434,8 +434,8 @@
       },
       "Microsoft.NETFramework.ReferenceAssemblies.net462": {
         "type": "Transitive",
-        "resolved": "1.0.3",
-        "contentHash": "IzAV30z22ESCeQfxP29oVf4qEo8fBGXLXSU6oacv/9Iqe6PzgHDKCaWfwMBak7bSJQM0F5boXWoZS+kChztRIQ=="
+        "resolved": "1.0.2",
+        "contentHash": "vnWMOt5+4SLOLu5hlB54LMK5OHqsX+5ekbo6vb7USvCM5uA4UKtATuMvIAw69ak62F94c+3895XwF5TcjjzpVw=="
       },
       "System.Buffers": {
         "type": "Transitive",

--- a/EasyPost.Tests/packages.lock.json
+++ b/EasyPost.Tests/packages.lock.json
@@ -293,11 +293,11 @@
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",
-        "requested": "[1.0.2, )",
-        "resolved": "1.0.2",
-        "contentHash": "5/cSEVld+px/CuRrbohO/djfg6++eR6zGpy88MgqloXvkj//WXWpFZyu/OpkXPN0u5m+dN/EVwLNYFUxD4h2+A==",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
         "dependencies": {
-          "Microsoft.NETFramework.ReferenceAssemblies.net462": "1.0.2"
+          "Microsoft.NETFramework.ReferenceAssemblies.net462": "1.0.3"
         }
       },
       "Microsoft.VisualStudio.TestPlatform.ObjectModel": {
@@ -434,8 +434,8 @@
       },
       "Microsoft.NETFramework.ReferenceAssemblies.net462": {
         "type": "Transitive",
-        "resolved": "1.0.2",
-        "contentHash": "vnWMOt5+4SLOLu5hlB54LMK5OHqsX+5ekbo6vb7USvCM5uA4UKtATuMvIAw69ak62F94c+3895XwF5TcjjzpVw=="
+        "resolved": "1.0.3",
+        "contentHash": "IzAV30z22ESCeQfxP29oVf4qEo8fBGXLXSU6oacv/9Iqe6PzgHDKCaWfwMBak7bSJQM0F5boXWoZS+kChztRIQ=="
       },
       "System.Buffers": {
         "type": "Transitive",

--- a/EasyPost/Models/API/Error.cs
+++ b/EasyPost/Models/API/Error.cs
@@ -1,10 +1,18 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using EasyPost._base;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace EasyPost.Models.API
 {
 #pragma warning disable CA1716
+    /// <summary>
+    ///     Represents an error returned by the EasyPost API.
+    ///     These are typically informational about why a request failed (server-side validation issues, missing data, etc.).
+    ///     This is different than the EasyPostError class, which represents exceptions in the EasyPost library,
+    ///     such as bad HTTP status codes or local validation issues. 
+    /// </summary>
     public class Error : EasyPostObject
 #pragma warning restore CA1716
     {
@@ -16,15 +24,65 @@ namespace EasyPost.Models.API
         public List<Error>? Errors { get; set; }
         [JsonProperty("field")]
         public string? Field { get; set; }
-        [JsonProperty("message")]
-        public string? Message { get; set; }
+
+        [JsonIgnore]
+        public string? Message
+        {
+            // This parses the message from the API response and returns it as a string regardless of what type it actually is.
+            get
+            {
+                ICollection<string> messages = CollectErrorMessages(RawMessage, new List<string>());
+                return messages.Count switch
+                {
+                    0 => null,
+                    1 => messages.First(),
+                    var _ => string.Join(", ", messages),
+                };
+            }
+        }
+
         [JsonProperty("suggestion")]
         public string? Suggestion { get; set; }
+
+        /// <summary>
+        ///     The "message" is most likely a string, but it can also be a dictionary or a list from the API.
+        ///     This field is specifically private, hidden from the user, and used to deserialize the message to a string when accessed by the public Message property.
+        /// </summary>
+        [JsonProperty("message")]
+        internal object? RawMessage { get; set; }
 
         #endregion
 
         internal Error()
         {
+        }
+
+        private static ICollection<string> CollectErrorMessages(object? element, ICollection<string> collectedMessages)
+        {
+            switch (element)
+            {
+                case null:
+                    break;
+                case JArray array:
+                    foreach (JToken item in array)
+                    {
+                        collectedMessages = CollectErrorMessages(item, collectedMessages);
+                    }
+                    break;
+                case JObject obj:
+                    foreach (JProperty property in obj.Properties())
+                    {
+                        collectedMessages = CollectErrorMessages(property.Value, collectedMessages);
+                    }
+                    break;
+                default:
+                    string? asString = element.ToString();
+                    if (!string.IsNullOrWhiteSpace(asString))
+                        collectedMessages.Add(asString);
+                    break;
+            }
+            
+            return collectedMessages;
         }
     }
 }

--- a/EasyPost/Models/API/Error.cs
+++ b/EasyPost/Models/API/Error.cs
@@ -11,7 +11,7 @@ namespace EasyPost.Models.API
     ///     Represents an error returned by the EasyPost API.
     ///     These are typically informational about why a request failed (server-side validation issues, missing data, etc.).
     ///     This is different than the EasyPostError class, which represents exceptions in the EasyPost library,
-    ///     such as bad HTTP status codes or local validation issues. 
+    ///     such as bad HTTP status codes or local validation issues.
     /// </summary>
     public class Error : EasyPostObject
 #pragma warning restore CA1716
@@ -68,12 +68,14 @@ namespace EasyPost.Models.API
                     {
                         collectedMessages = CollectErrorMessages(item, collectedMessages);
                     }
+
                     break;
                 case JObject obj:
                     foreach (JProperty property in obj.Properties())
                     {
                         collectedMessages = CollectErrorMessages(property.Value, collectedMessages);
                     }
+
                     break;
                 default:
                     string? asString = element.ToString();
@@ -81,7 +83,7 @@ namespace EasyPost.Models.API
                         collectedMessages.Add(asString);
                     break;
             }
-            
+
             return collectedMessages;
         }
     }


### PR DESCRIPTION
# Description

Most of the time, the `message` property of an `Error` object's JSON data is a string, but occasionally, our API sends something other than a string.

For example:

"message" is a JSON array
```
{
    "error": {
        ...
        "message": [
                "ERROR 1",
                "ERROR 2"
         ], 
       ...
}
```

"message" is a JSON dictionary
```
{
    "error": {
        ...
        "message": {
            "errors": [
                "ERROR 1",
                "ERROR 2"
            ]
        },
       ...
}
```

This PR enhances the JSON deserialization process for `Error` objects to account for the "message" being an array, being a JSON dictionary, or being empty.

# Testing

- Unit tests updated to confirm logic works as expected

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
