### PR TITLE
Better error message for API timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Handle API timeout errors more gracefully (produce proper `TimeoutError` exception with readable messages)
+
 ## v4.6.0 (2023-04-18)
 
 - Adds `GetNextPage` function to each service which retrieves the next page of a collection when the `has_more` key is present in the response (eg: `Client.Address.GetNextPage(addressCollection)`)

--- a/EasyPost.Tests/ExceptionsTests/ExceptionsTest.cs
+++ b/EasyPost.Tests/ExceptionsTests/ExceptionsTest.cs
@@ -436,6 +436,31 @@ namespace EasyPost.Tests.ExceptionsTests
             Assert.Equal(typeof(UnexpectedHttpError), generatedError.GetType());
         }
 
+        [Fact]
+        [Testing.Exception]
+        public async Task TestHTTPTimeoutFriendlyException()
+        {
+            // create a new client with a very short timeout
+            Client client = new(TestUtils.GetApiKey(TestUtils.ApiKey.Test));
+            client.Configuration.ConnectTimeoutMilliseconds = 1;
+            client.Configuration.RequestTimeoutMilliseconds = 1;
+
+            // make a real request that should timeout, assert that it threw a friendly TimeoutError rather than a TaskCanceledException
+            try
+            {
+                await client.Address.Create(Fixtures.CaAddress1);
+                // if we get here, the request didn't time out, consider test failed
+                Assert.Fail("Request did not time out");
+            }
+            catch (Exception e) // capture any exception
+            {
+                // we should get here
+                // assert that the exception is of type TimeoutError
+                Assert.IsType<TimeoutError>(e);
+                Assert.Equal(Constants.ErrorMessages.ApiRequestTimedOut, e.Message);
+            }
+        }
+
         #endregion
     }
 }

--- a/EasyPost/Constants.cs
+++ b/EasyPost/Constants.cs
@@ -84,6 +84,7 @@ namespace EasyPost
             public const string CouldNotPassClient = "Could not pass client to {0}.";
             internal const string ApiErrorDetailsParsingError = "RESPONSE.PARSE_ERROR"; // not for public consumption
             public const string NoMorePagesToRetrieve = "There are no more pages to retrieve.";
+            public const string ApiRequestTimedOut = "The request to EasyPost timed out.";
         }
 
         public static class CarrierAccountTypes

--- a/EasyPost/Exceptions/API/_Base.cs
+++ b/EasyPost/Exceptions/API/_Base.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+using System.Threading.Tasks;
 using EasyPost.Models.API;
 using EasyPost.Utilities.Internal;
 using RestSharp;
@@ -73,6 +74,13 @@ namespace EasyPost.Exceptions.API
         {
             // NOTE: This method anticipates that the status code will be a non-2xx code.
             // Do not use this method to parse a successful response.
+
+            // short-circuit if the request timed out
+            if (response.ErrorException?.GetType() == typeof(TaskCanceledException))
+            {
+                return new TimeoutError(Constants.ErrorMessages.ApiRequestTimedOut, 408);
+            }
+
             HttpStatusCode statusCode = response.StatusCode;
             int statusCodeInt = (int)statusCode;
 


### PR DESCRIPTION
# Description

Better handling for API timeout errors. Rather than proceeding with error handling, which produces a `ConnectionError` exception with an ambiguous error message, an API timeout will instead produce a `TimeoutError` with an understandable error message.

Portion of #433 

# Testing

- New unit test to confirm functionality

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
