### PR TITLE
[chore] Replace HTTP method, prep for RestSharp drop

### DIFF
--- a/EasyPost.Tests/BetaFeaturesTests/ServicesTests/BillingServiceTest.cs
+++ b/EasyPost.Tests/BetaFeaturesTests/ServicesTests/BillingServiceTest.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Net;
 using EasyPost.Models.API;
 using EasyPost.Tests._Utilities;
-using RestSharp;
 
 namespace EasyPost.Tests.BetaFeaturesTests.ServicesTests
 {
@@ -19,23 +18,23 @@ namespace EasyPost.Tests.BetaFeaturesTests.ServicesTests
                 return new List<TestUtils.MockRequest>
                 {
                     new(
-                        new TestUtils.MockRequestMatchRules(Method.Post, @"^v2\/bank_accounts\/\S*\/charges$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^v2\/bank_accounts\/\S*\/charges$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Method.Post, @"^v2\/credit_cards\/\S*\/charges$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^v2\/credit_cards\/\S*\/charges$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Method.Delete, @"^v2\/bank_accounts\/\S*$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Delete, @"^v2\/bank_accounts\/\S*$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Method.Delete, @"^v2\/credit_cards\/\S*$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Delete, @"^v2\/credit_cards\/\S*$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/payment_methods$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/payment_methods$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethodsSummary
                         {
                             Id = "summary_123",

--- a/EasyPost.Tests/ServicesTests/BillingServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/BillingServiceTest.cs
@@ -7,7 +7,6 @@ using EasyPost.Models.API;
 using EasyPost.Tests._Utilities;
 using EasyPost.Tests._Utilities.Attributes;
 using EasyPost.Utilities.Internal.Attributes;
-using RestSharp;
 using Xunit;
 
 namespace EasyPost.Tests.ServicesTests
@@ -25,23 +24,23 @@ namespace EasyPost.Tests.ServicesTests
                 return new List<TestUtils.MockRequest>
                 {
                     new(
-                        new TestUtils.MockRequestMatchRules(Method.Post, @"^v2\/bank_accounts\/\S*\/charges$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^v2\/bank_accounts\/\S*\/charges$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Method.Post, @"^v2\/credit_cards\/\S*\/charges$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^v2\/credit_cards\/\S*\/charges$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Method.Delete, @"^v2\/bank_accounts\/\S*$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Delete, @"^v2\/bank_accounts\/\S*$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Method.Delete, @"^v2\/credit_cards\/\S*$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Delete, @"^v2\/credit_cards\/\S*$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/payment_methods$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/payment_methods$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethodsSummary
                         {
                             Id = "summary_123",
@@ -111,7 +110,7 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/payment_methods$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/payment_methods$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethodsSummary
                     {
                         Id = null, // No ID, will throw an error when we try to interact with this summary
@@ -161,7 +160,7 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/payment_methods$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/payment_methods$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethodsSummary
                     {
                         Id = "summary_123",
@@ -183,7 +182,7 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/payment_methods$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/payment_methods$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethodsSummary
                     {
                         Id = "summary_123",

--- a/EasyPost.Tests/ServicesTests/PartnerServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/PartnerServiceTest.cs
@@ -9,7 +9,6 @@ using EasyPost.Models.API;
 using EasyPost.Tests._Utilities;
 using EasyPost.Tests._Utilities.Attributes;
 using EasyPost.Utilities.Internal.Attributes;
-using RestSharp;
 using Xunit;
 
 namespace EasyPost.Tests.ServicesTests
@@ -90,15 +89,15 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"pk_test_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Post, @"^https://api.stripe.com/v1/tokens$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^https://api.stripe.com/v1/tokens$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"id\":\"tok_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Post, @"^v2\/credit_cards$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^v2\/credit_cards$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethod
                     {
                         Id = "summary_123",
@@ -127,15 +126,15 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"pk_test_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Post, @"^https://api.stripe.com/v1/tokens$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^https://api.stripe.com/v1/tokens$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"id\":\"tok_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Post, @"^v2\/credit_cards$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^v2\/credit_cards$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethod
                     {
                         Id = "summary_123",
@@ -170,7 +169,7 @@ namespace EasyPost.Tests.ServicesTests
             {
                 {
                     new(
-                        new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/partners\/stripe_public_key$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"\"}")
                     )
                 }
@@ -188,7 +187,7 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"not_public_key\":\"random\"}")
                 ),
             });
@@ -205,11 +204,11 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"pk_test_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Post, @"^https://api.stripe.com/v1/tokens$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^https://api.stripe.com/v1/tokens$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"id\":\"\"}")
                 )
             });
@@ -226,11 +225,11 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"pk_test_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Post, @"^https://api.stripe.com/v1/tokens$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^https://api.stripe.com/v1/tokens$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.NotFound, content: "{}")
                 )
             });
@@ -247,11 +246,11 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"pk_test_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Post, @"^https://api.stripe.com/v1/tokens$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^https://api.stripe.com/v1/tokens$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"not_id\":\"random\"}")
                 )
             });
@@ -268,15 +267,15 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"pk_test_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Post, @"^https://api.stripe.com/v1/tokens$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^https://api.stripe.com/v1/tokens$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"id\":\"tok_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Post, @"^v2\/credit_cards$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^v2\/credit_cards$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.NotFound, content: "{}")
                 )
             });

--- a/EasyPost.Tests/ServicesTests/ServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/ServiceTest.cs
@@ -6,7 +6,6 @@ using EasyPost.Models.API;
 using EasyPost.Tests._Utilities;
 using EasyPost.Tests._Utilities.Attributes;
 using EasyPost.Utilities.Internal.Attributes;
-using RestSharp;
 using Xunit;
 
 namespace EasyPost.Tests.ServicesTests
@@ -70,7 +69,7 @@ namespace EasyPost.Tests.ServicesTests
             {
                 // API call to get the page of addresses will return an empty list with HasMore = false
                 new(
-                    new TestUtils.MockRequestMatchRules(Method.Get, @"^v2\/addresses$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/addresses$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new AddressCollection
                     {
                         Addresses = new List<Address>(),

--- a/EasyPost.Tests/TestUtils.cs
+++ b/EasyPost.Tests/TestUtils.cs
@@ -167,11 +167,11 @@ namespace EasyPost.Tests._Utilities
 
         public class MockRequestMatchRules
         {
-            internal Method Method { get; set; }
+            internal Http.Method Method { get; set; }
 
             internal string ResourceRegex { get; set; }
 
-            public MockRequestMatchRules(Method method, string resourceRegex)
+            public MockRequestMatchRules(Http.Method method, string resourceRegex)
             {
                 Method = method;
                 ResourceRegex = resourceRegex;
@@ -243,7 +243,7 @@ namespace EasyPost.Tests._Utilities
                 return new RestResponse
                 {
                     Content = mockRequest.ResponseInfo.Content,
-                    StatusCode = mockRequest.ResponseInfo.StatusCode
+                    StatusCode = mockRequest.ResponseInfo.StatusCode,
                 };
             }
 
@@ -255,7 +255,7 @@ namespace EasyPost.Tests._Utilities
 
             internal void AddMockRequests(IEnumerable<MockRequest> mockRequests) => _mockRequests.AddRange(mockRequests);
 
-            private MockRequest? FindMatchingMockRequest(RestRequest request) => _mockRequests.FirstOrDefault(mock => mock.MatchRules.Method == request.Method && EndpointMatches(request.Resource, mock.MatchRules.ResourceRegex));
+            private MockRequest? FindMatchingMockRequest(RestRequest request) => _mockRequests.FirstOrDefault(mock => mock.MatchRules.Method.RestSharpMethod == request.Method && EndpointMatches(request.Resource, mock.MatchRules.ResourceRegex));
 
             private static bool EndpointMatches(string endpoint, string pattern)
             {

--- a/EasyPost/Http/Method.cs
+++ b/EasyPost/Http/Method.cs
@@ -1,0 +1,41 @@
+using System.Net.Http;
+
+namespace EasyPost.Http
+{
+    /// <summary>
+    ///     Enum representing the available HTTP methods.
+    /// </summary>
+    public class Method
+    {
+        internal HttpMethod HttpMethod { get; }
+
+        internal RestSharp.Method RestSharpMethod { get; }
+
+        /// <summary>
+        ///     HTTP GET method.
+        /// </summary>
+        public static readonly Method Get = new Method(HttpMethod.Get, RestSharp.Method.Get);
+        /// <summary>
+        ///     HTTP POST method.
+        /// </summary>
+        public static readonly Method Post = new Method(HttpMethod.Post, RestSharp.Method.Post);
+        /// <summary>
+        ///     HTTP PUT method.
+        /// </summary>
+        public static readonly Method Put = new Method(HttpMethod.Put, RestSharp.Method.Put);
+        /// <summary>
+        ///     HTTP DELETE method.
+        /// </summary>
+        public static readonly Method Delete = new Method(HttpMethod.Delete, RestSharp.Method.Delete);
+        /// <summary>
+        ///     HTTP PATCH method.
+        /// </summary>
+        public static readonly Method Patch = new Method(new HttpMethod("PATCH"), RestSharp.Method.Patch);
+
+        private Method(HttpMethod httpMethod, RestSharp.Method restSharpMethod)
+        {
+            HttpMethod = httpMethod;
+            RestSharpMethod = restSharpMethod;
+        }
+    }
+}

--- a/EasyPost/Models/API/Address.cs
+++ b/EasyPost/Models/API/Address.cs
@@ -7,7 +7,6 @@ using EasyPost.Exceptions.General;
 using EasyPost.Models.Shared;
 using EasyPost.Utilities.Internal.Attributes;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -71,7 +70,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, nameof(Id));
             }
 
-            await Update<Address>(Method.Get, $"addresses/{Id}/verify", null, "address");
+            await Update<Address>(Http.Method.Get, $"addresses/{Id}/verify", null, "address");
             return this;
         }
 

--- a/EasyPost/Models/API/Batch.cs
+++ b/EasyPost/Models/API/Batch.cs
@@ -7,7 +7,6 @@ using EasyPost.Exceptions.General;
 using EasyPost.Models.Shared;
 using EasyPost.Utilities.Internal.Attributes;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -56,7 +55,7 @@ namespace EasyPost.Models.API
             }
 
             // parameters = parameters.Wrap("batch");  // TODO: Update docs to remove wrapped "batch" key
-            await Update<Batch>(Method.Post, $"batches/{Id}/add_shipments", parameters);
+            await Update<Batch>(Http.Method.Post, $"batches/{Id}/add_shipments", parameters);
             return this;
         }
 
@@ -73,7 +72,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, nameof(Id));
             }
 
-            await Update<Batch>(Method.Post, $"batches/{Id}/add_shipments", parameters.ToDictionary());
+            await Update<Batch>(Http.Method.Post, $"batches/{Id}/add_shipments", parameters.ToDictionary());
             return this;
         }
 
@@ -113,7 +112,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, nameof(Id));
             }
 
-            await Update<Batch>(Method.Post, $"batches/{Id}/buy");
+            await Update<Batch>(Http.Method.Post, $"batches/{Id}/buy");
             return this;
         }
 
@@ -131,7 +130,7 @@ namespace EasyPost.Models.API
             }
 
             Dictionary<string, object> parameters = new() { { "file_format", fileFormat } };
-            await Update<Batch>(Method.Post, $"batches/{Id}/label", parameters);
+            await Update<Batch>(Http.Method.Post, $"batches/{Id}/label", parameters);
             return this;
         }
 
@@ -148,7 +147,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, nameof(Id));
             }
 
-            await Update<Batch>(Method.Post, $"batches/{Id}/label", parameters.ToDictionary());
+            await Update<Batch>(Http.Method.Post, $"batches/{Id}/label", parameters.ToDictionary());
             return this;
         }
 
@@ -166,7 +165,7 @@ namespace EasyPost.Models.API
             }
 
             Dictionary<string, object> parameters = new() { { "file_format", fileFormat } };
-            await Update<Batch>(Method.Post, $"batches/{Id}/scan_form", parameters);
+            await Update<Batch>(Http.Method.Post, $"batches/{Id}/scan_form", parameters);
             return this;
         }
 
@@ -183,7 +182,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, nameof(Id));
             }
 
-            await Update<Batch>(Method.Post, $"batches/{Id}/scan_form", parameters.ToDictionary());
+            await Update<Batch>(Http.Method.Post, $"batches/{Id}/scan_form", parameters.ToDictionary());
             return this;
         }
 
@@ -201,7 +200,7 @@ namespace EasyPost.Models.API
             }
 
             // parameters = parameters.Wrap("batch");  // TODO: Update docs to remove wrapped "batch" key
-            await Update<Batch>(Method.Post, $"batches/{Id}/remove_shipments", parameters);
+            await Update<Batch>(Http.Method.Post, $"batches/{Id}/remove_shipments", parameters);
             return this;
         }
 
@@ -218,7 +217,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, nameof(Id));
             }
 
-            await Update<Batch>(Method.Post, $"batches/{Id}/remove_shipments", parameters.ToDictionary());
+            await Update<Batch>(Http.Method.Post, $"batches/{Id}/remove_shipments", parameters.ToDictionary());
             return this;
         }
 

--- a/EasyPost/Models/API/CarrierAccount.cs
+++ b/EasyPost/Models/API/CarrierAccount.cs
@@ -6,7 +6,6 @@ using EasyPost.BetaFeatures.Parameters;
 using EasyPost.Utilities.Internal.Attributes;
 using EasyPost.Utilities.Internal.Extensions;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -47,7 +46,7 @@ namespace EasyPost.Models.API
         public async Task<CarrierAccount> Update(Dictionary<string, object> parameters)
         {
             parameters = parameters.Wrap("carrier_account");
-            await Update<CarrierAccount>(Method.Patch, $"carrier_accounts/{Id}", parameters);
+            await Update<CarrierAccount>(Http.Method.Patch, $"carrier_accounts/{Id}", parameters);
             return this;
         }
 
@@ -59,7 +58,7 @@ namespace EasyPost.Models.API
         [CrudOperations.Update]
         public async Task<CarrierAccount> Update(BetaFeatures.Parameters.CarrierAccounts.Update parameters)
         {
-            await Update<CarrierAccount>(Method.Patch, $"carrier_accounts/{Id}", parameters.ToDictionary());
+            await Update<CarrierAccount>(Http.Method.Patch, $"carrier_accounts/{Id}", parameters.ToDictionary());
             return this;
         }
 

--- a/EasyPost/Models/API/EndShipper.cs
+++ b/EasyPost/Models/API/EndShipper.cs
@@ -7,7 +7,6 @@ using EasyPost.Models.Shared;
 using EasyPost.Utilities.Internal.Attributes;
 using EasyPost.Utilities.Internal.Extensions;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -59,7 +58,7 @@ namespace EasyPost.Models.API
             parameters = parameters.Wrap("address");
 
             // EndShipper needs Put, not Patch
-            await Update<EndShipper>(Method.Put, $"end_shippers/{Id}", parameters);
+            await Update<EndShipper>(Http.Method.Put, $"end_shippers/{Id}", parameters);
             return this;
         }
 
@@ -72,7 +71,7 @@ namespace EasyPost.Models.API
         public async Task<EndShipper> Update(BetaFeatures.Parameters.EndShippers.Update parameters)
         {
             // EndShipper needs Put, not Patch
-            await Update<EndShipper>(Method.Put, $"end_shippers/{Id}", parameters.ToDictionary());
+            await Update<EndShipper>(Http.Method.Put, $"end_shippers/{Id}", parameters.ToDictionary());
             return this;
         }
 

--- a/EasyPost/Models/API/Insurance.cs
+++ b/EasyPost/Models/API/Insurance.cs
@@ -7,7 +7,6 @@ using EasyPost.BetaFeatures.Parameters;
 using EasyPost.Models.Shared;
 using EasyPost.Utilities.Internal.Attributes;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -57,7 +56,7 @@ namespace EasyPost.Models.API
         [Obsolete("Use the Retrieve method instead. This method will be removed in a future version.")]
         public async Task<Insurance> Refresh(Dictionary<string, object>? parameters = null)
         {
-            await Update<Insurance>(Method.Get, $"insurances/{Id}");
+            await Update<Insurance>(Http.Method.Get, $"insurances/{Id}");
             return this;
         }
 

--- a/EasyPost/Models/API/Order.cs
+++ b/EasyPost/Models/API/Order.cs
@@ -5,7 +5,6 @@ using EasyPost.BetaFeatures.Parameters;
 using EasyPost.Exceptions.General;
 using EasyPost.Utilities.Internal.Attributes;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -66,7 +65,7 @@ namespace EasyPost.Models.API
                 { "service", withService },
             };
 
-            await Update<Order>(Method.Post, $"orders/{Id}/buy", parameters);
+            await Update<Order>(Http.Method.Post, $"orders/{Id}/buy", parameters);
             return this;
         }
 
@@ -106,7 +105,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, nameof(Id));
             }
 
-            await Update<Order>(Method.Post, $"orders/{Id}/buy", parameters.ToDictionary());
+            await Update<Order>(Http.Method.Post, $"orders/{Id}/buy", parameters.ToDictionary());
             return this;
         }
 
@@ -123,7 +122,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, nameof(Id));
             }
 
-            await Update<Order>(Method.Get, $"orders/{Id}/rates");
+            await Update<Order>(Http.Method.Get, $"orders/{Id}/rates");
         }
 
         #endregion

--- a/EasyPost/Models/API/Pickup.cs
+++ b/EasyPost/Models/API/Pickup.cs
@@ -8,7 +8,6 @@ using EasyPost.Exceptions.General;
 using EasyPost.Models.Shared;
 using EasyPost.Utilities.Internal.Attributes;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -75,7 +74,7 @@ namespace EasyPost.Models.API
                 { "service", withService },
             };
 
-            await Update<Pickup>(Method.Post, $"pickups/{Id}/buy", parameters);
+            await Update<Pickup>(Http.Method.Post, $"pickups/{Id}/buy", parameters);
             return this;
         }
 
@@ -92,7 +91,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, nameof(Id));
             }
 
-            await Update<Pickup>(Method.Post, $"pickups/{Id}/buy", parameters.ToDictionary());
+            await Update<Pickup>(Http.Method.Post, $"pickups/{Id}/buy", parameters.ToDictionary());
             return this;
         }
 
@@ -108,7 +107,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, nameof(Id));
             }
 
-            await Update<Pickup>(Method.Post, $"pickups/{Id}/cancel");
+            await Update<Pickup>(Http.Method.Post, $"pickups/{Id}/cancel");
             return this;
         }
 

--- a/EasyPost/Models/API/Shipment.cs
+++ b/EasyPost/Models/API/Shipment.cs
@@ -7,7 +7,6 @@ using EasyPost.Exceptions.General;
 using EasyPost.Models.Shared;
 using EasyPost.Utilities.Internal.Attributes;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -94,7 +93,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, nameof(Id));
             }
 
-            return await Request<List<Smartrate>>(Method.Get, $"shipments/{Id}/smartrate", null, "result");
+            return await Request<List<Smartrate>>(Http.Method.Get, $"shipments/{Id}/smartrate", null, "result");
         }
 
         /// <summary>
@@ -131,7 +130,7 @@ namespace EasyPost.Models.API
                 parameters.Add("end_shipper", endShipperId);
             }
 
-            await Update<Shipment>(Method.Post, $"shipments/{Id}/buy", parameters);
+            await Update<Shipment>(Http.Method.Post, $"shipments/{Id}/buy", parameters);
         }
 
         /// <summary>
@@ -166,7 +165,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, nameof(Id));
             }
 
-            await Update<Shipment>(Method.Post, $"shipments/{Id}/buy", parameters.ToDictionary());
+            await Update<Shipment>(Http.Method.Post, $"shipments/{Id}/buy", parameters.ToDictionary());
             return this;
         }
 
@@ -185,7 +184,7 @@ namespace EasyPost.Models.API
 
             Dictionary<string, object> parameters = new() { { "file_format", fileFormat } };
 
-            await Update<Shipment>(Method.Get, $"shipments/{Id}/label", parameters);
+            await Update<Shipment>(Http.Method.Get, $"shipments/{Id}/label", parameters);
             return this;
         }
 
@@ -202,7 +201,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, nameof(Id));
             }
 
-            await Update<Shipment>(Method.Get, $"shipments/{Id}/label", parameters.ToDictionary());
+            await Update<Shipment>(Http.Method.Get, $"shipments/{Id}/label", parameters.ToDictionary());
             return this;
         }
 
@@ -221,7 +220,7 @@ namespace EasyPost.Models.API
 
             Dictionary<string, object> parameters = new() { { "amount", amount } };
 
-            await Update<Shipment>(Method.Post, $"shipments/{Id}/insure", parameters);
+            await Update<Shipment>(Http.Method.Post, $"shipments/{Id}/insure", parameters);
             return this;
         }
 
@@ -238,7 +237,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, nameof(Id));
             }
 
-            await Update<Shipment>(Method.Post, $"shipments/{Id}/insure", parameters.ToDictionary());
+            await Update<Shipment>(Http.Method.Post, $"shipments/{Id}/insure", parameters.ToDictionary());
             return this;
         }
 
@@ -254,7 +253,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, nameof(Id));
             }
 
-            await Update<Shipment>(Method.Post, $"shipments/{Id}/refund");
+            await Update<Shipment>(Http.Method.Post, $"shipments/{Id}/refund");
             return this;
         }
 
@@ -276,7 +275,7 @@ namespace EasyPost.Models.API
 
             parameters.Add("carbon_offset", withCarbonOffset);
 
-            Shipment shipment = await Request<Shipment>(Method.Post, $"shipments/{Id}/rerate", parameters);
+            Shipment shipment = await Request<Shipment>(Http.Method.Post, $"shipments/{Id}/rerate", parameters);
             Rates = shipment.Rates;
         }
 
@@ -293,7 +292,7 @@ namespace EasyPost.Models.API
                 throw new MissingPropertyError(this, nameof(Id));
             }
 
-            Shipment shipment = await Request<Shipment>(Method.Post, $"shipments/{Id}/rerate", parameters.ToDictionary());
+            Shipment shipment = await Request<Shipment>(Http.Method.Post, $"shipments/{Id}/rerate", parameters.ToDictionary());
             Rates = shipment.Rates;
         }
 

--- a/EasyPost/Models/API/User.cs
+++ b/EasyPost/Models/API/User.cs
@@ -4,7 +4,6 @@ using EasyPost.BetaFeatures.Parameters;
 using EasyPost.Models.Shared;
 using EasyPost.Utilities.Internal.Attributes;
 using EasyPost.Utilities.Internal.Extensions;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -35,7 +34,7 @@ namespace EasyPost.Models.API
         public async Task<Brand> UpdateBrand(Dictionary<string, object> parameters)
         {
             parameters = parameters.Wrap("brand");
-            return await Request<Brand>(Method.Patch, $"users/{Id}/brand", parameters);
+            return await Request<Brand>(Http.Method.Patch, $"users/{Id}/brand", parameters);
         }
 
         /// <summary>
@@ -46,7 +45,7 @@ namespace EasyPost.Models.API
         [CrudOperations.Create]
         public async Task<Brand> UpdateBrand(BetaFeatures.Parameters.Users.UpdateBrand parameters)
         {
-            return await Request<Brand>(Method.Patch, $"users/{Id}/brand", parameters.ToDictionary());
+            return await Request<Brand>(Http.Method.Patch, $"users/{Id}/brand", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -68,7 +67,7 @@ namespace EasyPost.Models.API
         [CrudOperations.Update]
         public async Task<User> Update(Dictionary<string, object> parameters)
         {
-            await Update<User>(Method.Patch, $"users/{Id}", parameters);
+            await Update<User>(Http.Method.Patch, $"users/{Id}", parameters);
             return this;
         }
 
@@ -80,7 +79,7 @@ namespace EasyPost.Models.API
         [CrudOperations.Update]
         public async Task<User> Update(BetaFeatures.Parameters.Users.Update parameters)
         {
-            await Update<User>(Method.Patch, $"users/{Id}", parameters.ToDictionary());
+            await Update<User>(Http.Method.Patch, $"users/{Id}", parameters.ToDictionary());
             return this;
         }
 

--- a/EasyPost/Models/API/Webhook.cs
+++ b/EasyPost/Models/API/Webhook.cs
@@ -5,7 +5,6 @@ using EasyPost._base;
 using EasyPost.BetaFeatures.Parameters;
 using EasyPost.Utilities.Internal.Attributes;
 using Newtonsoft.Json;
-using RestSharp;
 
 namespace EasyPost.Models.API
 {
@@ -39,7 +38,7 @@ namespace EasyPost.Models.API
         [CrudOperations.Update]
         public async Task<Webhook> Update(Dictionary<string, object>? parameters = null)
         {
-            await Update<Webhook>(Method.Patch, $"webhooks/{Id}", parameters);
+            await Update<Webhook>(Http.Method.Patch, $"webhooks/{Id}", parameters);
             return this;
         }
 
@@ -51,7 +50,7 @@ namespace EasyPost.Models.API
         [CrudOperations.Update]
         public async Task<Webhook> Update(BetaFeatures.Parameters.Webhooks.Update parameters)
         {
-            await Update<Webhook>(Method.Patch, $"webhooks/{Id}", parameters.ToDictionary());
+            await Update<Webhook>(Http.Method.Patch, $"webhooks/{Id}", parameters.ToDictionary());
             return this;
         }
 

--- a/EasyPost/Services/Beta/ReferralService.cs
+++ b/EasyPost/Services/Beta/ReferralService.cs
@@ -5,7 +5,6 @@ using EasyPost.Exceptions.API;
 using EasyPost.Models.API;
 using EasyPost.Models.API.Beta;
 using EasyPost.Utilities.Internal.Attributes;
-using RestSharp;
 
 namespace EasyPost.Services.Beta
 {
@@ -46,7 +45,7 @@ namespace EasyPost.Services.Beta
                 },
             };
 
-            return await Request<PaymentMethod>(Method.Post, "referral_customers/payment_method", parameters, overrideApiVersion: ApiVersion.Beta);
+            return await Request<PaymentMethod>(Http.Method.Post, "referral_customers/payment_method", parameters, overrideApiVersion: ApiVersion.Beta);
         }
 
         /// <summary>
@@ -60,7 +59,7 @@ namespace EasyPost.Services.Beta
         [CrudOperations.Update]
         public async Task<PaymentMethod> AddPaymentMethod(BetaFeatures.Parameters.ReferralCustomers.AddPaymentMethod parameters)
         {
-            return await Request<PaymentMethod>(Method.Post, "referral_customers/payment_method", parameters.ToDictionary(), overrideApiVersion: ApiVersion.Beta);
+            return await Request<PaymentMethod>(Http.Method.Post, "referral_customers/payment_method", parameters.ToDictionary(), overrideApiVersion: ApiVersion.Beta);
         }
 
         /// <summary>
@@ -77,7 +76,7 @@ namespace EasyPost.Services.Beta
                 { "refund_amount", amount },
             };
 
-            return await Request<PaymentRefund>(Method.Post, "referral_customers/refunds", parameters, overrideApiVersion: ApiVersion.Beta);
+            return await Request<PaymentRefund>(Http.Method.Post, "referral_customers/refunds", parameters, overrideApiVersion: ApiVersion.Beta);
         }
 
         /// <summary>
@@ -88,7 +87,7 @@ namespace EasyPost.Services.Beta
         [CrudOperations.Update]
         public async Task<PaymentRefund> RefundByAmount(BetaFeatures.Parameters.ReferralCustomers.RefundByAmount parameters)
         {
-            return await Request<PaymentRefund>(Method.Post, "referral_customers/refunds", parameters.ToDictionary(), overrideApiVersion: ApiVersion.Beta);
+            return await Request<PaymentRefund>(Http.Method.Post, "referral_customers/refunds", parameters.ToDictionary(), overrideApiVersion: ApiVersion.Beta);
         }
 
         /// <summary>
@@ -105,7 +104,7 @@ namespace EasyPost.Services.Beta
                 { "payment_log_id", paymentLogId },
             };
 
-            return await Request<PaymentRefund>(Method.Post, "referral_customers/refunds", parameters, overrideApiVersion: ApiVersion.Beta);
+            return await Request<PaymentRefund>(Http.Method.Post, "referral_customers/refunds", parameters, overrideApiVersion: ApiVersion.Beta);
         }
 
         /// <summary>
@@ -116,7 +115,7 @@ namespace EasyPost.Services.Beta
         [CrudOperations.Update]
         public async Task<PaymentRefund> RefundByPaymentLog(BetaFeatures.Parameters.ReferralCustomers.RefundByPaymentLog parameters)
         {
-            return await Request<PaymentRefund>(Method.Post, "referral_customers/refunds", parameters.ToDictionary(), overrideApiVersion: ApiVersion.Beta);
+            return await Request<PaymentRefund>(Http.Method.Post, "referral_customers/refunds", parameters.ToDictionary(), overrideApiVersion: ApiVersion.Beta);
         }
 
         #endregion

--- a/EasyPost/Services/PartnerService.cs
+++ b/EasyPost/Services/PartnerService.cs
@@ -165,7 +165,7 @@ namespace EasyPost.Services
             try
             {
                 // Make request
-                paymentMethod = await Client.Request<PaymentMethod>(Method.Post, "credit_cards", ApiVersion.Current, parameters);
+                paymentMethod = await Client.Request<PaymentMethod>(Http.Method.Post, "credit_cards", ApiVersion.Current, parameters);
             }
             finally
             {

--- a/EasyPost/_base/EasyPostClient.cs
+++ b/EasyPost/_base/EasyPostClient.cs
@@ -83,7 +83,7 @@ namespace EasyPost._base
         /// <param name="rootElement">Optional root element for the JSON to begin deserialization at.</param>
         /// <typeparam name="T">Type of object to deserialize response data into. Must be subclass of EasyPostObject.</typeparam>
         /// <returns>An instance of a T type object.</returns>
-        internal async Task<T> Request<T>(Method method, string endpoint, ApiVersion apiVersion, Dictionary<string, object>? parameters = null, string? rootElement = null)
+        internal async Task<T> Request<T>(Http.Method method, string endpoint, ApiVersion apiVersion, Dictionary<string, object>? parameters = null, string? rootElement = null)
             where T : class
         {
             // Build the request
@@ -191,7 +191,7 @@ namespace EasyPost._base
         /// <param name="parameters">Optional parameters to use for the request.</param>
         /// <returns>Whether request was successful.</returns>
         // ReSharper disable once UnusedMethodReturnValue.Global
-        internal async Task<bool> Request(Method method, string endpoint, ApiVersion apiVersion, Dictionary<string, object>? parameters = null)
+        internal async Task<bool> Request(Http.Method method, string endpoint, ApiVersion apiVersion, Dictionary<string, object>? parameters = null)
         {
             // Build the request
             Request request = new(endpoint, method, apiVersion, parameters);

--- a/EasyPost/_base/EasyPostObject.cs
+++ b/EasyPost/_base/EasyPostObject.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
-using RestSharp;
 
 #pragma warning disable SA1300
 namespace EasyPost._base
@@ -67,7 +66,7 @@ namespace EasyPost._base
         /// <param name="overrideApiVersion">Override the API version used for update call.</param>
         /// <typeparam name="T">Type of object to update.</typeparam>
         /// <returns>A task representing the asynchronous operation.</returns>
-        protected async Task Update<T>(Method method, string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null)
+        protected async Task Update<T>(Http.Method method, string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null)
             where T : class
         {
             T updatedObject = await Request<T>(method, url, parameters, rootElement, overrideApiVersion);

--- a/EasyPost/_base/WithClient.cs
+++ b/EasyPost/_base/WithClient.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using EasyPost.Utilities.Internal.Attributes;
 using Newtonsoft.Json;
-using RestSharp;
 
 #pragma warning disable SA1300
 namespace EasyPost._base
@@ -16,28 +15,28 @@ namespace EasyPost._base
         [CrudOperations.Create]
         protected async Task<T> Create<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null)
             where T : class
-            => await Request<T>(Method.Post, url, parameters, rootElement, overrideApiVersion);
+            => await Request<T>(Http.Method.Post, url, parameters, rootElement, overrideApiVersion);
 
         [CrudOperations.Create]
-        protected async Task CreateNoResponse(string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Request(Method.Post, url, parameters, overrideApiVersion);
+        protected async Task CreateNoResponse(string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Request(Http.Method.Post, url, parameters, overrideApiVersion);
 
         [CrudOperations.Delete]
         protected async Task<T> Delete<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null)
             where T : class
-            => await Request<T>(Method.Delete, url, parameters, rootElement, overrideApiVersion);
+            => await Request<T>(Http.Method.Delete, url, parameters, rootElement, overrideApiVersion);
 
         [CrudOperations.Delete]
-        protected async Task DeleteNoResponse(string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Request(Method.Delete, url, parameters, overrideApiVersion);
+        protected async Task DeleteNoResponse(string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Request(Http.Method.Delete, url, parameters, overrideApiVersion);
 
         [CrudOperations.Read]
         protected async Task<T> Get<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null)
             where T : class
-            => await Request<T>(Method.Get, url, parameters, rootElement, overrideApiVersion);
+            => await Request<T>(Http.Method.Get, url, parameters, rootElement, overrideApiVersion);
 
         [CrudOperations.Read]
         protected async Task<T> List<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null)
             where T : class
-            => await Request<T>(Method.Get, url, parameters, rootElement, overrideApiVersion);
+            => await Request<T>(Http.Method.Get, url, parameters, rootElement, overrideApiVersion);
 
         /// <summary>
         ///     Make an HTTP request to the EasyPost API and deserialize the response JSON into an object.
@@ -49,7 +48,7 @@ namespace EasyPost._base
         /// <param name="overrideApiVersion">Override API version hit for HTTP request. Defaults to general availability.</param>
         /// <typeparam name="T">Type of object to return from request.</typeparam>
         /// <returns>A T-type object.</returns>
-        protected async Task<T> Request<T>(Method method, string endpoint, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null)
+        protected async Task<T> Request<T>(Http.Method method, string endpoint, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null)
             where T : class
             => await Client!.Request<T>(method, endpoint, overrideApiVersion ?? ApiVersion.Current, parameters, rootElement);
 
@@ -62,14 +61,14 @@ namespace EasyPost._base
         /// <param name="overrideApiVersion">Override API version hit for HTTP request. Defaults to general availability.</param>
         /// <returns>None.</returns>
         // ReSharper disable once MemberCanBePrivate.Global
-        protected async Task Request(Method method, string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Client!.Request(method, url, overrideApiVersion ?? ApiVersion.Current, parameters);
+        protected async Task Request(Http.Method method, string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Client!.Request(method, url, overrideApiVersion ?? ApiVersion.Current, parameters);
 
         [CrudOperations.Update]
         protected async Task<T> Update<T>(string url, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null)
             where T : class
-            => await Request<T>(Method.Patch, url, parameters, rootElement, overrideApiVersion);
+            => await Request<T>(Http.Method.Patch, url, parameters, rootElement, overrideApiVersion);
 
         [CrudOperations.Update]
-        protected async Task UpdateNoResponse(string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Request(Method.Patch, url, parameters, overrideApiVersion);
+        protected async Task UpdateNoResponse(string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Request(Http.Method.Patch, url, parameters, overrideApiVersion);
     }
 }


### PR DESCRIPTION
# Description

In preparing to drop RestSharp as a dependency, this introduces a custom drop-in replacement for RestSharp HTTP method enums, built currently as a bridge to be finished later when RestSharp is officially dropped. The custom implementation is required, as PATCH does not exist in .NET Standard 2.0 and must be manually supplemented.

All functions that accept RestSharp HTTP method enums have been updated to accept the new custom methods, and internal logic has been updated to account for the change. No user-facing changes have been introduced.

Part of #433 

# Testing

- All tests pass
- Testing utilities (mocking) have been updated to account for the new methods

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
