### PR TITLE
Remove RestSharp usage

### DIFF
--- a/EasyPost.Tests.FSharp/packages.lock.json
+++ b/EasyPost.Tests.FSharp/packages.lock.json
@@ -94,11 +94,6 @@
         "resolved": "5.11.0",
         "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
       },
-      "RestSharp": {
-        "type": "Transitive",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA=="
-      },
       "System.Reflection.Metadata": {
         "type": "Transitive",
         "resolved": "1.6.0",
@@ -152,8 +147,7 @@
       "easypost": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.1, 14.0.0)",
-          "RestSharp": "[108.0.1, 109.0.0)"
+          "Newtonsoft.Json": "[13.0.1, 14.0.0)"
         }
       }
     }

--- a/EasyPost.Tests.VB/packages.lock.json
+++ b/EasyPost.Tests.VB/packages.lock.json
@@ -88,11 +88,6 @@
         "resolved": "5.11.0",
         "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
       },
-      "RestSharp": {
-        "type": "Transitive",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA=="
-      },
       "System.Reflection.Metadata": {
         "type": "Transitive",
         "resolved": "1.6.0",
@@ -146,8 +141,7 @@
       "easypost": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.1, 14.0.0)",
-          "RestSharp": "[108.0.1, 109.0.0)"
+          "Newtonsoft.Json": "[13.0.1, 14.0.0)"
         }
       }
     }

--- a/EasyPost.Tests/BetaFeaturesTests/ServicesTests/BillingServiceTest.cs
+++ b/EasyPost.Tests/BetaFeaturesTests/ServicesTests/BillingServiceTest.cs
@@ -18,23 +18,23 @@ namespace EasyPost.Tests.BetaFeaturesTests.ServicesTests
                 return new List<TestUtils.MockRequest>
                 {
                     new(
-                        new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^v2\/bank_accounts\/\S*\/charges$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Post, @"v2\/bank_accounts\/\S*\/charges$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^v2\/credit_cards\/\S*\/charges$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Post, @"v2\/credit_cards\/\S*\/charges$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Http.Method.Delete, @"^v2\/bank_accounts\/\S*$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Delete, @"v2\/bank_accounts\/\S*$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Http.Method.Delete, @"^v2\/credit_cards\/\S*$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Delete, @"v2\/credit_cards\/\S*$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/payment_methods$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Get, @"v2\/payment_methods$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethodsSummary
                         {
                             Id = "summary_123",

--- a/EasyPost.Tests/ClientTest.cs
+++ b/EasyPost.Tests/ClientTest.cs
@@ -21,12 +21,9 @@ namespace EasyPost.Tests
         {
             // ReSharper disable once UseObjectOrCollectionInitializer
             // we specifically want to test the getters/setters
-            Client client = new(FakeApikey);
-            client.Configuration.ConnectTimeoutMilliseconds = 5000;
-            client.Configuration.RequestTimeoutMilliseconds = 5000;
+            Client client = new(FakeApikey, timeoutMilliseconds: 5000);
 
-            Assert.Equal(5000, client.Configuration.ConnectTimeoutMilliseconds);
-            Assert.Equal(5000, client.Configuration.RequestTimeoutMilliseconds);
+            Assert.Equal(5000, client.ConnectTimeoutMillisecondsInUse);
         }
 
         [Fact]

--- a/EasyPost.Tests/ClientTest.cs
+++ b/EasyPost.Tests/ClientTest.cs
@@ -23,7 +23,7 @@ namespace EasyPost.Tests
             // we specifically want to test the getters/setters
             Client client = new(FakeApikey, timeoutMilliseconds: 5000);
 
-            Assert.Equal(5000, client.TimeoutMillisecondsInUse);
+            Assert.Equal(5000, client.TimeoutMilliseconds);
         }
 
         [Fact]

--- a/EasyPost.Tests/ClientTest.cs
+++ b/EasyPost.Tests/ClientTest.cs
@@ -23,7 +23,7 @@ namespace EasyPost.Tests
             // we specifically want to test the getters/setters
             Client client = new(FakeApikey, timeoutMilliseconds: 5000);
 
-            Assert.Equal(5000, client.ConnectTimeoutMillisecondsInUse);
+            Assert.Equal(5000, client.TimeoutMillisecondsInUse);
         }
 
         [Fact]

--- a/EasyPost.Tests/EasyPost.Tests.csproj
+++ b/EasyPost.Tests/EasyPost.Tests.csproj
@@ -50,7 +50,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="[13.0.1, 14.0.0)" />
-    <PackageReference Include="RestSharp" Version="[108.0.1, 109.0.0)" />
     <PackageReference Include="SecurityCodeScan.VS2019" Version="[5.6.6, 6.0.0)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/EasyPost.Tests/ExceptionsTests/ExceptionsTest.cs
+++ b/EasyPost.Tests/ExceptionsTests/ExceptionsTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using EasyPost.Exceptions;
 using EasyPost.Exceptions.API;
@@ -10,7 +11,6 @@ using EasyPost.Exceptions.General;
 using EasyPost.Models.API;
 using EasyPost.Tests._Utilities;
 using EasyPost.Tests._Utilities.Attributes;
-using RestSharp;
 using Xunit;
 
 namespace EasyPost.Tests.ExceptionsTests
@@ -25,18 +25,18 @@ namespace EasyPost.Tests.ExceptionsTests
 
         [Fact]
         [Testing.Exception]
-        public void TestApiExceptionPrettyPrint()
+        public async Task TestApiExceptionPrettyPrint()
         {
             const int statusCode = 401;
 
-            // Generate a dummy RestResponse with the given status code to parse
+            // Generate a dummy HttpResponseMessage with the given status code to parse
             HttpStatusCode httpStatusCode = (HttpStatusCode)Enum.Parse(typeof(HttpStatusCode), statusCode.ToString(CultureInfo.InvariantCulture));
-            RestResponse response = new() { StatusCode = httpStatusCode };
+            HttpResponseMessage response = new() { StatusCode = httpStatusCode };
 
-            ApiError generatedError = ApiError.FromErrorResponse(response);
+            ApiError generatedError = await ApiError.FromErrorResponse(response);
 
             // we didn't load error-related JSON data into the response for parsing, so the pretty print is going to fallback to default values.
-            string expectedMessage = $@"{Constants.ErrorMessages.ApiErrorDetailsParsingError} ({statusCode}): {Constants.ErrorMessages.ApiDidNotReturnErrorDetails}";
+            string expectedMessage = $@"{Constants.ErrorMessages.ApiErrorDetailsParsingError} ({statusCode}): Unauthorized";
 
             string prettyPrintedError = generatedError.PrettyPrint;
 
@@ -45,11 +45,11 @@ namespace EasyPost.Tests.ExceptionsTests
             // Now test with some error-related JSON inside the response
             string errorMessageStringJson = "{\"error\": {\"code\": \"ERROR_CODE\", \"message\": \"ERROR_MESSAGE\", \"errors\": []}}";
 
-            // Generate a dummy RestResponse with the given status code to parse
+            // Generate a dummy HttpResponseMessage with the given status code to parse
             httpStatusCode = (HttpStatusCode)Enum.Parse(typeof(HttpStatusCode), statusCode.ToString(CultureInfo.InvariantCulture));
-            response = new() { StatusCode = httpStatusCode, Content = errorMessageStringJson };
+            response = new() { StatusCode = httpStatusCode, Content = new StringContent(errorMessageStringJson) };
 
-            generatedError = ApiError.FromErrorResponse(response);
+            generatedError = await ApiError.FromErrorResponse(response);
 
             expectedMessage = $@"ERROR_CODE (401): ERROR_MESSAGE";
 
@@ -61,11 +61,11 @@ namespace EasyPost.Tests.ExceptionsTests
             errorMessageStringJson = "{\"error\": {\"code\": \"ERROR_CODE\", \"message\": \"ERROR_MESSAGE\", \"errors\": [{\"field\": \"SUB_ERROR_FIELD\", \"message\": \"SUB_ERROR_MESSAGE\"}]}}";
             List<Error> subErrors = new() { new Error { Field = "SUB_ERROR_FIELD", RawMessage = "SUB_ERROR_MESSAGE" } };
 
-            // Generate a dummy RestResponse with the given status code to parse
+            // Generate a dummy HttpResponseMessage with the given status code to parse
             httpStatusCode = (HttpStatusCode)Enum.Parse(typeof(HttpStatusCode), statusCode.ToString(CultureInfo.InvariantCulture));
-            response = new() { StatusCode = httpStatusCode, Content = errorMessageStringJson };
+            response = new() { StatusCode = httpStatusCode, Content = new StringContent(errorMessageStringJson) };
 
-            generatedError = ApiError.FromErrorResponse(response);
+            generatedError = await ApiError.FromErrorResponse(response);
 
             expectedMessage = subErrors.Aggregate($@"ERROR_CODE (401): ERROR_MESSAGE", (current, error) => current + $@"
                             Field: {error.Field}
@@ -205,49 +205,49 @@ namespace EasyPost.Tests.ExceptionsTests
 
         [Fact]
         [Testing.Exception]
-        public void TestExceptionErrorMessageParsing()
+        public async Task TestExceptionErrorMessageParsing()
         {
             const string errorMessageStringJson = "{\"error\": {\"code\": \"ERROR_CODE\", \"message\": \"ERROR_MESSAGE_1\", \"errors\": []}}";
-            RestResponse response = new()
+            HttpResponseMessage response = new()
             {
                 StatusCode = HttpStatusCode.BadRequest,
-                Content = errorMessageStringJson,
+                Content = new StringContent(errorMessageStringJson),
             };
 
-            ApiError error = ApiError.FromErrorResponse(response);
+            ApiError error = await ApiError.FromErrorResponse(response);
 
             Assert.Equal("ERROR_MESSAGE_1", error.Message);
 
             const string errorMessageArrayJson = "{\"error\": {\"code\": \"ERROR_CODE\", \"message\": [\"ERROR_MESSAGE_1\", \"ERROR_MESSAGE_2\"], \"errors\": []}}";
-            response = new RestResponse
+            response = new HttpResponseMessage
             {
                 StatusCode = HttpStatusCode.BadRequest,
-                Content = errorMessageArrayJson,
+                Content = new StringContent(errorMessageArrayJson),
             };
 
-            error = ApiError.FromErrorResponse(response);
+            error = await ApiError.FromErrorResponse(response);
             Assert.Equal("ERROR_MESSAGE_1, ERROR_MESSAGE_2", error.Message);
 
             // Test that it can go down multiple levels into sub-dictionaries and collect multiple key-value pairs across multiple levels
             const string errorMessageDictJson = "{\"error\": {\"code\": \"ERROR_CODE\", \"message\": {\"errors\": {\"errors\": {\"errors\": {\"errors\": [\"ERROR_MESSAGE_1\", \"ERROR_MESSAGE_2\"], \"second_element\": \"ERROR_MESSAGE_3\"}}, \"third_element\": \"ERROR_MESSAGE_4\"}}, \"errors\": []}}";
-            response = new RestResponse
+            response = new HttpResponseMessage
             {
                 StatusCode = HttpStatusCode.BadRequest,
-                Content = errorMessageDictJson,
+                Content = new StringContent(errorMessageDictJson),
             };
 
-            error = ApiError.FromErrorResponse(response);
+            error = await ApiError.FromErrorResponse(response);
             Assert.Equal("ERROR_MESSAGE_1, ERROR_MESSAGE_2, ERROR_MESSAGE_3, ERROR_MESSAGE_4", error.Message);
 
             const string errorMessageBadFormatJson = "{\"error\": {\"code\": \"ERROR_CODE\", \"message\": {bad_key\": \"bad_value\"}, \"ERROR_MESSAGE_2\"], \"errors\": []}}";
-            response = new RestResponse
+            response = new HttpResponseMessage
             {
                 StatusCode = HttpStatusCode.BadRequest,
-                Content = errorMessageBadFormatJson,
+                Content = new StringContent(errorMessageBadFormatJson),
             };
 
-            error = ApiError.FromErrorResponse(response);
-            Assert.Equal(Constants.ErrorMessages.ApiDidNotReturnErrorDetails, error.Message);
+            error = await ApiError.FromErrorResponse(response);
+            Assert.Equal("Bad Request", error.Message);
         }
 
         [Fact]
@@ -294,7 +294,7 @@ namespace EasyPost.Tests.ExceptionsTests
 
         [Fact]
         [Testing.Exception]
-        public Task TestKnownApiExceptionGeneration()
+        public async Task TestKnownApiExceptionGeneration()
         {
             // all the error status codes the library should be able to handle
             Dictionary<int, Type> exceptionsMap = new()
@@ -330,11 +330,11 @@ namespace EasyPost.Tests.ExceptionsTests
                 int statusCodeInt = exceptionDetails.Key;
                 Type exceptionType = exceptionDetails.Value;
 
-                // Generate a dummy RestResponse with the given status code to parse
+                // Generate a dummy HttpResponseMessage with the given status code to parse
                 HttpStatusCode statusCode = (HttpStatusCode)Enum.Parse(typeof(HttpStatusCode), statusCodeInt.ToString(CultureInfo.InvariantCulture));
-                RestResponse response = new() { StatusCode = statusCode };
+                HttpResponseMessage response = new() { StatusCode = statusCode };
 
-                ApiError generatedError = ApiError.FromErrorResponse(response);
+                ApiError generatedError = await ApiError.FromErrorResponse(response);
 
                 // should be of base type ApiError
                 Assert.Equal(typeof(ApiError), generatedError.GetType().BaseType);
@@ -352,23 +352,21 @@ namespace EasyPost.Tests.ExceptionsTests
                 // because we're not giving it a real API response to parse, there's no code to extract, so the code should be the default
                 Assert.Equal("RESPONSE.PARSE_ERROR", generatedError.Code);
             }
-
-            return Task.CompletedTask;
         }
 
         [Fact]
         [Testing.Exception]
-        public void TestUnknownApiException1xxGeneration()
+        public async Task TestUnknownApiException1xxGeneration()
         {
             // library does not have a specific exception for this status code
             // Since it's a 1xx error, it should throw an UnexpectedHttpError
             const int unexpectedStatusCode = 199;
 
-            // Generate a dummy RestResponse with the given status code to parse
+            // Generate a dummy HttpResponseMessage with the given status code to parse
             HttpStatusCode statusCode = (HttpStatusCode)Enum.Parse(typeof(HttpStatusCode), unexpectedStatusCode.ToString(CultureInfo.InvariantCulture));
-            RestResponse response = new() { StatusCode = statusCode };
+            HttpResponseMessage response = new() { StatusCode = statusCode };
 
-            ApiError generatedError = ApiError.FromErrorResponse(response);
+            ApiError generatedError = await ApiError.FromErrorResponse(response);
 
             // the exception should be of base type ApiError
             Assert.Equal(typeof(ApiError), generatedError.GetType().BaseType);
@@ -378,17 +376,17 @@ namespace EasyPost.Tests.ExceptionsTests
 
         [Fact]
         [Testing.Exception]
-        public void TestUnknownApiException3xxGeneration()
+        public async Task TestUnknownApiException3xxGeneration()
         {
             // library does not have a specific exception for this status code
             // Since it's a 3xx error, it should throw an UnexpectedHttpError
             const int unexpectedStatusCode = 319;
 
-            // Generate a dummy RestResponse with the given status code to parse
+            // Generate a dummy HttpResponseMessage with the given status code to parse
             HttpStatusCode statusCode = (HttpStatusCode)Enum.Parse(typeof(HttpStatusCode), unexpectedStatusCode.ToString(CultureInfo.InvariantCulture));
-            RestResponse response = new() { StatusCode = statusCode };
+            HttpResponseMessage response = new() { StatusCode = statusCode };
 
-            ApiError generatedError = ApiError.FromErrorResponse(response);
+            ApiError generatedError = await ApiError.FromErrorResponse(response);
 
             // the exception should be of base type ApiError
             Assert.Equal(typeof(ApiError), generatedError.GetType().BaseType);
@@ -398,17 +396,17 @@ namespace EasyPost.Tests.ExceptionsTests
 
         [Fact]
         [Testing.Exception]
-        public void TestUnknownApiException4xxGeneration()
+        public async Task TestUnknownApiException4xxGeneration()
         {
             // library does not have a specific exception for this status code
             // Since it's a 4xx error, it should throw an UnknownApiError
             const int unexpectedStatusCode = 418;
 
-            // Generate a dummy RestResponse with the given status code to parse
+            // Generate a dummy HttpResponseMessage with the given status code to parse
             HttpStatusCode statusCode = (HttpStatusCode)Enum.Parse(typeof(HttpStatusCode), unexpectedStatusCode.ToString(CultureInfo.InvariantCulture));
-            RestResponse response = new() { StatusCode = statusCode };
+            HttpResponseMessage response = new() { StatusCode = statusCode };
 
-            ApiError generatedError = ApiError.FromErrorResponse(response);
+            ApiError generatedError = await ApiError.FromErrorResponse(response);
 
             // the exception should be of base type ApiError
             Assert.Equal(typeof(ApiError), generatedError.GetType().BaseType);
@@ -418,17 +416,17 @@ namespace EasyPost.Tests.ExceptionsTests
 
         [Fact]
         [Testing.Exception]
-        public void TestUnknownApiException5xxGeneration()
+        public async Task TestUnknownApiException5xxGeneration()
         {
             // library does not have a specific exception for this status code
             // Since it's a 5xx error, it should throw an UnexpectedHttpError
             const int unexpectedStatusCode = 502;
 
-            // Generate a dummy RestResponse with the given status code to parse
+            // Generate a dummy HttpResponseMessage with the given status code to parse
             HttpStatusCode statusCode = (HttpStatusCode)Enum.Parse(typeof(HttpStatusCode), unexpectedStatusCode.ToString(CultureInfo.InvariantCulture));
-            RestResponse response = new() { StatusCode = statusCode };
+            HttpResponseMessage response = new() { StatusCode = statusCode };
 
-            ApiError generatedError = ApiError.FromErrorResponse(response);
+            ApiError generatedError = await ApiError.FromErrorResponse(response);
 
             // the exception should be of base type ApiError
             Assert.Equal(typeof(ApiError), generatedError.GetType().BaseType);
@@ -441,9 +439,7 @@ namespace EasyPost.Tests.ExceptionsTests
         public async Task TestHTTPTimeoutFriendlyException()
         {
             // create a new client with a very short timeout
-            Client client = new(TestUtils.GetApiKey(TestUtils.ApiKey.Test));
-            client.Configuration.ConnectTimeoutMilliseconds = 1;
-            client.Configuration.RequestTimeoutMilliseconds = 1;
+            Client client = new(TestUtils.GetApiKey(TestUtils.ApiKey.Test), timeoutMilliseconds: 1);
 
             // make a real request that should timeout, assert that it threw a friendly TimeoutError rather than a TaskCanceledException
             try

--- a/EasyPost.Tests/HttpTests/ClientConfigurationTest.cs
+++ b/EasyPost.Tests/HttpTests/ClientConfigurationTest.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using EasyPost.Http;
 using EasyPost.Tests._Utilities.Attributes;
 using Xunit;
@@ -51,10 +52,12 @@ namespace EasyPost.Tests.HttpTests
         {
             const string apiKey = "fake_api_key";
             const string apiBase = "https://www.example.com";
-            ClientConfiguration configuration1 = new(apiKey, apiBase);
+            HttpClient httpClient = new();
+
+            ClientConfiguration configuration1 = new(apiKey, apiBase, customHttpClient: httpClient);
 
             // Assert that hashcode is calculated correctly
-            int expectedHashCode = apiKey.GetHashCode() ^ apiBase.GetHashCode() ^ 1; // 1 is the default value if no HttpClient is passed
+            int expectedHashCode = apiKey.GetHashCode() ^ apiBase.GetHashCode() ^ httpClient.GetHashCode();
             Assert.Equal(expectedHashCode, configuration1.GetHashCode());
         }
 

--- a/EasyPost.Tests/ServicesTests/BillingServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/BillingServiceTest.cs
@@ -24,23 +24,23 @@ namespace EasyPost.Tests.ServicesTests
                 return new List<TestUtils.MockRequest>
                 {
                     new(
-                        new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^v2\/bank_accounts\/\S*\/charges$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Post, @"v2\/bank_accounts\/\S*\/charges$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^v2\/credit_cards\/\S*\/charges$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Post, @"v2\/credit_cards\/\S*\/charges$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Http.Method.Delete, @"^v2\/bank_accounts\/\S*$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Delete, @"v2\/bank_accounts\/\S*$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Http.Method.Delete, @"^v2\/credit_cards\/\S*$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Delete, @"v2\/credit_cards\/\S*$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK)
                     ),
                     new(
-                        new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/payment_methods$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Get, @"v2\/payment_methods$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethodsSummary
                         {
                             Id = "summary_123",
@@ -110,7 +110,7 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/payment_methods$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"v2\/payment_methods$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethodsSummary
                     {
                         Id = null, // No ID, will throw an error when we try to interact with this summary
@@ -160,7 +160,7 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/payment_methods$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"v2\/payment_methods$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethodsSummary
                     {
                         Id = "summary_123",
@@ -182,7 +182,7 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/payment_methods$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"v2\/payment_methods$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethodsSummary
                     {
                         Id = "summary_123",

--- a/EasyPost.Tests/ServicesTests/PartnerServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/PartnerServiceTest.cs
@@ -89,15 +89,15 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"pk_test_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^https://api.stripe.com/v1/tokens$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"https://api.stripe.com/v1/tokens$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"id\":\"tok_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^v2\/credit_cards$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"v2\/credit_cards$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethod
                     {
                         Id = "summary_123",
@@ -126,15 +126,15 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"pk_test_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^https://api.stripe.com/v1/tokens$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"https://api.stripe.com/v1/tokens$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"id\":\"tok_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^v2\/credit_cards$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"v2\/credit_cards$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new PaymentMethod
                     {
                         Id = "summary_123",
@@ -169,7 +169,7 @@ namespace EasyPost.Tests.ServicesTests
             {
                 {
                     new(
-                        new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                        new TestUtils.MockRequestMatchRules(Http.Method.Get, @"v2\/partners\/stripe_public_key$"),
                         new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"\"}")
                     )
                 }
@@ -187,7 +187,7 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"not_public_key\":\"random\"}")
                 ),
             });
@@ -204,11 +204,11 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"pk_test_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^https://api.stripe.com/v1/tokens$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"https://api.stripe.com/v1/tokens$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"id\":\"\"}")
                 )
             });
@@ -225,11 +225,11 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"pk_test_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^https://api.stripe.com/v1/tokens$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"https://api.stripe.com/v1/tokens$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.NotFound, content: "{}")
                 )
             });
@@ -246,11 +246,11 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"pk_test_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^https://api.stripe.com/v1/tokens$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"https://api.stripe.com/v1/tokens$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"not_id\":\"random\"}")
                 )
             });
@@ -267,15 +267,15 @@ namespace EasyPost.Tests.ServicesTests
             UseMockClient(new List<TestUtils.MockRequest>
             {
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/partners\/stripe_public_key$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"v2\/partners\/stripe_public_key$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"public_key\":\"pk_test_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^https://api.stripe.com/v1/tokens$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"https://api.stripe.com/v1/tokens$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, content: "{\"id\":\"tok_12345\"}")
                 ),
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"^v2\/credit_cards$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Post, @"v2\/credit_cards$"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.NotFound, content: "{}")
                 )
             });

--- a/EasyPost.Tests/ServicesTests/ServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/ServiceTest.cs
@@ -69,7 +69,7 @@ namespace EasyPost.Tests.ServicesTests
             {
                 // API call to get the page of addresses will return an empty list with HasMore = false
                 new(
-                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"^v2\/addresses$"),
+                    new TestUtils.MockRequestMatchRules(Http.Method.Get, @"v2\/addresses"),
                     new TestUtils.MockRequestResponseInfo(HttpStatusCode.OK, data: new AddressCollection
                     {
                         Addresses = new List<Address>(),

--- a/EasyPost.Tests/UtilitiesTests/HttpTest.cs
+++ b/EasyPost.Tests/UtilitiesTests/HttpTest.cs
@@ -1,7 +1,7 @@
 using System.Net;
+using System.Net.Http;
 using EasyPost.Tests._Utilities.Attributes;
 using EasyPost.Utilities.Internal.Extensions;
-using RestSharp;
 using Xunit;
 
 namespace EasyPost.Tests.UtilitiesTests
@@ -47,9 +47,9 @@ namespace EasyPost.Tests.UtilitiesTests
 
         [Fact]
         [Testing.Function]
-        public void TestStatusCodeChecksRestResponse()
+        public void TestStatusCodeChecksHttpResponseMessage()
         {
-            RestResponse response = new() { StatusCode = HttpStatusCode.OK };
+            HttpResponseMessage response = new() { StatusCode = HttpStatusCode.OK };
 
             Assert.True(Utilities.Internal.Extensions.Http.StatusCodeBetween(response, 200, 300));
             Assert.True(response.HasStatusCodeBetween(200, 300));

--- a/EasyPost.Tests/packages.lock.json
+++ b/EasyPost.Tests/packages.lock.json
@@ -55,15 +55,6 @@
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
-        "dependencies": {
-          "System.Text.Json": "5.0.0"
-        }
-      },
       "SecurityCodeScan.VS2019": {
         "type": "Direct",
         "requested": "[5.6.6, 6.0.0)",
@@ -201,11 +192,6 @@
         "resolved": "6.0.0",
         "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
-      },
       "xunit.abstractions": {
         "type": "Transitive",
         "resolved": "2.0.3",
@@ -254,8 +240,7 @@
       "easypost": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.1, 14.0.0)",
-          "RestSharp": "[108.0.1, 109.0.0)"
+          "Newtonsoft.Json": "[13.0.1, 14.0.0)"
         }
       }
     },
@@ -293,11 +278,11 @@
       },
       "Microsoft.NETFramework.ReferenceAssemblies": {
         "type": "Direct",
-        "requested": "[1.0.2, )",
-        "resolved": "1.0.2",
-        "contentHash": "5/cSEVld+px/CuRrbohO/djfg6++eR6zGpy88MgqloXvkj//WXWpFZyu/OpkXPN0u5m+dN/EVwLNYFUxD4h2+A==",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
         "dependencies": {
-          "Microsoft.NETFramework.ReferenceAssemblies.net462": "1.0.2"
+          "Microsoft.NETFramework.ReferenceAssemblies.net462": "1.0.3"
         }
       },
       "Microsoft.VisualStudio.TestPlatform.ObjectModel": {
@@ -320,15 +305,6 @@
         "requested": "[13.0.1, 14.0.0)",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-      },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
-        "dependencies": {
-          "System.Text.Json": "5.0.0"
-        }
       },
       "SecurityCodeScan.VS2019": {
         "type": "Direct",
@@ -434,8 +410,8 @@
       },
       "Microsoft.NETFramework.ReferenceAssemblies.net462": {
         "type": "Transitive",
-        "resolved": "1.0.2",
-        "contentHash": "vnWMOt5+4SLOLu5hlB54LMK5OHqsX+5ekbo6vb7USvCM5uA4UKtATuMvIAw69ak62F94c+3895XwF5TcjjzpVw=="
+        "resolved": "1.0.3",
+        "contentHash": "IzAV30z22ESCeQfxP29oVf4qEo8fBGXLXSU6oacv/9Iqe6PzgHDKCaWfwMBak7bSJQM0F5boXWoZS+kChztRIQ=="
       },
       "System.Buffers": {
         "type": "Transitive",
@@ -470,29 +446,6 @@
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
-      },
-      "System.Text.Encodings.Web": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "EEslUvHKll1ftizbn20mX3Ix/l4Ygk/bdJ2LY6/X6FlGaP0RIhKMo9nS6JIGnKKT6KBP2PGj6JC3B9/ZF6ErqQ==",
-        "dependencies": {
-          "System.Memory": "4.5.4"
-        }
-      },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw==",
-        "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
-          "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.4",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "5.0.0",
-          "System.Text.Encodings.Web": "5.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4",
-          "System.ValueTuple": "4.5.0"
-        }
       },
       "System.Threading.Tasks.Extensions": {
         "type": "Transitive",
@@ -550,8 +503,7 @@
       "easypost": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.1, 14.0.0)",
-          "RestSharp": "[108.0.1, 109.0.0)"
+          "Newtonsoft.Json": "[13.0.1, 14.0.0)"
         }
       }
     },
@@ -608,15 +560,6 @@
         "requested": "[13.0.1, 14.0.0)",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-      },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
-        "dependencies": {
-          "System.Text.Json": "5.0.0"
-        }
       },
       "SecurityCodeScan.VS2019": {
         "type": "Direct",
@@ -754,11 +697,6 @@
         "resolved": "6.0.0",
         "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
-      },
       "xunit.abstractions": {
         "type": "Transitive",
         "resolved": "2.0.3",
@@ -807,8 +745,7 @@
       "easypost": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.1, 14.0.0)",
-          "RestSharp": "[108.0.1, 109.0.0)"
+          "Newtonsoft.Json": "[13.0.1, 14.0.0)"
         }
       }
     },
@@ -866,12 +803,6 @@
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA=="
-      },
       "SecurityCodeScan.VS2019": {
         "type": "Direct",
         "requested": "[5.6.6, 6.0.0)",
@@ -1042,8 +973,7 @@
       "easypost": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.1, 14.0.0)",
-          "RestSharp": "[108.0.1, 109.0.0)"
+          "Newtonsoft.Json": "[13.0.1, 14.0.0)"
         }
       }
     },
@@ -1101,12 +1031,6 @@
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA=="
-      },
       "SecurityCodeScan.VS2019": {
         "type": "Direct",
         "requested": "[5.6.6, 6.0.0)",
@@ -1277,8 +1201,7 @@
       "easypost": {
         "type": "Project",
         "dependencies": {
-          "Newtonsoft.Json": "[13.0.1, 14.0.0)",
-          "RestSharp": "[108.0.1, 109.0.0)"
+          "Newtonsoft.Json": "[13.0.1, 14.0.0)"
         }
       }
     }

--- a/EasyPost/BetaClient.cs
+++ b/EasyPost/BetaClient.cs
@@ -34,9 +34,10 @@ namespace EasyPost
         /// </summary>
         /// <param name="apiKey">API key to use with this client.</param>
         /// <param name="baseUrl">Base URL to use with this client.</param>
-        /// <param name="customHttpClient">Custom HttpClient to pass into RestSharp if needed.</param>
-        internal BetaClient(string apiKey, string? baseUrl = null, HttpClient? customHttpClient = null)
-            : base(apiKey, baseUrl, customHttpClient)
+        /// <param name="timeoutMilliseconds">Timeout length, in milliseconds, for API calls.</param>
+        /// <param name="customHttpClient">Custom HttpClient to use if needed.</param>
+        internal BetaClient(string apiKey, string? baseUrl = null, int? timeoutMilliseconds = null, HttpClient? customHttpClient = null)
+            : base(apiKey, baseUrl, timeoutMilliseconds, customHttpClient)
         {
             Referral = new ReferralService(this);
             Rate = new RateService(this);

--- a/EasyPost/Client.cs
+++ b/EasyPost/Client.cs
@@ -62,14 +62,15 @@ namespace EasyPost
         /// </summary>
         /// <param name="apiKey">API key to use with this client.</param>
         /// <param name="baseUrl">Base URL to use with this client. Must include API version.</param>
-        /// <param name="customHttpClient">Custom HttpClient to pass into RestSharp if needed.</param>
+        /// <param name="timeoutMilliseconds">Timeout length, in milliseconds, for API calls.</param>
+        /// <param name="customHttpClient">Custom HttpClient to use if needed.</param>
 #pragma warning disable IDE0021 // Ignoring since more properties will be added during construction in the future.
-        public Client(string apiKey, string? baseUrl = null, HttpClient? customHttpClient = null)
-            : base(apiKey, baseUrl, customHttpClient)
+        public Client(string apiKey, string? baseUrl = null, int? timeoutMilliseconds = null, HttpClient? customHttpClient = null)
+            : base(apiKey, baseUrl, timeoutMilliseconds, customHttpClient)
 #pragma warning restore IDE0021
         {
             // We go ahead and initialize the Beta client internally here as well, since initializing a new one on each property call is expensive and causes lockups with the HttpClient library.
-            Beta = new BetaClient(apiKey, baseUrl, customHttpClient);
+            Beta = new BetaClient(apiKey, baseUrl, timeoutMilliseconds, customHttpClient);
         }
     }
 }

--- a/EasyPost/EasyPost.csproj
+++ b/EasyPost/EasyPost.csproj
@@ -66,7 +66,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="[13.0.1, 14.0.0)" />
-    <PackageReference Include="RestSharp" Version="[108.0.1, 109.0.0)" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" Condition=" '$(Configuration)' == 'Linting' ">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/EasyPost/Http/ClientConfiguration.cs
+++ b/EasyPost/Http/ClientConfiguration.cs
@@ -96,7 +96,7 @@ namespace EasyPost.Http
 
             // Prepare the HttpClient
             PreparedHttpClient = HttpClient;
-            PreparedHttpClient.Timeout = TimeSpan.FromMilliseconds(timeoutMilliseconds ?? 30000); // Default to 30 seconds
+            PreparedHttpClient.Timeout = TimeSpan.FromMilliseconds(timeoutMilliseconds ?? 60000); // Default to 60 seconds
 
             _libraryVersion = RuntimeInfo.ApplicationInfo.ApplicationVersion;
             _dotNetVersion = RuntimeInfo.ApplicationInfo.DotNetVersion;

--- a/EasyPost/Http/ClientConfiguration.cs
+++ b/EasyPost/Http/ClientConfiguration.cs
@@ -91,31 +91,18 @@ namespace EasyPost.Http
             ApiKey = apiKey;
 
             // Optional constructor parameters with defaults
-            ApiBase = baseUrl ?? Defaults.DefaultBaseUrl;
+            ApiBase = baseUrl ?? "https://api.easypost.com";
             HttpClient = customHttpClient ?? new HttpClient();
 
             // Prepare the HttpClient
             PreparedHttpClient = HttpClient;
-            PreparedHttpClient.Timeout = TimeSpan.FromMilliseconds(timeoutMilliseconds ?? Defaults.DefaultConnectTimeoutMilliseconds);
+            PreparedHttpClient.Timeout = TimeSpan.FromMilliseconds(timeoutMilliseconds ?? 30000); // Default to 30 seconds
 
             _libraryVersion = RuntimeInfo.ApplicationInfo.ApplicationVersion;
             _dotNetVersion = RuntimeInfo.ApplicationInfo.DotNetVersion;
             _osName = RuntimeInfo.OperationSystemInfo.Name;
             _osVersion = RuntimeInfo.OperationSystemInfo.Version;
             _osArch = RuntimeInfo.OperationSystemInfo.Architecture;
-        }
-
-        private abstract class Defaults
-        {
-            /// <summary>
-            ///     The default API base URI.
-            /// </summary>
-            internal const string DefaultBaseUrl = "https://api.easypost.com";
-
-            /// <summary>
-            ///     The default connection timeout in milliseconds.
-            /// </summary>
-            internal const int DefaultConnectTimeoutMilliseconds = 30000;
         }
 
         public override bool Equals(object? obj) => obj is ClientConfiguration other && ApiKey == other.ApiKey && ApiBase == other.ApiBase;

--- a/EasyPost/Http/ClientConfiguration.cs
+++ b/EasyPost/Http/ClientConfiguration.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using EasyPost._base;
 using EasyPost.Utilities.Internal;
@@ -11,10 +13,9 @@ namespace EasyPost.Http
     {
         /// <summary>
         ///     The API base URI.
-        ///     This cannot be changed after the client has been initialized.
         /// </summary>
-        // This cannot be changed, because the internal RestClient is initialized with this value immediately.
-        public readonly string ApiBase;
+        // This can be changed between API calls by the end user.
+        public string ApiBase { get; set; }
 
         /// <summary>
         ///     Gets the API key.
@@ -25,10 +26,15 @@ namespace EasyPost.Http
 
         /// <summary>
         ///     A custom HttpClient to use for requests.
-        ///     This cannot be changed after the client has been initialized.
         /// </summary>
-        // This cannot be changed, because the internal RestClient is initialized with this value immediately.
-        public readonly HttpClient? HttpClient;
+        // This cannot be changed after the client has been initialized, and is stored for reference only.
+        internal HttpClient HttpClient { get; }
+
+        /// <summary>
+        ///     Gets the HttpClient to use for requests.
+        ///     This is the HttpClient with the connect timeout set.
+        /// </summary>
+        internal HttpClient PreparedHttpClient { get; }
 
         /// <summary>
         ///    The .NET version of the current application.
@@ -55,39 +61,21 @@ namespace EasyPost.Http
         /// </summary>
         private readonly string _osVersion;
 
-        /// <summary>
-        ///     The connect timeout in milliseconds set by the user.
-        /// </summary>
-        private int? _connectTimeoutMilliseconds;
-
-        /// <summary>
-        ///     The request timeout in milliseconds set by the user.
-        /// </summary>
-        private int? _requestTimeoutMilliseconds;
-
-        /// <summary>
-        ///     Gets or sets the connect timeout in milliseconds.
-        /// </summary>
-        public int ConnectTimeoutMilliseconds
-        {
-            get => _connectTimeoutMilliseconds ?? Defaults.DefaultConnectTimeoutMilliseconds;
-            set => _connectTimeoutMilliseconds = value;
-        }
-
-        /// <summary>
-        ///     Gets or sets the request timeout in milliseconds.
-        /// </summary>
-        public int RequestTimeoutMilliseconds
-        {
-            get => _requestTimeoutMilliseconds ?? Defaults.DefaultRequestTimeoutMilliseconds;
-            set => _requestTimeoutMilliseconds = value;
-        }
-
         /*
          * NOTE: User-Agent will always show the general availability API version, even if the API call itself goes to a different API version (i.e. beta).
          * This is because the User-Agent must be set when the client is initialized, and the target API version is not known until a request is made.
          */
-        internal string UserAgent => $"EasyPost/{ApiVersion.Current.Value} CSharpClient/{_libraryVersion} .NET/{_dotNetVersion} OS/{_osName} OSVersion/{_osVersion} OSArch/{_osArch}";
+        private string UserAgent => $"EasyPost/{ApiVersion.Current.Value} CSharpClient/{_libraryVersion} .NET/{_dotNetVersion} OS/{_osName} OSVersion/{_osVersion} OSArch/{_osArch}";
+
+        /// <summary>
+        ///     Gets the headers to use for a request.
+        /// </summary>
+        internal Dictionary<string, string> Headers => new()
+        {
+            { "Authorization", $"Bearer {ApiKey}" },
+            { "User-Agent", UserAgent },
+            // Content-Type is set downstream while constructing the request body
+        };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ClientConfiguration"/> class.
@@ -95,12 +83,20 @@ namespace EasyPost.Http
         /// </summary>
         /// <param name="apiKey">The API key to use for the client connection.</param>
         /// <param name="baseUrl">Base URL to use with this client. This will override `apiVersion`.</param>
+        /// <param name="timeoutMilliseconds">Timeout length, in milliseconds, for API calls.</param>
         /// <param name="customHttpClient">The custom HTTP client to use for the client connection.</param>
-        internal ClientConfiguration(string apiKey, string? baseUrl, HttpClient? customHttpClient = null)
+        internal ClientConfiguration(string apiKey, string? baseUrl, int? timeoutMilliseconds = null, HttpClient? customHttpClient = null)
         {
+            // Required constructor parameters
             ApiKey = apiKey;
+
+            // Optional constructor parameters with defaults
             ApiBase = baseUrl ?? Defaults.DefaultBaseUrl;
-            HttpClient = customHttpClient;
+            HttpClient = customHttpClient ?? new HttpClient();
+
+            // Prepare the HttpClient
+            PreparedHttpClient = HttpClient;
+            PreparedHttpClient.Timeout = TimeSpan.FromMilliseconds(timeoutMilliseconds ?? Defaults.DefaultConnectTimeoutMilliseconds);
 
             _libraryVersion = RuntimeInfo.ApplicationInfo.ApplicationVersion;
             _dotNetVersion = RuntimeInfo.ApplicationInfo.DotNetVersion;
@@ -120,11 +116,6 @@ namespace EasyPost.Http
             ///     The default connection timeout in milliseconds.
             /// </summary>
             internal const int DefaultConnectTimeoutMilliseconds = 30000;
-
-            /// <summary>
-            ///     The default request timeout in milliseconds.
-            /// </summary>
-            internal const int DefaultRequestTimeoutMilliseconds = 60000;
         }
 
         public override bool Equals(object? obj) => obj is ClientConfiguration other && ApiKey == other.ApiKey && ApiBase == other.ApiBase;

--- a/EasyPost/Http/Method.cs
+++ b/EasyPost/Http/Method.cs
@@ -9,33 +9,30 @@ namespace EasyPost.Http
     {
         internal HttpMethod HttpMethod { get; }
 
-        internal RestSharp.Method RestSharpMethod { get; }
-
         /// <summary>
         ///     HTTP GET method.
         /// </summary>
-        public static readonly Method Get = new Method(HttpMethod.Get, RestSharp.Method.Get);
+        public static readonly Method Get = new Method(HttpMethod.Get);
         /// <summary>
         ///     HTTP POST method.
         /// </summary>
-        public static readonly Method Post = new Method(HttpMethod.Post, RestSharp.Method.Post);
+        public static readonly Method Post = new Method(HttpMethod.Post);
         /// <summary>
         ///     HTTP PUT method.
         /// </summary>
-        public static readonly Method Put = new Method(HttpMethod.Put, RestSharp.Method.Put);
+        public static readonly Method Put = new Method(HttpMethod.Put);
         /// <summary>
         ///     HTTP DELETE method.
         /// </summary>
-        public static readonly Method Delete = new Method(HttpMethod.Delete, RestSharp.Method.Delete);
+        public static readonly Method Delete = new Method(HttpMethod.Delete);
         /// <summary>
         ///     HTTP PATCH method.
         /// </summary>
-        public static readonly Method Patch = new Method(new HttpMethod("PATCH"), RestSharp.Method.Patch);
+        public static readonly Method Patch = new Method(new HttpMethod("PATCH"));
 
-        private Method(HttpMethod httpMethod, RestSharp.Method restSharpMethod)
+        private Method(HttpMethod httpMethod)
         {
             HttpMethod = httpMethod;
-            RestSharpMethod = restSharpMethod;
         }
     }
 }

--- a/EasyPost/Http/Request.cs
+++ b/EasyPost/Http/Request.cs
@@ -1,37 +1,56 @@
+using System;
 using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
 using EasyPost._base;
 using EasyPost.Utilities.Internal;
-using RestSharp;
-using RestSharp.Serializers;
 
 namespace EasyPost.Http
 {
+    // TODO: Make disposable and dispose of the request message
+#pragma warning disable CA1001
     internal sealed class Request
+#pragma warning restore CA1001
     {
-        public readonly string? RootElement;
+        private readonly HttpRequestMessage _requestMessage;
 
         private readonly Dictionary<string, object> _parameters;
-        private readonly RestRequest _restRequest;
 
         private readonly Http.Method _method;
 
         // ReSharper disable once SuggestBaseTypeForParameterInConstructor
-        public Request(string endpoint, Method method, ApiVersion apiVersion, Dictionary<string, object>? parameters = null, string? rootElement = null)
+        internal Request(string domain, string endpoint, Method method, ApiVersion apiVersion, Dictionary<string, object>? parameters = null, Dictionary<string, string>? headers = null)
         {
-            endpoint = $"{apiVersion.Value}/{endpoint}";
+            // store method for later use
             _method = method;
 
-            _restRequest = new RestRequest(endpoint, method.RestSharpMethod);
+            // build the request URL, then request message
+            Uri url = new($"{domain}/{apiVersion.Value}/{endpoint}");
+            _requestMessage = new HttpRequestMessage(_method.HttpMethod, url);
 
+            // store parameters for later use
             _parameters = parameters ?? new Dictionary<string, object>();
 
-            RootElement = rootElement;
+            // set the headers (user-agent, auth, and content-type should have been included in the headers dictionary)
+            if (headers == null) return;
+            foreach (KeyValuePair<string, string> header in headers)
+            {
+                _requestMessage.Headers.Add(header.Key, header.Value);
+            }
+        }
+
+        internal HttpRequestMessage AsHttpRequestMessage()
+        {
+            // wait until the last possible moment to set the content
+            BuildParameters();
+
+            return _requestMessage;
         }
 
         /// <summary>
         ///     Build the request parameters.
         /// </summary>
-        internal void BuildParameters()
+        private void BuildParameters()
         {
             if (_parameters.Count == 0)
             {
@@ -57,7 +76,7 @@ namespace EasyPost.Http
         private void BuildBodyParameters()
         {
             string body = JsonSerialization.ConvertObjectToJson(_parameters);
-            _restRequest.AddStringBody(body, ContentType.Json);
+            _requestMessage.Content = new StringContent(body, Encoding.UTF8, "application/json");
         }
 
         /// <summary>
@@ -65,6 +84,9 @@ namespace EasyPost.Http
         /// </summary>
         private void BuildQueryParameters()
         {
+            // add query parameters
+            var query = new StringBuilder();
+
             foreach (KeyValuePair<string, object> pair in _parameters)
             {
                 // ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
@@ -73,10 +95,14 @@ namespace EasyPost.Http
                     continue;
                 }
 
-                _restRequest.AddParameter(pair.Key, pair.Value, ParameterType.QueryString);
+                query.Append($"{pair.Key}={pair.Value}&");
             }
-        }
 
-        public static explicit operator RestRequest(Request request) => request._restRequest;
+            // remove last '&'
+            query.Remove(query.Length - 1, 1);
+
+            // add query to request uri
+            _requestMessage.RequestUri = new Uri($"{_requestMessage.RequestUri}?{query}");
+        }
     }
 }

--- a/EasyPost/Services/PartnerService.cs
+++ b/EasyPost/Services/PartnerService.cs
@@ -226,8 +226,9 @@ namespace EasyPost.Services
 
             string content = await response.Content.ReadAsStringAsync();
             Dictionary<string, object> data = JsonSerialization.ConvertJsonToObject<Dictionary<string, object>>(content);
-            
-            // Dispose of the response
+
+            // Dispose of the request and response
+            request.Dispose();
             response.Dispose();
 
             data.TryGetValue("id", out object? id);

--- a/EasyPost/Services/PartnerService.cs
+++ b/EasyPost/Services/PartnerService.cs
@@ -226,6 +226,9 @@ namespace EasyPost.Services
 
             string content = await response.Content.ReadAsStringAsync();
             Dictionary<string, object> data = JsonSerialization.ConvertJsonToObject<Dictionary<string, object>>(content);
+            
+            // Dispose of the response
+            response.Dispose();
 
             data.TryGetValue("id", out object? id);
             return id == null

--- a/EasyPost/Services/PartnerService.cs
+++ b/EasyPost/Services/PartnerService.cs
@@ -1,14 +1,15 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Net.Http;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.Exceptions.API;
 using EasyPost.Exceptions.General;
 using EasyPost.Models.API;
+using EasyPost.Utilities.Internal;
 using EasyPost.Utilities.Internal.Attributes;
 using EasyPost.Utilities.Internal.Extensions;
-using RestSharp;
 
 namespace EasyPost.Services
 {
@@ -189,22 +190,42 @@ namespace EasyPost.Services
         {
             const string url = "https://api.stripe.com/v1/tokens";
 
-            RestRequest request = new(url, Method.Post);
-            request.AddHeader("Authorization", $"Bearer {easypostStripeApiKey}");
-            request.AddHeader("Accept", "application/x-www-form-urlencoded");
-            request.AddParameter("card[number]", number);
-            request.AddParameter("card[exp_month]", expirationMonth.ToString(CultureInfo.InvariantCulture));
-            request.AddParameter("card[exp_year]", expirationYear.ToString(CultureInfo.InvariantCulture));
-            request.AddParameter("card[cvc]", cvc);
+            HttpRequestMessage request = new(Http.Method.Post.HttpMethod, url);
 
-            RestResponse<Dictionary<string, object>> response = await Client!.ExecuteRequest<Dictionary<string, object>>(request);
+            Dictionary<string, string> headers = new Dictionary<string, string>
+            {
+                { "Authorization", $"Bearer {easypostStripeApiKey}" },
+                { "Accept", "application/x-www-form-urlencoded" },
+            };
 
-            if (response.ReturnedError() || response.Data == null)
+            foreach (KeyValuePair<string, string> header in headers)
+            {
+                request.Headers.Add(header.Key, header.Value);
+            }
+
+            // add parameters
+#pragma warning disable SA0001 // Nullability
+#pragma warning disable CS8620 // Nullability
+            Dictionary<string, string?> parameters = new Dictionary<string, string?>
+            {
+                { "card[number]", number },
+                { "card[exp_month]", expirationMonth.ToString(CultureInfo.InvariantCulture) },
+                { "card[exp_year]", expirationYear.ToString(CultureInfo.InvariantCulture) },
+                { "card[cvc]", cvc },
+            };
+            request.Content = new FormUrlEncodedContent(parameters);
+#pragma warning restore SA0001 // Nullability
+#pragma warning restore CS8620 // Nullability
+
+            HttpResponseMessage response = await Client!.ExecuteRequest(request);
+
+            if (response.ReturnedError())
             {
                 throw new ExternalApiError("Could not send card details to Stripe, please try again later.", (int)response.StatusCode);
             }
 
-            Dictionary<string, object>? data = response.Data;
+            string content = await response.Content.ReadAsStringAsync();
+            Dictionary<string, object> data = JsonSerialization.ConvertJsonToObject<Dictionary<string, object>>(content);
 
             data.TryGetValue("id", out object? id);
             return id == null

--- a/EasyPost/Utilities/Internal/Extensions/Http.cs
+++ b/EasyPost/Utilities/Internal/Extensions/Http.cs
@@ -1,5 +1,5 @@
 using System.Net;
-using RestSharp;
+using System.Net.Http;
 
 // ReSharper disable InconsistentNaming
 namespace EasyPost.Utilities.Internal.Extensions
@@ -13,7 +13,7 @@ namespace EasyPost.Utilities.Internal.Extensions
         /// <param name="min">Minimum valid status code.</param>
         /// <param name="max">Maximum valid status code.</param>
         /// <returns>Whether the given response has a status code in the given range.</returns>
-        internal static bool HasStatusCodeBetween(this RestResponseBase response, int min, int max) => StatusCodeBetween(response, min, max);
+        internal static bool HasStatusCodeBetween(this HttpResponseMessage response, int min, int max) => StatusCodeBetween(response, min, max);
 
         /// <summary>
         ///     Return whether the given status code is a 1xx error.
@@ -64,14 +64,14 @@ namespace EasyPost.Utilities.Internal.Extensions
         /// </summary>
         /// <param name="response">Response to check.</param>
         /// <returns>True if the response code is not in the 200-299 range, false otherwise.</returns>
-        internal static bool ReturnedError(this RestResponse response) => !ReturnedNoError(response);
+        internal static bool ReturnedError(this HttpResponseMessage response) => !ReturnedNoError(response);
 
         /// <summary>
         ///     Return whether the given response has a successful status code.
         /// </summary>
         /// <param name="response">Response to check.</param>
         /// <returns>True if the response code is in the 200-299 range, false otherwise.</returns>
-        internal static bool ReturnedNoError(this RestResponse response) => response.StatusCode.Is2xx();
+        internal static bool ReturnedNoError(this HttpResponseMessage response) => response.StatusCode.Is2xx();
 
         /// <summary>
         ///     Return whether the given status code is in the given range.
@@ -98,7 +98,7 @@ namespace EasyPost.Utilities.Internal.Extensions
         /// <param name="min">Minimum valid status code.</param>
         /// <param name="max">Maximum valid status code.</param>
         /// <returns>Whether the given response has a status code in the given range.</returns>
-        internal static bool StatusCodeBetween(RestResponseBase response, int min, int max) => StatusCodeBetween(response.StatusCode, min, max);
+        internal static bool StatusCodeBetween(HttpResponseMessage response, int min, int max) => StatusCodeBetween(response.StatusCode, min, max);
 
         /// <summary>
         ///     Return whether the given status code is a 1xx error.

--- a/EasyPost/Utilities/Internal/JsonSerialization.cs
+++ b/EasyPost/Utilities/Internal/JsonSerialization.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.Net.Http;
+using System.Threading.Tasks;
 using EasyPost.Exceptions.General;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using RestSharp;
 
 namespace EasyPost.Utilities.Internal
 {
@@ -91,10 +92,10 @@ namespace EasyPost.Utilities.Internal
         internal static ExpandoObject ConvertJsonToObject(string? data, JsonSerializerSettings? jsonSerializerSettings = null, List<string>? rootElementKeys = null) => ConvertJsonToObject<ExpandoObject>(data, jsonSerializerSettings, rootElementKeys);
 
         /// <summary>
-        ///     Deserialize data from a RestSharp.RestResponse into a T-type object, using this instance's
+        ///     Deserialize JSON data into a T-type object, using this instance's
         ///     <see cref="JsonSerializerSettings" />.
         /// </summary>
-        /// <param name="response">RestSharp.RestResponse object to extract data from.</param>
+        /// <param name="content"><see cref="HttpContent"/> object to extract data from.</param>
         /// <param name="jsonSerializerSettings">
         ///     The <see cref="Newtonsoft.Json.JsonSerializerSettings" /> to use for
         ///     deserialization. Defaults to <see cref="DefaultJsonSerializerSettings" /> if not provided.
@@ -102,7 +103,21 @@ namespace EasyPost.Utilities.Internal
         /// <param name="rootElementKeys">List, in order, of sub-keys path to follow to deserialization starting position.</param>
         /// <typeparam name="T">Type of object to deserialize to.</typeparam>
         /// <returns>A T-type object.</returns>
-        internal static T ConvertJsonToObject<T>(RestResponse response, JsonSerializerSettings? jsonSerializerSettings = null, List<string>? rootElementKeys = null) => ConvertJsonToObject<T>(response.Content, jsonSerializerSettings, rootElementKeys);
+        internal static async Task<T> ConvertJsonToObject<T>(HttpContent content, JsonSerializerSettings? jsonSerializerSettings = null, List<string>? rootElementKeys = null) => ConvertJsonToObject<T>(await content.ReadAsStringAsync(), jsonSerializerSettings, rootElementKeys);
+
+        /// <summary>
+        ///     Deserialize data from a HttpResponseMessage into a T-type object, using this instance's
+        ///     <see cref="JsonSerializerSettings" />.
+        /// </summary>
+        /// <param name="response">HttpResponseMessage object to extract data from.</param>
+        /// <param name="jsonSerializerSettings">
+        ///     The <see cref="Newtonsoft.Json.JsonSerializerSettings" /> to use for
+        ///     deserialization. Defaults to <see cref="DefaultJsonSerializerSettings" /> if not provided.
+        /// </param>
+        /// <param name="rootElementKeys">List, in order, of sub-keys path to follow to deserialization starting position.</param>
+        /// <typeparam name="T">Type of object to deserialize to.</typeparam>
+        /// <returns>A T-type object.</returns>
+        internal static async Task<T> ConvertJsonToObject<T>(HttpResponseMessage response, JsonSerializerSettings? jsonSerializerSettings = null, List<string>? rootElementKeys = null) => await ConvertJsonToObject<T>(response.Content, jsonSerializerSettings, rootElementKeys);
 
         /// <summary>
         ///     Serialize an object into a JSON string, using this instance's <see cref="JsonSerializerSettings" />.

--- a/EasyPost/_base/EasyPostClient.cs
+++ b/EasyPost/_base/EasyPostClient.cs
@@ -21,22 +21,22 @@ namespace EasyPost._base
         /// <summary>
         ///     Gets the API key used by this client.
         /// </summary>
-        public string ApiKeyInUse => Configuration.ApiKey; // public read-only property so users can audit the API key used by the client
+        public string ApiKey => Configuration.ApiKey; // public read-only property so users can audit the API key used by the client
 
         /// <summary>
         ///     Gets the base URL used by this client.
         /// </summary>
-        public string ApiBaseInUse => Configuration.ApiBase; // public read-only property so users can audit the base URL used by the client
+        public string ApiBase => Configuration.ApiBase; // public read-only property so users can audit the base URL used by the client
 
         /// <summary>
         ///     Gets the timeout in milliseconds used by this client.
         /// </summary>
-        public int TimeoutMillisecondsInUse => (int)HttpClient.Timeout.TotalMilliseconds; // public read-only property so users can audit the connect timeout used by the client
+        public int TimeoutMilliseconds => (int)HttpClient.Timeout.TotalMilliseconds; // public read-only property so users can audit the connect timeout used by the client
 
         /// <summary>
         ///     Gets the custom HTTP client used by this client.
         /// </summary>
-        public HttpClient? CustomHttpClientInUse => Configuration.HttpClient; // public read-only property so users can audit the custom HTTP client they set to be used by the client
+        public HttpClient? CustomHttpClient => Configuration.HttpClient; // public read-only property so users can audit the custom HTTP client they set to be used by the client
 
         /// <summary>
         ///     Gets the prepared HTTP client used by this client for all API calls.
@@ -96,7 +96,7 @@ namespace EasyPost._base
         {
             // Build the request
             Dictionary<string, string> headers = Configuration.Headers;
-            Request request = new(ApiBaseInUse, endpoint, method, apiVersion, parameters, headers);
+            Request request = new(ApiBase, endpoint, method, apiVersion, parameters, headers);
 
             // Execute the request
             HttpResponseMessage response = await ExecuteRequest(request.AsHttpRequestMessage());
@@ -203,7 +203,7 @@ namespace EasyPost._base
         {
             // Build the request
             Dictionary<string, string> headers = Configuration.Headers;
-            Request request = new(ApiBaseInUse, endpoint, method, apiVersion, parameters, headers);
+            Request request = new(ApiBase, endpoint, method, apiVersion, parameters, headers);
 
             // Execute the request
             HttpResponseMessage response = await ExecuteRequest(request.AsHttpRequestMessage());

--- a/EasyPost/_base/EasyPostClient.cs
+++ b/EasyPost/_base/EasyPostClient.cs
@@ -240,38 +240,5 @@ namespace EasyPost._base
 #pragma warning disable CA1307
         public override int GetHashCode() => Configuration.GetHashCode();
 #pragma warning restore CA1307
-
-        /// <summary>
-        ///     Make a copy of this client, with the ability to override API key, API base, and HttpClient.
-        /// </summary>
-        /// <param name="overrideApiKey">Optional alternate API key to use.</param>
-        /// <param name="overrideApiBase">Optional alternate API base to use.</param>
-        /// <param name="overrideHttpClient">Optional alternate HttpClient to use.</param>
-        /// <typeparam name="T">Type of client to duplicate.</typeparam>
-        /// <returns>A T-type client object.</returns>
-        // NOTE: If you ever need to initialize a new client (i.e. temporarily switch API keys), use this function to do so.
-        // This will preserve all other configuration options (e.g. request timeout, VCR, etc.)
-        [Obsolete("This method does not always function as expected. Create a new Client instead.")]
-        public T Clone<T>(string? overrideApiKey = null, string? overrideApiBase = null, HttpClient? overrideHttpClient = null)
-            where T : EasyPostClient
-        {
-            // TODO: You can't reuse the same HTTP client to re-initialize an EasyPost client, because the HTTP client is already initialized and can't be modified.
-            // From a testing perspective, this means any VCR client will not be passed into the new client.
-            // We should investigate a re-initialization/cloning process for HttpClient.
-            ConstructorInfo[] constructors = typeof(T).GetConstructors();
-
-            if (constructors == null || constructors.Length == 0)
-            {
-                throw new EasyPostError("Could not clone client. No constructors found.");
-            }
-
-            T clone = (T)constructors[0].Invoke(new object?[] { overrideApiKey ?? Configuration.ApiKey, overrideApiBase ?? Configuration.ApiBase, overrideHttpClient });
-
-            // We need to manually copy over other configuration options
-            clone.Configuration.ConnectTimeoutMilliseconds = Configuration.ConnectTimeoutMilliseconds;
-            clone.Configuration.RequestTimeoutMilliseconds = Configuration.RequestTimeoutMilliseconds;
-
-            return clone;
-        }
     }
 }

--- a/EasyPost/_base/EasyPostClient.cs
+++ b/EasyPost/_base/EasyPostClient.cs
@@ -1,17 +1,14 @@
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
-using EasyPost.Exceptions;
 using EasyPost.Exceptions.API;
 using EasyPost.Exceptions.General;
 using EasyPost.Http;
 using EasyPost.Models.Shared;
 using EasyPost.Utilities.Internal;
 using EasyPost.Utilities.Internal.Extensions;
-using RestSharp;
 
 #pragma warning disable SA1300
 namespace EasyPost._base
@@ -21,7 +18,30 @@ namespace EasyPost._base
     {
         public readonly ClientConfiguration Configuration;
 
-        private readonly RestClient _restClient;
+        /// <summary>
+        ///     Gets the API key used by this client.
+        /// </summary>
+        public string ApiKeyInUse => Configuration.ApiKey; // public read-only property so users can audit the API key used by the client
+
+        /// <summary>
+        ///     Gets the base URL used by this client.
+        /// </summary>
+        public string ApiBaseInUse => Configuration.ApiBase; // public read-only property so users can audit the base URL used by the client
+
+        /// <summary>
+        ///     Gets the connect timeout in milliseconds used by this client.
+        /// </summary>
+        public int ConnectTimeoutMillisecondsInUse => (int)HttpClient.Timeout.TotalMilliseconds; // public read-only property so users can audit the connect timeout used by the client
+
+        /// <summary>
+        ///     Gets the custom HTTP client used by this client.
+        /// </summary>
+        public HttpClient? CustomHttpClientInUse => Configuration.HttpClient; // public read-only property so users can audit the custom HTTP client they set to be used by the client
+
+        /// <summary>
+        ///     Gets the prepared HTTP client used by this client for all API calls.
+        /// </summary>
+        private HttpClient HttpClient => Configuration.PreparedHttpClient; // this is the actual, prepared HttpClient used to make requests
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EasyPostClient"/> class.
@@ -29,49 +49,37 @@ namespace EasyPost._base
         /// </summary>
         /// <param name="apiKey">API key to use with this client.</param>
         /// <param name="baseUrl">Base URL to use with this client. This will override `apiVersion`.</param>
+        /// <param name="timeoutMilliseconds">Timeout length, in milliseconds, for API calls.</param>
         /// <param name="customHttpClient">
-        ///     Custom HttpClient to pass into RestSharp if needed. Mostly for debug purposes, not
+        ///     Custom HttpClient to use if needed. Mostly for debug purposes, not
         ///     advised for general use.
         /// </param>
-        protected EasyPostClient(string apiKey, string? baseUrl = null, HttpClient? customHttpClient = null)
+        protected EasyPostClient(string apiKey, string? baseUrl = null, int? timeoutMilliseconds = null, HttpClient? customHttpClient = null)
         {
-            Configuration = new ClientConfiguration(apiKey, baseUrl, customHttpClient);
-
-            RestClientOptions clientOptions = new()
-            {
-                MaxTimeout = Configuration.ConnectTimeoutMilliseconds,
-                BaseUrl = new Uri(Configuration.ApiBase),
-                UserAgent = Configuration.UserAgent,
-            };
-
-            _restClient = Configuration.HttpClient != null ? new RestClient(Configuration.HttpClient, clientOptions) : new RestClient(clientOptions);
+            Configuration = new ClientConfiguration(apiKey, baseUrl, timeoutMilliseconds, customHttpClient);
         }
 
         /// <summary>
         ///     Execute an HTTP request.
         /// </summary>
         /// <param name="request">Request to execute.</param>
-        /// <typeparam name="T">Type of object to serialize response into.</typeparam>
-        /// <returns>A RestResponse containing a T-type object.</returns>
-        internal virtual async Task<RestResponse<T>> ExecuteRequest<T>(RestRequest request) =>
-
+        /// <returns>An <see cref="HttpResponseMessage"/> object.</returns>
+        internal virtual async Task<HttpResponseMessage> ExecuteRequest(HttpRequestMessage request)
+        {
             // This method actually executes the request and returns the response.
             // Everything up to this point has been pre-request, and everything after this point is post-request.
             // This method is "virtual" so it can be overriden (i.e. by a MockClient in testing to avoid making actual HTTP requests).
-            await _restClient.ExecuteAsync<T>(request);
 
-        /// <summary>
-        ///     Execute an HTTP request.
-        /// </summary>
-        /// <param name="request">Request to execute.</param>
-        /// <returns>A RestResponse object.</returns>
-        // ReSharper disable once MemberCanBeProtected.Global
-        internal virtual async Task<RestResponse> ExecuteRequest(RestRequest request) =>
-
-            // This method actually executes the request and returns the response.
-            // Everything up to this point has been pre-request, and everything after this point is post-request.
-            // This method is "virtual" so it can be overriden (i.e. by a MockClient in testing to avoid making actual HTTP requests).
-            await _restClient.ExecuteAsync(request);
+            // try to execute the request, catch and rethrow an HTTP timeout exception, all other exceptions are thrown as-is
+            try
+            {
+                return await HttpClient.SendAsync(request);
+            }
+            catch (TaskCanceledException)
+            {
+                throw new TimeoutError(Constants.ErrorMessages.ApiRequestTimedOut, 408);
+            }
+        }
 
         /// <summary>
         ///     Execute a request against the EasyPost API.
@@ -87,27 +95,27 @@ namespace EasyPost._base
             where T : class
         {
             // Build the request
-            Request request = new(endpoint, method, apiVersion, parameters, rootElement);
-            RestRequest restRequest = PrepareRequest(request);
+            Dictionary<string, string> headers = Configuration.Headers;
+            Request request = new(ApiBaseInUse, endpoint, method, apiVersion, parameters, headers);
 
             // Execute the request
-            RestResponse<T> response = await ExecuteRequest<T>(restRequest);
+            HttpResponseMessage response = await ExecuteRequest(request.AsHttpRequestMessage());
 
             // Check the response's status code
             if (response.ReturnedError())
             {
-                throw ApiError.FromErrorResponse(response);
+                throw await ApiError.FromErrorResponse(response);
             }
 
             // Prepare the list of root elements to use during deserialization
             List<string>? rootElements = null;
-            if (request.RootElement != null)
+            if (rootElement != null)
             {
-                rootElements = new List<string> { request.RootElement };
+                rootElements = new List<string> { rootElement };
             }
 
             // Deserialize the response into an object
-            T resource = JsonSerialization.ConvertJsonToObject<T>(response, null, rootElements);
+            T resource = await JsonSerialization.ConvertJsonToObject<T>(response, null, rootElements);
 
 #pragma warning disable IDE0270 // Simplify null check
             if (resource is null)
@@ -194,15 +202,16 @@ namespace EasyPost._base
         internal async Task<bool> Request(Http.Method method, string endpoint, ApiVersion apiVersion, Dictionary<string, object>? parameters = null)
         {
             // Build the request
-            Request request = new(endpoint, method, apiVersion, parameters);
-            RestRequest restRequest = PrepareRequest(request);
+            Dictionary<string, string> headers = Configuration.Headers;
+            Request request = new(ApiBaseInUse, endpoint, method, apiVersion, parameters, headers);
 
             // Execute the request
-            // RestSharp does not throw exception directly (https://restsharp.dev/error-handling.html), we'll need to check the response status code
-            RestResponse response = await ExecuteRequest(restRequest);
+            HttpResponseMessage response = await ExecuteRequest(request.AsHttpRequestMessage());
 
-            // Return whether the HTTP request produced an error (3xx, 4xx or 5xx status code) or not
-            return response.ReturnedNoError();
+            // Check whether the HTTP request produced an error (3xx, 4xx or 5xx status code) or not
+            bool errorRaised = response.ReturnedNoError();
+
+            return errorRaised;
         }
 
         /// <summary>
@@ -216,23 +225,6 @@ namespace EasyPost._base
             // construct a new service
             ConstructorInfo[] cons = typeof(T).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance);
             return (T)cons[0].Invoke(new object[] { this });
-        }
-
-        /// <summary>
-        ///     Prepare a request for execution by attaching required headers.
-        /// </summary>
-        /// <param name="request">EasyPost.Request object instance to prepare.</param>
-        /// <returns>RestSharp.RestRequest object instance to execute.</returns>
-        private RestRequest PrepareRequest(Request request)
-        {
-            request.BuildParameters();
-
-            RestRequest restRequest = (RestRequest)request;
-            restRequest.Timeout = Configuration.RequestTimeoutMilliseconds;
-            restRequest.AddHeader("authorization", $"Bearer {Configuration.ApiKey}");
-            restRequest.AddHeader("content_type", "application/json");
-
-            return restRequest;
         }
 
         public override bool Equals(object? obj) => obj is EasyPostClient client && Configuration.Equals(client.Configuration);

--- a/EasyPost/_base/EasyPostClient.cs
+++ b/EasyPost/_base/EasyPostClient.cs
@@ -29,9 +29,9 @@ namespace EasyPost._base
         public string ApiBaseInUse => Configuration.ApiBase; // public read-only property so users can audit the base URL used by the client
 
         /// <summary>
-        ///     Gets the connect timeout in milliseconds used by this client.
+        ///     Gets the timeout in milliseconds used by this client.
         /// </summary>
-        public int ConnectTimeoutMillisecondsInUse => (int)HttpClient.Timeout.TotalMilliseconds; // public read-only property so users can audit the connect timeout used by the client
+        public int TimeoutMillisecondsInUse => (int)HttpClient.Timeout.TotalMilliseconds; // public read-only property so users can audit the connect timeout used by the client
 
         /// <summary>
         ///     Gets the custom HTTP client used by this client.

--- a/EasyPost/packages.lock.json
+++ b/EasyPost/packages.lock.json
@@ -7,34 +7,6 @@
         "requested": "[13.0.1, 14.0.0)",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-      },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
-        "dependencies": {
-          "System.Text.Json": "5.0.0"
-        }
-      },
-      "StyleCop.Analyzers": {
-        "type": "Direct",
-        "requested": "[1.2.0-beta.435, )",
-        "resolved": "1.2.0-beta.435",
-        "contentHash": "TADk7vdGXtfTnYCV7GyleaaRTQjfoSfZXprQrVMm7cSJtJbFc1QIbWPyLvrgrfGdfHbGmUPvaN4ODKNxg2jgPQ==",
-        "dependencies": {
-          "StyleCop.Analyzers.Unstable": "1.2.0.435"
-        }
-      },
-      "StyleCop.Analyzers.Unstable": {
-        "type": "Transitive",
-        "resolved": "1.2.0.435",
-        "contentHash": "ouwPWZxbOV3SmCZxIRqHvljkSzkCyi1tDoMzQtDb/bRP8ctASV/iRJr+A2Gdj0QLaLmWnqTWDrH82/iP+X80Lg=="
-      },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
       }
     },
     ".NETStandard,Version=v2.0": {
@@ -53,96 +25,10 @@
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
-        "dependencies": {
-          "System.Text.Json": "5.0.0"
-        }
-      },
-      "StyleCop.Analyzers": {
-        "type": "Direct",
-        "requested": "[1.2.0-beta.435, )",
-        "resolved": "1.2.0-beta.435",
-        "contentHash": "TADk7vdGXtfTnYCV7GyleaaRTQjfoSfZXprQrVMm7cSJtJbFc1QIbWPyLvrgrfGdfHbGmUPvaN4ODKNxg2jgPQ==",
-        "dependencies": {
-          "StyleCop.Analyzers.Unstable": "1.2.0.435"
-        }
-      },
-      "Microsoft.Bcl.AsyncInterfaces": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
-        "dependencies": {
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
         "resolved": "1.1.0",
         "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
-      },
-      "StyleCop.Analyzers.Unstable": {
-        "type": "Transitive",
-        "resolved": "1.2.0.435",
-        "contentHash": "ouwPWZxbOV3SmCZxIRqHvljkSzkCyi1tDoMzQtDb/bRP8ctASV/iRJr+A2Gdj0QLaLmWnqTWDrH82/iP+X80Lg=="
-      },
-      "System.Buffers": {
-        "type": "Transitive",
-        "resolved": "4.5.1",
-        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
-      },
-      "System.Memory": {
-        "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw==",
-        "dependencies": {
-          "System.Buffers": "4.5.1",
-          "System.Numerics.Vectors": "4.4.0",
-          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
-        }
-      },
-      "System.Numerics.Vectors": {
-        "type": "Transitive",
-        "resolved": "4.5.0",
-        "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
-      },
-      "System.Runtime.CompilerServices.Unsafe": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZD9TMpsmYJLrxbbmdvhwt9YEgG5WntEnZ/d1eH8JBX9LBp+Ju8BSBhUGbZMNVHHomWo2KVImJhTDl2hIgw/6MA=="
-      },
-      "System.Text.Encodings.Web": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "EEslUvHKll1ftizbn20mX3Ix/l4Ygk/bdJ2LY6/X6FlGaP0RIhKMo9nS6JIGnKKT6KBP2PGj6JC3B9/ZF6ErqQ==",
-        "dependencies": {
-          "System.Memory": "4.5.4"
-        }
-      },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw==",
-        "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
-          "System.Buffers": "4.5.1",
-          "System.Memory": "4.5.4",
-          "System.Numerics.Vectors": "4.5.0",
-          "System.Runtime.CompilerServices.Unsafe": "5.0.0",
-          "System.Text.Encodings.Web": "5.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
-      "System.Threading.Tasks.Extensions": {
-        "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
-        }
       }
     },
     ".NETCoreApp,Version=v5.0": {
@@ -151,34 +37,6 @@
         "requested": "[13.0.1, 14.0.0)",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-      },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA==",
-        "dependencies": {
-          "System.Text.Json": "5.0.0"
-        }
-      },
-      "StyleCop.Analyzers": {
-        "type": "Direct",
-        "requested": "[1.2.0-beta.435, )",
-        "resolved": "1.2.0-beta.435",
-        "contentHash": "TADk7vdGXtfTnYCV7GyleaaRTQjfoSfZXprQrVMm7cSJtJbFc1QIbWPyLvrgrfGdfHbGmUPvaN4ODKNxg2jgPQ==",
-        "dependencies": {
-          "StyleCop.Analyzers.Unstable": "1.2.0.435"
-        }
-      },
-      "StyleCop.Analyzers.Unstable": {
-        "type": "Transitive",
-        "resolved": "1.2.0.435",
-        "contentHash": "ouwPWZxbOV3SmCZxIRqHvljkSzkCyi1tDoMzQtDb/bRP8ctASV/iRJr+A2Gdj0QLaLmWnqTWDrH82/iP+X80Lg=="
-      },
-      "System.Text.Json": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
       }
     },
     "net6.0": {
@@ -187,26 +45,6 @@
         "requested": "[13.0.1, 14.0.0)",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-      },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA=="
-      },
-      "StyleCop.Analyzers": {
-        "type": "Direct",
-        "requested": "[1.2.0-beta.435, )",
-        "resolved": "1.2.0-beta.435",
-        "contentHash": "TADk7vdGXtfTnYCV7GyleaaRTQjfoSfZXprQrVMm7cSJtJbFc1QIbWPyLvrgrfGdfHbGmUPvaN4ODKNxg2jgPQ==",
-        "dependencies": {
-          "StyleCop.Analyzers.Unstable": "1.2.0.435"
-        }
-      },
-      "StyleCop.Analyzers.Unstable": {
-        "type": "Transitive",
-        "resolved": "1.2.0.435",
-        "contentHash": "ouwPWZxbOV3SmCZxIRqHvljkSzkCyi1tDoMzQtDb/bRP8ctASV/iRJr+A2Gdj0QLaLmWnqTWDrH82/iP+X80Lg=="
       }
     },
     "net7.0": {
@@ -215,26 +53,6 @@
         "requested": "[13.0.1, 14.0.0)",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-      },
-      "RestSharp": {
-        "type": "Direct",
-        "requested": "[108.0.1, 109.0.0)",
-        "resolved": "108.0.1",
-        "contentHash": "XKwuwWq7A4dxZ8l9QkS2+ePLJ9ImmLaJSeFO6H2kpII4Us4n1NRs4w3c//8H2BYpL1XqBE8nmsd9aNCVBwXmOA=="
-      },
-      "StyleCop.Analyzers": {
-        "type": "Direct",
-        "requested": "[1.2.0-beta.435, )",
-        "resolved": "1.2.0-beta.435",
-        "contentHash": "TADk7vdGXtfTnYCV7GyleaaRTQjfoSfZXprQrVMm7cSJtJbFc1QIbWPyLvrgrfGdfHbGmUPvaN4ODKNxg2jgPQ==",
-        "dependencies": {
-          "StyleCop.Analyzers.Unstable": "1.2.0.435"
-        }
-      },
-      "StyleCop.Analyzers.Unstable": {
-        "type": "Transitive",
-        "resolved": "1.2.0.435",
-        "contentHash": "ouwPWZxbOV3SmCZxIRqHvljkSzkCyi1tDoMzQtDb/bRP8ctASV/iRJr+A2Gdj0QLaLmWnqTWDrH82/iP+X80Lg=="
       }
     }
   }


### PR DESCRIPTION
# Description

Removes all usage of RestSharp and drops the package as a dependency.

This library was using RestSharp as an HTTP client, but was not utilizing the package's JSON deserialization capabilities after [a custom de/serializer was implemented last year](https://github.com/EasyPost/easypost-csharp/commit/d06961811ae613fd0d69808fae4e65ac1e143df9). Rather than continuing to include this package under-utilized, the library has been restructured internally to simply use the default `HttpClient` built into the .NET framework and drop an unnecessary dependency.

Due to the immutability of connection timeouts (once the timeout length for an HttpClient has been set, it cannot be changed), connection timeout must be set during the construction of the `EasyPostClient` (and subsequent Beta client). This PR changes the construction signature of the `EasyPostClient` constructor to accept an optional `timeoutMilliseconds` parameter. If not set, the default 30-second timeout will be used. This is an optional parameter, so it should not impact the majority of users. Because of its placement in the constructor parameter order, a user may have to account for this if they are using the optional `customHttpClient` parameter.

Part of #433 

# Testing

- Unit tests, utilities updated to account for change
  - Regex patterns for mocking had to be slightly tweaked to account for domain presence
- No cassettes needed to be re-recorded, suggesting that the RestSharp switch does not impact the final HTTP request, and that the previous HTTP responses that were deserialized properly with RestSharp present are still deserialized properly without RestSharp present.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
