### PR TITLE
[chore] Best practices for async functions, avoid deadlocks (part 1)

### DIFF
--- a/EasyPost/Services/AddressService.cs
+++ b/EasyPost/Services/AddressService.cs
@@ -64,7 +64,7 @@ namespace EasyPost.Services
                 parameters.Add("verify_strict", true);
             }
 
-            return await Request<Address>(Method.Post, "addresses", parameters);
+            return await RequestAsync<Address>(Method.Post, "addresses", parameters);
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace EasyPost.Services
         public async Task<Address> Create(BetaFeatures.Parameters.Addresses.Create parameters)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await Request<Address>(Method.Post, "addresses", parameters.ToDictionary());
+            return await RequestAsync<Address>(Method.Post, "addresses", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>An Address object.</returns>
         [CrudOperations.Create]
-        public async Task<Address> CreateAndVerify(Dictionary<string, object> parameters) => await Request<Address>(Method.Post, "addresses/create_and_verify", parameters, "address");
+        public async Task<Address> CreateAndVerify(Dictionary<string, object> parameters) => await RequestAsync<Address>(Method.Post, "addresses/create_and_verify", parameters, "address");
 
         /// <summary>
         ///     Create and verify an <see cref="Address"/>.
@@ -109,7 +109,7 @@ namespace EasyPost.Services
         public async Task<Address> CreateAndVerify(BetaFeatures.Parameters.Addresses.Create parameters)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await Request<Address>(Method.Post, "addresses/create_and_verify", parameters.ToDictionary(), "address");
+            return await RequestAsync<Address>(Method.Post, "addresses/create_and_verify", parameters.ToDictionary(), "address");
         }
 
         /// <summary>
@@ -130,7 +130,7 @@ namespace EasyPost.Services
         [CrudOperations.Read]
         public async Task<AddressCollection> All(Dictionary<string, object>? parameters = null)
         {
-            AddressCollection collection = await Request<AddressCollection>(Method.Get, "addresses", parameters);
+            AddressCollection collection = await RequestAsync<AddressCollection>(Method.Get, "addresses", parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.Addresses.All>(parameters);
             return collection;
         }
@@ -159,7 +159,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing an Address. Starts with "adr_".</param>
         /// <returns>EasyPost.Address instance.</returns>
         [CrudOperations.Read]
-        public async Task<Address> Retrieve(string id) => await Request<Address>(Method.Get, $"addresses/{id}");
+        public async Task<Address> Retrieve(string id) => await RequestAsync<Address>(Method.Get, $"addresses/{id}");
 
         /// <summary>
         ///     Verify an Address.
@@ -169,7 +169,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Address> Verify(string id)
         {
-            return await Request<Address>(Method.Get, $"addresses/{id}/verify", null, "address");
+            return await RequestAsync<Address>(Method.Get, $"addresses/{id}/verify", null, "address");
         }
 
         #endregion

--- a/EasyPost/Services/ApiKeyService.cs
+++ b/EasyPost/Services/ApiKeyService.cs
@@ -21,7 +21,7 @@ namespace EasyPost.Services
         /// </summary>
         /// <returns>An EasyPost.ApiKeyCollection instances.</returns>
         [CrudOperations.Read]
-        public async Task<ApiKeyCollection> All() => await Request<ApiKeyCollection>(Method.Get, "api_keys");
+        public async Task<ApiKeyCollection> All() => await RequestAsync<ApiKeyCollection>(Method.Get, "api_keys");
 
         #endregion
     }

--- a/EasyPost/Services/BatchService.cs
+++ b/EasyPost/Services/BatchService.cs
@@ -35,7 +35,7 @@ namespace EasyPost.Services
         public async Task<Batch> Create(Dictionary<string, object>? parameters = null)
         {
             parameters = parameters?.Wrap("batch");
-            return await Request<Batch>(Method.Post, "batches", parameters);
+            return await RequestAsync<Batch>(Method.Post, "batches", parameters);
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace EasyPost.Services
         public async Task<Batch> Create(BetaFeatures.Parameters.Batches.Create parameters)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await Request<Batch>(Method.Post, "batches", parameters.ToDictionary());
+            return await RequestAsync<Batch>(Method.Post, "batches", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace EasyPost.Services
         public async Task<Batch> CreateAndBuy(Dictionary<string, object> parameters)
         {
             parameters = parameters.Wrap("batch");
-            return await Request<Batch>(Method.Post, "batches/create_and_buy", parameters);
+            return await RequestAsync<Batch>(Method.Post, "batches/create_and_buy", parameters);
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace EasyPost.Services
         public async Task<Batch> CreateAndBuy(BetaFeatures.Parameters.Batches.Create parameters)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await Request<Batch>(Method.Post, "batches/create_and_buy", parameters.ToDictionary());
+            return await RequestAsync<Batch>(Method.Post, "batches/create_and_buy", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace EasyPost.Services
         [CrudOperations.Read]
         public async Task<BatchCollection> All(Dictionary<string, object>? parameters = null)
         {
-            BatchCollection collection = await Request<BatchCollection>(Method.Get, "batches", parameters);
+            BatchCollection collection = await RequestAsync<BatchCollection>(Method.Get, "batches", parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.Batches.All>(parameters);
             return collection;
         }
@@ -120,7 +120,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Batch> AddShipments(string id, Dictionary<string, object> parameters)
         {
-            return await Request<Batch>(Method.Post, $"batches/{id}/add_shipments", parameters);
+            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/add_shipments", parameters);
         }
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a Batch. Starts with "batch_".</param>
         /// <returns>EasyPost.Batch instance.</returns>
         [CrudOperations.Read]
-        public async Task<Batch> Retrieve(string id) => await Request<Batch>(Method.Get, $"batches/{id}");
+        public async Task<Batch> Retrieve(string id) => await RequestAsync<Batch>(Method.Get, $"batches/{id}");
 
         /// <summary>
         ///     Add <see cref="Shipment"/>s to this <see cref="Batch"/>.
@@ -139,7 +139,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Batch> AddShipments(string id, BetaFeatures.Parameters.Batches.AddShipments parameters)
         {
-            return await Request<Batch>(Method.Post, $"batches/{id}/add_shipments", parameters.ToDictionary());
+            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/add_shipments", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -173,7 +173,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Batch> Buy(string id)
         {
-            return await Request<Batch>(Method.Post, $"batches/{id}/buy");
+            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/buy");
         }
 
         /// <summary>
@@ -185,7 +185,7 @@ namespace EasyPost.Services
         public async Task<Batch> GenerateLabel(string id, string fileFormat = "pdf") // TODO: Remove default value (breaking change)
         {
             Dictionary<string, object> parameters = new() { { "file_format", fileFormat } };
-            return await Request<Batch>(Method.Post, $"batches/{id}/label", parameters);
+            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/label", parameters);
         }
 
         /// <summary>
@@ -196,7 +196,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Batch> GenerateLabel(string id, BetaFeatures.Parameters.Batches.GenerateLabel parameters)
         {
-            return await Request<Batch>(Method.Post, $"batches/{id}/label", parameters.ToDictionary());
+            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/label", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace EasyPost.Services
         public async Task<Batch> GenerateScanForm(string id, string fileFormat = "pdf") // TODO: Remove default value (breaking change)
         {
             Dictionary<string, object> parameters = new() { { "file_format", fileFormat } };
-            return await Request<Batch>(Method.Post, $"batches/{id}/scan_form", parameters);
+            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/scan_form", parameters);
         }
 
         /// <summary>
@@ -219,7 +219,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Batch> GenerateScanForm(string id, BetaFeatures.Parameters.Batches.GenerateScanForm parameters)
         {
-            return await Request<Batch>(Method.Post, $"batches/{id}/scan_form", parameters.ToDictionary());
+            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/scan_form", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -230,7 +230,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Batch> RemoveShipments(string id, Dictionary<string, object> parameters)
         {
-            return await Request<Batch>(Method.Post, $"batches/{id}/remove_shipments", parameters);
+            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/remove_shipments", parameters);
         }
 
         /// <summary>
@@ -241,7 +241,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Batch> RemoveShipments(string id, BetaFeatures.Parameters.Batches.RemoveShipments parameters)
         {
-            return await Request<Batch>(Method.Post, $"batches/{id}/remove_shipments", parameters.ToDictionary());
+            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/remove_shipments", parameters.ToDictionary());
         }
 
         /// <summary>

--- a/EasyPost/Services/Beta/CarrierMetadataService.cs
+++ b/EasyPost/Services/Beta/CarrierMetadataService.cs
@@ -27,7 +27,7 @@ namespace EasyPost.Services.Beta
         {
             Dictionary<string, object> data = parameters?.ToDictionary() ?? new Dictionary<string, object>();
 
-            return await Request<List<Carrier>>(Method.Get, "metadata", data, "carriers", ApiVersion.Beta);
+            return await RequestAsync<List<Carrier>>(Method.Get, "metadata", data, "carriers", ApiVersion.Beta);
         }
 
         #endregion

--- a/EasyPost/Services/Beta/RateService.cs
+++ b/EasyPost/Services/Beta/RateService.cs
@@ -43,7 +43,7 @@ namespace EasyPost.Services.Beta
         public async Task<List<StatelessRate>> RetrieveStatelessRates(Dictionary<string, object> parameters)
         {
             parameters = parameters.Wrap("shipment");
-            return await Request<List<StatelessRate>>(Method.Post, "rates", parameters, "rates", ApiVersion.Beta);
+            return await RequestAsync<List<StatelessRate>>(Method.Post, "rates", parameters, "rates", ApiVersion.Beta);
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace EasyPost.Services.Beta
         [CrudOperations.Create]
         public async Task<List<StatelessRate>> RetrieveStatelessRates(BetaFeatures.Parameters.Beta.Rates.Retrieve parameters)
         {
-            return await Request<List<StatelessRate>>(Method.Post, "rates", parameters.ToDictionary(), "rates", ApiVersion.Beta);
+            return await RequestAsync<List<StatelessRate>>(Method.Post, "rates", parameters.ToDictionary(), "rates", ApiVersion.Beta);
         }
 
         #endregion

--- a/EasyPost/Services/Beta/ReferralCustomerService.cs
+++ b/EasyPost/Services/Beta/ReferralCustomerService.cs
@@ -46,7 +46,7 @@ namespace EasyPost.Services.Beta
                 },
             };
 
-            return await Request<PaymentMethod>(Method.Post, "referral_customers/payment_method", parameters, overrideApiVersion: ApiVersion.Beta);
+            return await RequestAsync<PaymentMethod>(Method.Post, "referral_customers/payment_method", parameters, overrideApiVersion: ApiVersion.Beta);
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace EasyPost.Services.Beta
         [CrudOperations.Update]
         public async Task<PaymentMethod> AddPaymentMethod(BetaFeatures.Parameters.ReferralCustomers.AddPaymentMethod parameters)
         {
-            return await Request<PaymentMethod>(Method.Post, "referral_customers/payment_method", parameters.ToDictionary(), overrideApiVersion: ApiVersion.Beta);
+            return await RequestAsync<PaymentMethod>(Method.Post, "referral_customers/payment_method", parameters.ToDictionary(), overrideApiVersion: ApiVersion.Beta);
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace EasyPost.Services.Beta
                 { "refund_amount", amount },
             };
 
-            return await Request<PaymentRefund>(Method.Post, "referral_customers/refunds", parameters, overrideApiVersion: ApiVersion.Beta);
+            return await RequestAsync<PaymentRefund>(Method.Post, "referral_customers/refunds", parameters, overrideApiVersion: ApiVersion.Beta);
         }
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace EasyPost.Services.Beta
         [CrudOperations.Update]
         public async Task<PaymentRefund> RefundByAmount(BetaFeatures.Parameters.ReferralCustomers.RefundByAmount parameters)
         {
-            return await Request<PaymentRefund>(Method.Post, "referral_customers/refunds", parameters.ToDictionary(), overrideApiVersion: ApiVersion.Beta);
+            return await RequestAsync<PaymentRefund>(Method.Post, "referral_customers/refunds", parameters.ToDictionary(), overrideApiVersion: ApiVersion.Beta);
         }
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace EasyPost.Services.Beta
                 { "payment_log_id", paymentLogId },
             };
 
-            return await Request<PaymentRefund>(Method.Post, "referral_customers/refunds", parameters, overrideApiVersion: ApiVersion.Beta);
+            return await RequestAsync<PaymentRefund>(Method.Post, "referral_customers/refunds", parameters, overrideApiVersion: ApiVersion.Beta);
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace EasyPost.Services.Beta
         [CrudOperations.Update]
         public async Task<PaymentRefund> RefundByPaymentLog(BetaFeatures.Parameters.ReferralCustomers.RefundByPaymentLog parameters)
         {
-            return await Request<PaymentRefund>(Method.Post, "referral_customers/refunds", parameters.ToDictionary(), overrideApiVersion: ApiVersion.Beta);
+            return await RequestAsync<PaymentRefund>(Method.Post, "referral_customers/refunds", parameters.ToDictionary(), overrideApiVersion: ApiVersion.Beta);
         }
 
         #endregion

--- a/EasyPost/Services/BillingService.cs
+++ b/EasyPost/Services/BillingService.cs
@@ -35,7 +35,7 @@ namespace EasyPost.Services
 
             Dictionary<string, object> parameters = new() { { "amount", amount } };
 
-            await Request(Method.Post, $"{paymentMethod.Endpoint}/{paymentMethod.Id}/charges", parameters);
+            await RequestAsync(Method.Post, $"{paymentMethod.Endpoint}/{paymentMethod.Id}/charges", parameters);
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace EasyPost.Services
         [CrudOperations.Read]
         public async Task<PaymentMethodsSummary> RetrievePaymentMethodsSummary()
         {
-            PaymentMethodsSummary paymentMethodsSummary = await Request<PaymentMethodsSummary>(Method.Get, "payment_methods");
+            PaymentMethodsSummary paymentMethodsSummary = await RequestAsync<PaymentMethodsSummary>(Method.Get, "payment_methods");
 
             return paymentMethodsSummary.Id == null
                 ? throw new InvalidObjectError(Constants.ErrorMessages.NoPaymentMethods)
@@ -62,7 +62,7 @@ namespace EasyPost.Services
         {
             PaymentMethod paymentMethod = await GetPaymentMethodByPriority(priority);
 
-            await Request(Method.Delete, $"{paymentMethod.Endpoint}/{paymentMethod.Id}");
+            await RequestAsync(Method.Delete, $"{paymentMethod.Endpoint}/{paymentMethod.Id}");
         }
 
         #endregion

--- a/EasyPost/Services/CarrierAccountService.cs
+++ b/EasyPost/Services/CarrierAccountService.cs
@@ -47,7 +47,7 @@ namespace EasyPost.Services
 
             parameters = parameters.Wrap("carrier_account");
 
-            return await Request<CarrierAccount>(Method.Post, endpoint, parameters);
+            return await RequestAsync<CarrierAccount>(Method.Post, endpoint, parameters);
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace EasyPost.Services
 
             string endpoint = SelectCarrierAccountCreationEndpoint(parameters.Type);
 
-            return await Request<CarrierAccount>(Method.Post, endpoint, parameters.ToDictionary());
+            return await RequestAsync<CarrierAccount>(Method.Post, endpoint, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace EasyPost.Services
         /// </summary>
         /// <returns>A list of EasyPost.CarrierAccount instances.</returns>
         [CrudOperations.Read]
-        public async Task<List<CarrierAccount>> All() => await Request<List<CarrierAccount>>(Method.Get, "carrier_accounts");
+        public async Task<List<CarrierAccount>> All() => await RequestAsync<List<CarrierAccount>>(Method.Get, "carrier_accounts");
 
         /// <summary>
         ///     Retrieve a CarrierAccount from its id.
@@ -82,7 +82,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a carrier account. Starts with "ca_".</param>
         /// <returns>EasyPost.CarrierAccount instance.</returns>
         [CrudOperations.Read]
-        public async Task<CarrierAccount> Retrieve(string id) => await Request<CarrierAccount>(Method.Get, $"carrier_accounts/{id}");
+        public async Task<CarrierAccount> Retrieve(string id) => await RequestAsync<CarrierAccount>(Method.Get, $"carrier_accounts/{id}");
 
         /// <summary>
         ///     Update this CarrierAccount.
@@ -93,7 +93,7 @@ namespace EasyPost.Services
         public async Task<CarrierAccount> Update(string id, Dictionary<string, object> parameters)
         {
             parameters = parameters.Wrap("carrier_account");
-            return await Request<CarrierAccount>(Method.Put, $"carrier_accounts/{id}", parameters);
+            return await RequestAsync<CarrierAccount>(Method.Put, $"carrier_accounts/{id}", parameters);
         }
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<CarrierAccount> Update(string id, BetaFeatures.Parameters.CarrierAccounts.Update parameters)
         {
-            return await Request<CarrierAccount>(Method.Put, $"carrier_accounts/{id}", parameters.ToDictionary());
+            return await RequestAsync<CarrierAccount>(Method.Put, $"carrier_accounts/{id}", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace EasyPost.Services
         /// </summary>
         /// <returns>Whether the request was successful or not.</returns>
         [CrudOperations.Delete]
-        public async Task Delete(string id) => await Request(Method.Delete, $"carrier_accounts/{id}");
+        public async Task Delete(string id) => await RequestAsync(Method.Delete, $"carrier_accounts/{id}");
 
         #endregion
 

--- a/EasyPost/Services/CarrierTypeService.cs
+++ b/EasyPost/Services/CarrierTypeService.cs
@@ -22,7 +22,7 @@ namespace EasyPost.Services
         /// </summary>
         /// <returns>A list of EasyPost.CarrierType instances.</returns>
         [CrudOperations.Read]
-        public async Task<List<CarrierType>> All() => await Request<List<CarrierType>>(Method.Get, "carrier_types");
+        public async Task<List<CarrierType>> All() => await RequestAsync<List<CarrierType>>(Method.Get, "carrier_types");
 
         #endregion
     }

--- a/EasyPost/Services/CustomsInfoService.cs
+++ b/EasyPost/Services/CustomsInfoService.cs
@@ -38,7 +38,7 @@ namespace EasyPost.Services
         public async Task<CustomsInfo> Create(Dictionary<string, object> parameters)
         {
             parameters = parameters.Wrap("customs_info");
-            return await Request<CustomsInfo>(Method.Post, "customs_infos", parameters);
+            return await RequestAsync<CustomsInfo>(Method.Post, "customs_infos", parameters);
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace EasyPost.Services
         public async Task<CustomsInfo> Create(BetaFeatures.Parameters.CustomsInfo.Create parameters)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await Request<CustomsInfo>(Method.Post, "customs_infos", parameters.ToDictionary());
+            return await RequestAsync<CustomsInfo>(Method.Post, "customs_infos", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a CustomsInfo. Starts with "cstinfo_".</param>
         /// <returns>EasyPost.CustomsInfo instance.</returns>
         [CrudOperations.Read]
-        public async Task<CustomsInfo> Retrieve(string id) => await Request<CustomsInfo>(Method.Get, $"customs_infos/{id}");
+        public async Task<CustomsInfo> Retrieve(string id) => await RequestAsync<CustomsInfo>(Method.Get, $"customs_infos/{id}");
 
         #endregion
     }

--- a/EasyPost/Services/CustomsItemService.cs
+++ b/EasyPost/Services/CustomsItemService.cs
@@ -36,7 +36,7 @@ namespace EasyPost.Services
         public async Task<CustomsItem> Create(Dictionary<string, object> parameters)
         {
             parameters = parameters.Wrap("customs_item");
-            return await Request<CustomsItem>(Method.Post, "customs_items", parameters);
+            return await RequestAsync<CustomsItem>(Method.Post, "customs_items", parameters);
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace EasyPost.Services
         public async Task<CustomsItem> Create(BetaFeatures.Parameters.CustomsItems.Create parameters)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await Request<CustomsItem>(Method.Post, "customs_items", parameters.ToDictionary());
+            return await RequestAsync<CustomsItem>(Method.Post, "customs_items", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a CustomsItem. Starts with "cstitem_".</param>
         /// <returns>EasyPost.CustomsItem instance.</returns>
         [CrudOperations.Read]
-        public async Task<CustomsItem> Retrieve(string id) => await Request<CustomsItem>(Method.Get, $"customs_items/{id}");
+        public async Task<CustomsItem> Retrieve(string id) => await RequestAsync<CustomsItem>(Method.Get, $"customs_items/{id}");
 
         #endregion
     }

--- a/EasyPost/Services/EndShipperService.cs
+++ b/EasyPost/Services/EndShipperService.cs
@@ -42,7 +42,7 @@ namespace EasyPost.Services
         public async Task<EndShipper> Create(Dictionary<string, object> parameters)
         {
             parameters = parameters.Wrap("address");
-            return await Request<EndShipper>(Method.Post, "end_shippers", parameters);
+            return await RequestAsync<EndShipper>(Method.Post, "end_shippers", parameters);
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace EasyPost.Services
         public async Task<EndShipper> Create(BetaFeatures.Parameters.EndShippers.Create parameters)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await Request<EndShipper>(Method.Post, "end_shippers", parameters.ToDictionary());
+            return await RequestAsync<EndShipper>(Method.Post, "end_shippers", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace EasyPost.Services
         [CrudOperations.Read]
         public async Task<EndShipperCollection> All(Dictionary<string, object>? parameters = null)
         {
-            EndShipperCollection collection = await Request<EndShipperCollection>(Method.Get, "end_shippers", parameters);
+            EndShipperCollection collection = await RequestAsync<EndShipperCollection>(Method.Get, "end_shippers", parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.EndShippers.All>(parameters);
             return collection;
         }
@@ -97,7 +97,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing an EndShipper. Starts with "es_".</param>
         /// <returns>EasyPost.EndShipper instance.</returns>
         [CrudOperations.Read]
-        public async Task<EndShipper> Retrieve(string id) => await Request<EndShipper>(Method.Get, $"end_shippers/{id}");
+        public async Task<EndShipper> Retrieve(string id) => await RequestAsync<EndShipper>(Method.Get, $"end_shippers/{id}");
 
         /// <summary>
         ///     Update this EndShipper. Must pass in all properties (new and existing).
@@ -109,7 +109,7 @@ namespace EasyPost.Services
         {
             parameters = parameters.Wrap("address");
 
-            return await Request<EndShipper>(Method.Put, $"end_shippers/{id}", parameters);
+            return await RequestAsync<EndShipper>(Method.Put, $"end_shippers/{id}", parameters);
         }
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<EndShipper> Update(string id, BetaFeatures.Parameters.EndShippers.Update parameters)
         {
-            return await Request<EndShipper>(Method.Put, $"end_shippers/{id}", parameters.ToDictionary());
+            return await RequestAsync<EndShipper>(Method.Put, $"end_shippers/{id}", parameters.ToDictionary());
         }
 
         #endregion

--- a/EasyPost/Services/EventService.cs
+++ b/EasyPost/Services/EventService.cs
@@ -38,7 +38,7 @@ namespace EasyPost.Services
         [CrudOperations.Read]
         public async Task<EventCollection> All(Dictionary<string, object>? parameters = null)
         {
-            EventCollection collection = await Request<EventCollection>(Method.Get, "events", parameters);
+            EventCollection collection = await RequestAsync<EventCollection>(Method.Get, "events", parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.Events.All>(parameters);
             return collection;
         }
@@ -67,14 +67,14 @@ namespace EasyPost.Services
         /// <param name="id">String representing a Event. Starts with "evt_".</param>
         /// <returns>EasyPost.Event instance.</returns>
         [CrudOperations.Read]
-        public async Task<Event> Retrieve(string id) => await Request<Event>(Method.Get, $"events/{id}");
+        public async Task<Event> Retrieve(string id) => await RequestAsync<Event>(Method.Get, $"events/{id}");
 
         /// <summary>
         ///     Retrieve all <see cref="Payload"/>s for an <see cref="Event"/>.
         /// </summary>
         /// <param name="eventId">ID of the <see cref="Event"/> to retrieve payloads for.</param>
         /// <returns>A list of <see cref="Payload"/> objects.</returns>
-        public async Task<List<Payload>> RetrieveAllPayloads(string eventId) => await Request<List<Payload>>(Method.Get, $"events/{eventId}/payloads", rootElement: "payloads");
+        public async Task<List<Payload>> RetrieveAllPayloads(string eventId) => await RequestAsync<List<Payload>>(Method.Get, $"events/{eventId}/payloads", rootElement: "payloads");
 
         /// <summary>
         ///     Retrieve a specific <see cref="Payload"/> for an <see cref="Event"/>.
@@ -84,7 +84,7 @@ namespace EasyPost.Services
         /// <returns>A <see cref="Payload"/> object.</returns>
         /// <exception cref="InvalidRequestError">Thrown if the specified payload ID is malformed.</exception>
         /// <exception cref="NotFoundError">Thrown if the specified payload is not found.</exception>
-        public async Task<Payload> RetrievePayload(string eventId, string payloadId) => await Request<Payload>(Method.Get, $"events/{eventId}/payloads/{payloadId}");
+        public async Task<Payload> RetrievePayload(string eventId, string payloadId) => await RequestAsync<Payload>(Method.Get, $"events/{eventId}/payloads/{payloadId}");
 
         #endregion
     }

--- a/EasyPost/Services/InsuranceService.cs
+++ b/EasyPost/Services/InsuranceService.cs
@@ -41,7 +41,7 @@ namespace EasyPost.Services
         public async Task<Insurance> Create(Dictionary<string, object> parameters)
         {
             parameters = parameters.Wrap("insurance");
-            return await Request<Insurance>(Method.Post, "insurances", parameters);
+            return await RequestAsync<Insurance>(Method.Post, "insurances", parameters);
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace EasyPost.Services
         public async Task<Insurance> Create(BetaFeatures.Parameters.Insurance.Create parameters)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await Request<Insurance>(Method.Post, "insurances", parameters.ToDictionary());
+            return await RequestAsync<Insurance>(Method.Post, "insurances", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace EasyPost.Services
         [CrudOperations.Read]
         public async Task<InsuranceCollection> All(Dictionary<string, object>? parameters = null)
         {
-            InsuranceCollection collection = await Request<InsuranceCollection>(Method.Get, "insurances", parameters);
+            InsuranceCollection collection = await RequestAsync<InsuranceCollection>(Method.Get, "insurances", parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.Insurance.All>(parameters);
             return collection;
         }
@@ -99,7 +99,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing an Insurance. Starts with "ins_".</param>
         /// <returns>EasyPost.Insurance instance.</returns>
         [CrudOperations.Read]
-        public async Task<Insurance> Retrieve(string id) => await Request<Insurance>(Method.Get, $"insurances/{id}");
+        public async Task<Insurance> Retrieve(string id) => await RequestAsync<Insurance>(Method.Get, $"insurances/{id}");
 
         #endregion
     }

--- a/EasyPost/Services/OrderService.cs
+++ b/EasyPost/Services/OrderService.cs
@@ -42,7 +42,7 @@ namespace EasyPost.Services
         public async Task<Order> Create(Dictionary<string, object> parameters)
         {
             parameters = parameters.Wrap("order");
-            return await Request<Order>(Method.Post, "orders", parameters);
+            return await RequestAsync<Order>(Method.Post, "orders", parameters);
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace EasyPost.Services
         public async Task<Order> Create(BetaFeatures.Parameters.Orders.Create parameters)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await Request<Order>(Method.Post, "orders", parameters.ToDictionary());
+            return await RequestAsync<Order>(Method.Post, "orders", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a Order. Starts with "order_" if passing an id.</param>
         /// <returns>EasyPost.Order instance.</returns>
         [CrudOperations.Read]
-        public async Task<Order> Retrieve(string id) => await Request<Order>(Method.Get, $"orders/{id}");
+        public async Task<Order> Retrieve(string id) => await RequestAsync<Order>(Method.Get, $"orders/{id}");
 
         /// <summary>
         ///     Purchase the shipments within this order with a carrier and service.
@@ -80,7 +80,7 @@ namespace EasyPost.Services
                 { "service", withService },
             };
 
-            return await Request<Order>(Method.Post, $"orders/{id}/buy", parameters);
+            return await RequestAsync<Order>(Method.Post, $"orders/{id}/buy", parameters);
         }
 
         /// <summary>
@@ -114,7 +114,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Order> Buy(string id, BetaFeatures.Parameters.Orders.Buy parameters)
         {
-            return await Request<Order>(Method.Post, $"orders/{id}/buy", parameters.ToDictionary());
+            return await RequestAsync<Order>(Method.Post, $"orders/{id}/buy", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace EasyPost.Services
         public async Task<Order> RefreshRates(string id)
         {
             // TODO: Make consistent with Shipment, Pickup and Order: GetRates, RefreshRates, RegenerateRates?
-            return await Request<Order>(Method.Get, $"orders/{id}/rates");
+            return await RequestAsync<Order>(Method.Get, $"orders/{id}/rates");
         }
 
         #endregion

--- a/EasyPost/Services/ParcelService.cs
+++ b/EasyPost/Services/ParcelService.cs
@@ -35,7 +35,7 @@ namespace EasyPost.Services
         public async Task<Parcel> Create(Dictionary<string, object> parameters)
         {
             parameters = parameters.Wrap("parcel");
-            return await Request<Parcel>(Method.Post, "parcels", parameters);
+            return await RequestAsync<Parcel>(Method.Post, "parcels", parameters);
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace EasyPost.Services
         public async Task<Parcel> Create(BetaFeatures.Parameters.Parcels.Create parameters)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await Request<Parcel>(Method.Post, "parcels", parameters.ToDictionary());
+            return await RequestAsync<Parcel>(Method.Post, "parcels", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a Parcel. Starts with "prcl_".</param>
         /// <returns>EasyPost.Parcel instance.</returns>
         [CrudOperations.Read]
-        public async Task<Parcel> Retrieve(string id) => await Request<Parcel>(Method.Get, $"parcels/{id}");
+        public async Task<Parcel> Retrieve(string id) => await RequestAsync<Parcel>(Method.Get, $"parcels/{id}");
 
         #endregion
     }

--- a/EasyPost/Services/PickupService.cs
+++ b/EasyPost/Services/PickupService.cs
@@ -41,7 +41,7 @@ namespace EasyPost.Services
         public async Task<Pickup> Create(Dictionary<string, object> parameters)
         {
             parameters = parameters.Wrap("pickup");
-            return await Request<Pickup>(Method.Post, "pickups", parameters);
+            return await RequestAsync<Pickup>(Method.Post, "pickups", parameters);
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace EasyPost.Services
         public async Task<Pickup> Create(BetaFeatures.Parameters.Pickups.Create parameters)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await Request<Pickup>(Method.Post, "pickups", parameters.ToDictionary());
+            return await RequestAsync<Pickup>(Method.Post, "pickups", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a Pickup. Starts with "pickup_".</param>
         /// <returns>EasyPost.Pickup instance.</returns>
         [CrudOperations.Read]
-        public async Task<Pickup> Retrieve(string id) => await Request<Pickup>(Method.Get, $"pickups/{id}");
+        public async Task<Pickup> Retrieve(string id) => await RequestAsync<Pickup>(Method.Get, $"pickups/{id}");
 
         /// <summary>
         ///     Get a paginated list of <see cref="Pickup"/>s.
@@ -83,7 +83,7 @@ namespace EasyPost.Services
         [CrudOperations.Read]
         public async Task<PickupCollection> All(Dictionary<string, object>? parameters = null)
         {
-            PickupCollection collection = await Request<PickupCollection>(Method.Get, "pickups", parameters);
+            PickupCollection collection = await RequestAsync<PickupCollection>(Method.Get, "pickups", parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.Pickups.All>(parameters);
             return collection;
         }
@@ -121,7 +121,7 @@ namespace EasyPost.Services
                 { "service", withService },
             };
 
-            return await Request<Pickup>(Method.Post, $"pickups/{id}/buy", parameters);
+            return await RequestAsync<Pickup>(Method.Post, $"pickups/{id}/buy", parameters);
         }
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Pickup> Buy(string id, BetaFeatures.Parameters.Pickups.Buy parameters)
         {
-            return await Request<Pickup>(Method.Post, $"pickups/{id}/buy", parameters.ToDictionary());
+            return await RequestAsync<Pickup>(Method.Post, $"pickups/{id}/buy", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Pickup> Cancel(string id)
         {
-            return await Request<Pickup>(Method.Post, $"pickups/{id}/cancel");
+            return await RequestAsync<Pickup>(Method.Post, $"pickups/{id}/cancel");
         }
 
         #endregion

--- a/EasyPost/Services/RateService.cs
+++ b/EasyPost/Services/RateService.cs
@@ -24,7 +24,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a rate. Starts with `rate_`.</param>
         /// <returns>EasyPost.Rate instance.</returns>
         [CrudOperations.Read]
-        public async Task<Rate> Retrieve(string id) => await Request<Rate>(Method.Get, $"rates/{id}");
+        public async Task<Rate> Retrieve(string id) => await RequestAsync<Rate>(Method.Get, $"rates/{id}");
 
         #endregion
 

--- a/EasyPost/Services/ReferralCustomerService.cs
+++ b/EasyPost/Services/ReferralCustomerService.cs
@@ -40,7 +40,7 @@ namespace EasyPost.Services
         public async Task<ReferralCustomer> CreateReferral(Dictionary<string, object> parameters)
         {
             parameters = parameters.Wrap("user");
-            return await Request<ReferralCustomer>(Method.Post, "referral_customers", parameters);
+            return await RequestAsync<ReferralCustomer>(Method.Post, "referral_customers", parameters);
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace EasyPost.Services
         public async Task<ReferralCustomer> CreateReferral(BetaFeatures.Parameters.ReferralCustomers.CreateReferralCustomer parameters)
         {
             // Because the normal CreateReferral method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await Request<ReferralCustomer>(Method.Post, "referral_customers", parameters.ToDictionary());
+            return await RequestAsync<ReferralCustomer>(Method.Post, "referral_customers", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace EasyPost.Services
         [CrudOperations.Read]
         public async Task<ReferralCustomerCollection> All(Dictionary<string, object>? parameters = null)
         {
-            ReferralCustomerCollection collection = await Request<ReferralCustomerCollection>(Method.Get, "referral_customers", parameters);
+            ReferralCustomerCollection collection = await RequestAsync<ReferralCustomerCollection>(Method.Get, "referral_customers", parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.ReferralCustomers.All>(parameters);
             return collection;
         }
@@ -136,7 +136,7 @@ namespace EasyPost.Services
         {
             Dictionary<string, object> parameters = new() { { "user", new Dictionary<string, object> { { "email", email } } } };
 
-            await Request(Method.Put, $"referral_customers/{referralId}", parameters);
+            await RequestAsync(Method.Put, $"referral_customers/{referralId}", parameters);
         }
 
         #endregion
@@ -172,7 +172,7 @@ namespace EasyPost.Services
             try
             {
                 // Make request
-                paymentMethod = await Client.Request<PaymentMethod>(Method.Post, "credit_cards", ApiVersion.Current, parameters);
+                paymentMethod = await Client.RequestAsync<PaymentMethod>(Method.Post, "credit_cards", ApiVersion.Current, parameters);
             }
             finally
             {
@@ -250,7 +250,7 @@ namespace EasyPost.Services
         /// <returns>EasyPost Stripe API key.</returns>
         private async Task<string?> RetrieveEasypostStripeApiKey()
         {
-            Dictionary<string, object> response = await Request<Dictionary<string, object>>(Method.Get, "partners/stripe_public_key");
+            Dictionary<string, object> response = await RequestAsync<Dictionary<string, object>>(Method.Get, "partners/stripe_public_key");
 
             response.TryGetValue("public_key", out object? easypostStripePublicKey);
 

--- a/EasyPost/Services/RefundService.cs
+++ b/EasyPost/Services/RefundService.cs
@@ -32,7 +32,7 @@ namespace EasyPost.Services
         public async Task<List<Refund>> Create(Dictionary<string, object> parameters)
         {
             parameters = parameters.Wrap("refund");
-            return await Request<List<Refund>>(Method.Post, "refunds", parameters);
+            return await RequestAsync<List<Refund>>(Method.Post, "refunds", parameters);
         }
 
         /// <summary>
@@ -44,7 +44,7 @@ namespace EasyPost.Services
         public async Task<List<Refund>> Create(BetaFeatures.Parameters.Refunds.Create parameters)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await Request<List<Refund>>(Method.Post, "refunds", parameters.ToDictionary());
+            return await RequestAsync<List<Refund>>(Method.Post, "refunds", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace EasyPost.Services
         [CrudOperations.Read]
         public async Task<RefundCollection> All(Dictionary<string, object>? parameters = null)
         {
-            RefundCollection collection = await Request<RefundCollection>(Method.Get, "refunds", parameters);
+            RefundCollection collection = await RequestAsync<RefundCollection>(Method.Get, "refunds", parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.Refunds.All>(parameters);
             return collection;
         }
@@ -87,7 +87,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a Refund. Starts with "rfnd_".</param>
         /// <returns>EasyPost.Refund instance.</returns>
         [CrudOperations.Read]
-        public async Task<Refund> Retrieve(string id) => await Request<Refund>(Method.Get, $"refunds/{id}");
+        public async Task<Refund> Retrieve(string id) => await RequestAsync<Refund>(Method.Get, $"refunds/{id}");
 
         #endregion
     }

--- a/EasyPost/Services/ReportService.cs
+++ b/EasyPost/Services/ReportService.cs
@@ -37,10 +37,10 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>EasyPost.Report instance.</returns>
         [CrudOperations.Create]
-        public async Task<Report> Create(string type, Dictionary<string, object>? parameters = null) => await Request<Report>(Method.Post, $"reports/{type}", parameters);
+        public async Task<Report> Create(string type, Dictionary<string, object>? parameters = null) => await RequestAsync<Report>(Method.Post, $"reports/{type}", parameters);
 
         [CrudOperations.Create]
-        public async Task<Report> Create(string type, BetaFeatures.Parameters.Reports.Create parameters) => await Request<Report>(Method.Post, $"reports/{type}", parameters.ToDictionary());
+        public async Task<Report> Create(string type, BetaFeatures.Parameters.Reports.Create parameters) => await RequestAsync<Report>(Method.Post, $"reports/{type}", parameters.ToDictionary());
 
         /// <summary>
         ///     Get a paginated list of reports.
@@ -60,7 +60,7 @@ namespace EasyPost.Services
         [CrudOperations.Read]
         public async Task<ReportCollection> All(string type, Dictionary<string, object>? parameters = null)
         {
-            ReportCollection collection = await Request<ReportCollection>(Method.Get, $"reports/{type}", parameters);
+            ReportCollection collection = await RequestAsync<ReportCollection>(Method.Get, $"reports/{type}", parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.Reports.All>(parameters);
             ((BetaFeatures.Parameters.Reports.All)collection.Filters).ReportType = type;
             return collection;
@@ -86,7 +86,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a report.</param>
         /// <returns>EasyPost.Report instance.</returns>
         [CrudOperations.Read]
-        public async Task<Report> Retrieve(string id) => await Request<Report>(Method.Get, $"reports/{id}");
+        public async Task<Report> Retrieve(string id) => await RequestAsync<Report>(Method.Get, $"reports/{id}");
 
         /// <summary>
         ///     Retrieve a Report from its id and type.
@@ -95,7 +95,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a report.</param>
         /// <returns>EasyPost.Report instance.</returns>
         [CrudOperations.Read]
-        public async Task<Report> Retrieve(string type, string id) => await Request<Report>(Method.Get, $"reports/{type}/{id}");
+        public async Task<Report> Retrieve(string type, string id) => await RequestAsync<Report>(Method.Get, $"reports/{type}/{id}");
 
         #endregion
     }

--- a/EasyPost/Services/ScanFormService.cs
+++ b/EasyPost/Services/ScanFormService.cs
@@ -28,7 +28,7 @@ namespace EasyPost.Services
         public async Task<ScanForm> Create(List<Shipment> shipments)
         {
             Dictionary<string, object> parameters = new() { { "shipments", shipments } };
-            return await Request<ScanForm>(Method.Post, "scan_forms", parameters);
+            return await RequestAsync<ScanForm>(Method.Post, "scan_forms", parameters);
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace EasyPost.Services
         public async Task<ScanForm> Create(BetaFeatures.Parameters.ScanForms.Create parameters)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await Request<ScanForm>(Method.Post, "scan_forms", parameters.ToDictionary());
+            return await RequestAsync<ScanForm>(Method.Post, "scan_forms", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace EasyPost.Services
         [CrudOperations.Read]
         public async Task<ScanFormCollection> All(Dictionary<string, object>? parameters = null)
         {
-            ScanFormCollection collection = await Request<ScanFormCollection>(Method.Get, "scan_forms", parameters);
+            ScanFormCollection collection = await RequestAsync<ScanFormCollection>(Method.Get, "scan_forms", parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.ScanForms.All>(parameters);
             return collection;
         }
@@ -90,7 +90,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a scan form, starts with "sf_".</param>
         /// <returns>EasyPost.ScanForm instance.</returns>
         [CrudOperations.Read]
-        public async Task<ScanForm> Retrieve(string id) => await Request<ScanForm>(Method.Get, $"scan_forms/{id}");
+        public async Task<ScanForm> Retrieve(string id) => await RequestAsync<ScanForm>(Method.Get, $"scan_forms/{id}");
 
         #endregion
     }

--- a/EasyPost/Services/ShipmentService.cs
+++ b/EasyPost/Services/ShipmentService.cs
@@ -47,7 +47,7 @@ namespace EasyPost.Services
         {
             parameters = parameters.Wrap("shipment");
             parameters.Add("carbon_offset", withCarbonOffset);
-            return await Request<Shipment>(Method.Post, "shipments", parameters);
+            return await RequestAsync<Shipment>(Method.Post, "shipments", parameters);
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace EasyPost.Services
         public async Task<Shipment> Create(BetaFeatures.Parameters.Shipments.Create parameters)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await Request<Shipment>(Method.Post, "shipments", parameters.ToDictionary());
+            return await RequestAsync<Shipment>(Method.Post, "shipments", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace EasyPost.Services
         [CrudOperations.Read]
         public async Task<ShipmentCollection> All(Dictionary<string, object>? parameters = null)
         {
-            ShipmentCollection collection = await Request<ShipmentCollection>(Method.Get, "shipments", parameters);
+            ShipmentCollection collection = await RequestAsync<ShipmentCollection>(Method.Get, "shipments", parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.Shipments.All>(parameters);
             return collection;
         }
@@ -110,7 +110,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a Shipment. Starts with "shp_".</param>
         /// <returns>An EasyPost.Shipment instance.</returns>
         [CrudOperations.Read]
-        public async Task<Shipment> Retrieve(string id) => await Request<Shipment>(Method.Get, $"shipments/{id}");
+        public async Task<Shipment> Retrieve(string id) => await RequestAsync<Shipment>(Method.Get, $"shipments/{id}");
 
         /// <summary>
         ///     Get the SmartRates for this shipment.
@@ -119,7 +119,7 @@ namespace EasyPost.Services
         [CrudOperations.Read]
         public async Task<List<SmartRate>> GetSmartRates(string id)
         {
-            return await Request<List<SmartRate>>(Method.Get, $"shipments/{id}/smartrate", null, "result");
+            return await RequestAsync<List<SmartRate>>(Method.Get, $"shipments/{id}/smartrate", null, "result");
         }
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace EasyPost.Services
             {
                 { "planned_ship_date", plannedShipDate },
             };
-            return await Request<List<RateWithEstimatedDeliveryDate>>(Method.Get, $"shipments/{id}/smartrate/delivery_date", parameters, "rates");
+            return await RequestAsync<List<RateWithEstimatedDeliveryDate>>(Method.Get, $"shipments/{id}/smartrate/delivery_date", parameters, "rates");
         }
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace EasyPost.Services
         [CrudOperations.Read]
         public async Task<List<RateWithEstimatedDeliveryDate>> RetrieveEstimatedDeliveryDate(string id, BetaFeatures.Parameters.Shipments.RetrieveEstimatedDeliveryDate parameters)
         {
-            return await Request<List<RateWithEstimatedDeliveryDate>>(Method.Get, $"shipments/{id}/smartrate/delivery_date", parameters.ToDictionary(), "rates");
+            return await RequestAsync<List<RateWithEstimatedDeliveryDate>>(Method.Get, $"shipments/{id}/smartrate/delivery_date", parameters.ToDictionary(), "rates");
         }
 
         /// <summary>
@@ -178,7 +178,7 @@ namespace EasyPost.Services
                 parameters.Add("end_shipper", endShipperId);
             }
 
-            return await Request<Shipment>(Method.Post, $"shipments/{id}/buy", parameters);
+            return await RequestAsync<Shipment>(Method.Post, $"shipments/{id}/buy", parameters);
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Shipment> Buy(string id, BetaFeatures.Parameters.Shipments.Buy parameters)
         {
-            return await Request<Shipment>(Method.Post, $"shipments/{id}/buy", parameters.ToDictionary());
+            return await RequestAsync<Shipment>(Method.Post, $"shipments/{id}/buy", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -221,7 +221,7 @@ namespace EasyPost.Services
         {
             Dictionary<string, object> parameters = new() { { "file_format", fileFormat } };
 
-            return await Request<Shipment>(Method.Get, $"shipments/{id}/label", parameters);
+            return await RequestAsync<Shipment>(Method.Get, $"shipments/{id}/label", parameters);
         }
 
         /// <summary>
@@ -232,7 +232,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Shipment> GenerateLabel(string id, BetaFeatures.Parameters.Shipments.GenerateLabel parameters)
         {
-            return await Request<Shipment>(Method.Get, $"shipments/{id}/label", parameters.ToDictionary());
+            return await RequestAsync<Shipment>(Method.Get, $"shipments/{id}/label", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -245,7 +245,7 @@ namespace EasyPost.Services
         {
             Dictionary<string, object> parameters = new() { { "amount", amount } };
 
-            return await Request<Shipment>(Method.Post, $"shipments/{id}/insure", parameters);
+            return await RequestAsync<Shipment>(Method.Post, $"shipments/{id}/insure", parameters);
         }
 
         /// <summary>
@@ -256,7 +256,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Shipment> Insure(string id, BetaFeatures.Parameters.Shipments.Insure parameters)
         {
-            return await Request<Shipment>(Method.Post, $"shipments/{id}/insure", parameters.ToDictionary());
+            return await RequestAsync<Shipment>(Method.Post, $"shipments/{id}/insure", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -266,7 +266,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Shipment> Refund(string id)
         {
-            return await Request<Shipment>(Method.Post, $"shipments/{id}/refund");
+            return await RequestAsync<Shipment>(Method.Post, $"shipments/{id}/refund");
         }
 
         /// <summary>
@@ -282,7 +282,7 @@ namespace EasyPost.Services
 
             parameters.Add("carbon_offset", withCarbonOffset);
 
-            return await Request<Shipment>(Method.Post, $"shipments/{id}/rerate", parameters);
+            return await RequestAsync<Shipment>(Method.Post, $"shipments/{id}/rerate", parameters);
         }
 
         /// <summary>
@@ -293,7 +293,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Shipment> RegenerateRates(string id, BetaFeatures.Parameters.Shipments.RegenerateRates parameters)
         {
-            return await Request<Shipment>(Method.Post, $"shipments/{id}/rerate", parameters.ToDictionary());
+            return await RequestAsync<Shipment>(Method.Post, $"shipments/{id}/rerate", parameters.ToDictionary());
         }
 
         #endregion

--- a/EasyPost/Services/TrackerService.cs
+++ b/EasyPost/Services/TrackerService.cs
@@ -36,7 +36,7 @@ namespace EasyPost.Services
                 { "tracking_code", trackingCode },
             };
             parameters = parameters.Wrap("tracker");
-            return await Request<Tracker>(Method.Post, "trackers", parameters);
+            return await RequestAsync<Tracker>(Method.Post, "trackers", parameters);
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace EasyPost.Services
         public async Task<Tracker> Create(BetaFeatures.Parameters.Trackers.Create parameters)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await Request<Tracker>(Method.Post, "trackers", parameters.ToDictionary());
+            return await RequestAsync<Tracker>(Method.Post, "trackers", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace EasyPost.Services
         {
             parameters = parameters.Wrap("trackers");
             // This endpoint does not return a response, so we simply send the request and only throw an exception if the API returns an error.
-            await Request(Method.Post, "trackers/create_list", parameters);
+            await RequestAsync(Method.Post, "trackers/create_list", parameters);
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace EasyPost.Services
         [Obsolete("This method is deprecated. Please use TrackerService.Create() instead. This method will be removed in a future version.", false)]
         public async Task CreateList(BetaFeatures.Parameters.Trackers.CreateList parameters)
         {
-            await Request(Method.Post, "trackers/create_list", parameters.ToDictionary());
+            await RequestAsync(Method.Post, "trackers/create_list", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace EasyPost.Services
         public async Task<TrackerCollection> All(Dictionary<string, object>? parameters = null)
         {
             // TODO: When we adopt parameter objects as the only way to pass parameters, we don't need to do this object -> dictionary -> object conversion to store the filters.
-            TrackerCollection collection = await Request<TrackerCollection>(Method.Get, "trackers", parameters);
+            TrackerCollection collection = await RequestAsync<TrackerCollection>(Method.Get, "trackers", parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.Trackers.All>(parameters);
             return collection;
         }
@@ -128,7 +128,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a Tracker. Starts with "trk_".</param>
         /// <returns>EasyPost.Tracker instance.</returns>
         [CrudOperations.Read]
-        public async Task<Tracker> Retrieve(string id) => await Request<Tracker>(Method.Get, $"trackers/{id}");
+        public async Task<Tracker> Retrieve(string id) => await RequestAsync<Tracker>(Method.Get, $"trackers/{id}");
 
         #endregion
     }

--- a/EasyPost/Services/UserService.cs
+++ b/EasyPost/Services/UserService.cs
@@ -31,7 +31,7 @@ namespace EasyPost.Services
         public async Task<User> CreateChild(Dictionary<string, object> parameters)
         {
             parameters = parameters.Wrap("user");
-            return await Request<User>(Method.Post, "users", parameters);
+            return await RequestAsync<User>(Method.Post, "users", parameters);
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace EasyPost.Services
         public async Task<User> CreateChild(BetaFeatures.Parameters.Users.CreateChild parameters)
         {
             // Because the normal CreateChild method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await Request<User>(Method.Post, "users", parameters.ToDictionary());
+            return await RequestAsync<User>(Method.Post, "users", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a user. Starts with "user_".</param>
         /// <returns>EasyPost.User instance.</returns>
         [CrudOperations.Read]
-        public async Task<User> Retrieve(string? id = null) => id == null ? await Request<User>(Method.Get, "users") : await Request<User>(Method.Get, $"users/{id}");
+        public async Task<User> Retrieve(string? id = null) => id == null ? await RequestAsync<User>(Method.Get, "users") : await RequestAsync<User>(Method.Get, $"users/{id}");
 
         /// <summary>
         ///     Retrieve the current user.
@@ -80,7 +80,7 @@ namespace EasyPost.Services
         public async Task<Brand> UpdateBrand(string? id, Dictionary<string, object> parameters)
         {
             parameters = parameters.Wrap("brand");
-            return await Request<Brand>(Method.Put, $"users/{id}/brand", parameters);
+            return await RequestAsync<Brand>(Method.Put, $"users/{id}/brand", parameters);
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace EasyPost.Services
         [CrudOperations.Create]
         public async Task<Brand> UpdateBrand(string? id, BetaFeatures.Parameters.Users.UpdateBrand parameters)
         {
-            return await Request<Brand>(Method.Put, $"users/{id}/brand", parameters.ToDictionary());
+            return await RequestAsync<Brand>(Method.Put, $"users/{id}/brand", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<User> Update(string? id, Dictionary<string, object> parameters)
         {
-            return await Request<User>(Method.Put, $"users/{id}", parameters);
+            return await RequestAsync<User>(Method.Put, $"users/{id}", parameters);
         }
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<User> Update(string? id, BetaFeatures.Parameters.Users.Update parameters)
         {
-            return await Request<User>(Method.Put, $"users/{id}", parameters.ToDictionary());
+            return await RequestAsync<User>(Method.Put, $"users/{id}", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace EasyPost.Services
         /// </summary>
         /// <returns>Whether the request was successful or not.</returns>
         [CrudOperations.Delete]
-        public async Task Delete(string? id) => await Request(Method.Delete, $"users/{id}");
+        public async Task Delete(string? id) => await RequestAsync(Method.Delete, $"users/{id}");
 
         #endregion
     }

--- a/EasyPost/Services/WebhookService.cs
+++ b/EasyPost/Services/WebhookService.cs
@@ -35,7 +35,7 @@ namespace EasyPost.Services
         public async Task<Webhook> Create(Dictionary<string, object> parameters)
         {
             parameters = parameters.Wrap("webhook");
-            return await Request<Webhook>(Method.Post, "webhooks", parameters);
+            return await RequestAsync<Webhook>(Method.Post, "webhooks", parameters);
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace EasyPost.Services
         public async Task<Webhook> Create(BetaFeatures.Parameters.Webhooks.Create parameters)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await Request<Webhook>(Method.Post, "webhooks", parameters.ToDictionary());
+            return await RequestAsync<Webhook>(Method.Post, "webhooks", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace EasyPost.Services
         /// <param name="parameters">A optional dictionary of parameters to include in the API request.</param>
         /// <returns>List of EasyPost.Webhook instances.</returns>
         [CrudOperations.Read]
-        public async Task<List<Webhook>> All(Dictionary<string, object>? parameters = null) => await Request<List<Webhook>>(Method.Get, "webhooks", parameters, "webhooks");
+        public async Task<List<Webhook>> All(Dictionary<string, object>? parameters = null) => await RequestAsync<List<Webhook>>(Method.Get, "webhooks", parameters, "webhooks");
 
         /// <summary>
         ///     List all <see cref="Webhook"/> objects.
@@ -64,7 +64,7 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Webhooks.All"/> parameter set.</param>
         /// <returns>List of <see cref="Webhook"/> instances.</returns>
         [CrudOperations.Read]
-        public async Task<List<Webhook>> All(BetaFeatures.Parameters.Webhooks.All parameters) => await Request<List<Webhook>>(Method.Get, "webhooks", parameters.ToDictionary(), "webhooks");
+        public async Task<List<Webhook>> All(BetaFeatures.Parameters.Webhooks.All parameters) => await RequestAsync<List<Webhook>>(Method.Get, "webhooks", parameters.ToDictionary(), "webhooks");
 
         /// <summary>
         ///     Retrieve a Webhook from its id.
@@ -72,7 +72,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a webhook. Starts with "hook_".</param>
         /// <returns>EasyPost.User instance.</returns>
         [CrudOperations.Read]
-        public async Task<Webhook> Retrieve(string id) => await Request<Webhook>(Method.Get, $"webhooks/{id}");
+        public async Task<Webhook> Retrieve(string id) => await RequestAsync<Webhook>(Method.Get, $"webhooks/{id}");
 
         /// <summary>
         ///     Update a Webhook. A disabled webhook will be enabled.
@@ -87,7 +87,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Webhook> Update(string id, Dictionary<string, object>? parameters = null)
         {
-            return await Request<Webhook>(Method.Put, $"webhooks/{id}", parameters);
+            return await RequestAsync<Webhook>(Method.Put, $"webhooks/{id}", parameters);
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Webhook> Update(string id, BetaFeatures.Parameters.Webhooks.Update parameters)
         {
-            return await Request<Webhook>(Method.Put, $"webhooks/{id}", parameters.ToDictionary());
+            return await RequestAsync<Webhook>(Method.Put, $"webhooks/{id}", parameters.ToDictionary());
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace EasyPost.Services
         /// </summary>
         /// <returns>Whether the request was successful or not.</returns>
         [CrudOperations.Delete]
-        public async Task Delete(string id) => await Request(Method.Delete, $"webhooks/{id}");
+        public async Task Delete(string id) => await RequestAsync(Method.Delete, $"webhooks/{id}");
 
         /// <summary>
         ///     Validate a received webhook's HMAC signature.

--- a/EasyPost/_base/EasyPostClient.cs
+++ b/EasyPost/_base/EasyPostClient.cs
@@ -71,7 +71,7 @@ namespace EasyPost._base
             // try to execute the request, catch and rethrow an HTTP timeout exception, all other exceptions are thrown as-is
             try
             {
-                return await HttpClient.SendAsync(request);
+                return await HttpClient.SendAsync(request).ConfigureAwait(false);
             }
             catch (TaskCanceledException)
             {
@@ -89,7 +89,7 @@ namespace EasyPost._base
         /// <param name="rootElement">Optional root element for the JSON to begin deserialization at.</param>
         /// <typeparam name="T">Type of object to deserialize response data into. Must be subclass of EasyPostObject.</typeparam>
         /// <returns>An instance of a T type object.</returns>
-        internal async Task<T> Request<T>(Method method, string endpoint, ApiVersion apiVersion, Dictionary<string, object>? parameters = null, string? rootElement = null)
+        internal async Task<T> RequestAsync<T>(Method method, string endpoint, ApiVersion apiVersion, Dictionary<string, object>? parameters = null, string? rootElement = null)
             where T : class
         {
             // Build the request
@@ -139,7 +139,7 @@ namespace EasyPost._base
         /// <param name="parameters">Optional parameters to use for the request.</param>
         /// <returns>Whether request was successful.</returns>
         // ReSharper disable once UnusedMethodReturnValue.Global
-        internal async Task<bool> Request(Method method, string endpoint, ApiVersion apiVersion, Dictionary<string, object>? parameters = null)
+        internal async Task<bool> RequestAsync(Method method, string endpoint, ApiVersion apiVersion, Dictionary<string, object>? parameters = null)
         {
             // Build the request
             Dictionary<string, string> headers = _configuration.GetHeaders(apiVersion);

--- a/EasyPost/_base/EasyPostService.cs
+++ b/EasyPost/_base/EasyPostService.cs
@@ -27,9 +27,9 @@ namespace EasyPost._base
         /// <param name="overrideApiVersion">Override API version hit for HTTP request. Defaults to general availability.</param>
         /// <typeparam name="T">Type of object to return from request.</typeparam>
         /// <returns>A T-type object.</returns>
-        protected async Task<T> Request<T>(Http.Method method, string endpoint, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null)
+        protected async Task<T> RequestAsync<T>(Http.Method method, string endpoint, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null)
             where T : class
-            => await Client.Request<T>(method, endpoint, overrideApiVersion ?? ApiVersion.Current, parameters, rootElement);
+            => await Client.RequestAsync<T>(method, endpoint, overrideApiVersion ?? ApiVersion.Current, parameters, rootElement).ConfigureAwait(false);
 
         /// <summary>
         ///     Make an HTTP request to the EasyPost API.
@@ -40,7 +40,7 @@ namespace EasyPost._base
         /// <param name="overrideApiVersion">Override API version hit for HTTP request. Defaults to general availability.</param>
         /// <returns>None.</returns>
         // ReSharper disable once MemberCanBePrivate.Global
-        protected async Task Request(Http.Method method, string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Client.Request(method, url, overrideApiVersion ?? ApiVersion.Current, parameters);
+        protected async Task RequestAsync(Http.Method method, string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Client.RequestAsync(method, url, overrideApiVersion ?? ApiVersion.Current, parameters).ConfigureAwait(false);
 
         private bool _isDisposed;
 


### PR DESCRIPTION
# Description

- Rename Request functions to RequestAsync to fit best practice for async function naming:
  - [Debated](https://github.com/dotnet/roslyn/issues/47592), but the [current convention](https://learn.microsoft.com/en-us/dotnet/csharp/asynchronous-programming/task-asynchronous-programming-model#:~:text=The%20name%20of%20an%20async%20method%2C%20by%20convention%2C%20ends%20with%20an%20%22Async%22%20suffix.). Not user-facing or high-level, likely has no impact on actual code functionality.
  - Stripe does it: https://github.com/stripe/stripe-dotnet/blob/master/src/Stripe.net/Infrastructure/Public/StripeClient.cs#L105
- Add `ConfigureAwait(false)` to the functionality that executes the HTTP request, since this async function doesn't need to return to the same thread that spawned it once complete. This will avoid potential deadlocks if a user is calling a function from a UI thread (our library does not need to run on the UI thread as it does not interact with UI elements).
  - Suggested reading: 
    - https://medium.com/bynder-tech/c-why-you-should-use-configureawait-false-in-your-library-code-d7837dce3d7f
    - https://devblogs.microsoft.com/dotnet/configureawait-faq/
  - Stripe does it: https://github.com/stripe/stripe-dotnet/pull/1658

# Testing

- No change to unit tests or cassettes needed

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
