### PR TITLE
[chore] Cancellation token best practice, parameter cleanup

### DIFF
--- a/EasyPost.Tests/BetaFeaturesTests/ServicesTests/ReportServiceTest.cs
+++ b/EasyPost.Tests/BetaFeaturesTests/ServicesTests/ReportServiceTest.cs
@@ -110,7 +110,7 @@ namespace EasyPost.Tests.BetaFeaturesTests.ServicesTests
         {
             UseVCR("all");
 
-            Dictionary<string, object> data = new Dictionary<string, object>() { { "page_size", Fixtures.PageSize}, { "type", "shipment" } };
+            Dictionary<string, object> data = new Dictionary<string, object>() { { "page_size", Fixtures.PageSize }, { "type", "shipment" } };
 
             BetaFeatures.Parameters.Reports.All parameters = Fixtures.Parameters.Reports.All(data);
 
@@ -152,11 +152,11 @@ namespace EasyPost.Tests.BetaFeaturesTests.ServicesTests
         public async Task TestMissingTypeWhenCallingAll()
         {
             UseVCR("missing_type_when_calling_all");
-            
+
             Dictionary<string, object> data = new Dictionary<string, object>() { { "page_size", Fixtures.PageSize } }; // missing type
-            
+
             BetaFeatures.Parameters.Reports.All parameters = Fixtures.Parameters.Reports.All(data);
-            
+
             await Assert.ThrowsAsync<MissingParameterError>(() => Client.Report.All(parameters));
         }
 

--- a/EasyPost.Tests/Fixture.cs
+++ b/EasyPost.Tests/Fixture.cs
@@ -550,6 +550,7 @@ namespace EasyPost.Tests._Utilities
                         StartDate = fixture.GetOrNull<string>("start_date"),
                         IncludeChildren = fixture.GetOrNullBoolean("include_children"),
                         SendEmail = fixture.GetOrNullBoolean("send_email"),
+                        Type = fixture.GetOrNull<string>("type"),
                     };
                 }
 
@@ -564,6 +565,7 @@ namespace EasyPost.Tests._Utilities
                         AfterId = fixture.GetOrNull<string>("after_id"),
                         StartDatetime = fixture.GetOrNull<string>("start_datetime"),
                         EndDatetime = fixture.GetOrNull<string>("end_datetime"),
+                        Type = fixture.GetOrNull<string>("type"),
                     };
                 }
             }

--- a/EasyPost.Tests/ServicesTests/BatchServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/BatchServiceTest.cs
@@ -197,7 +197,7 @@ namespace EasyPost.Tests.ServicesTests
                 Thread.Sleep(10000); // Wait enough time to process
             }
 
-            batch = await Client.Batch.GenerateScanForm(batch.Id);
+            batch = await Client.Batch.GenerateScanForm(batch.Id, "pdf");
 
             // We can't assert anything meaningful here because the scanform gets queued for generation and may not be immediately available
             Assert.IsType<Batch>(batch);

--- a/EasyPost.Tests/ServicesTests/ReportServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/ReportServiceTest.cs
@@ -124,7 +124,7 @@ namespace EasyPost.Tests.ServicesTests
 
             ReportCollection reportCollection = await Client.Report.All(type, filters);
 
-            Assert.Equal(type, ((BetaFeatures.Parameters.Reports.All)reportCollection.Filters!).ReportType);
+            Assert.Equal(type, ((BetaFeatures.Parameters.Reports.All)reportCollection.Filters!).Type);
         }
 
         [Fact]

--- a/EasyPost.Tests/TestUtils.cs
+++ b/EasyPost.Tests/TestUtils.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.Http;
@@ -220,7 +221,7 @@ namespace EasyPost.Tests._Utilities
             private readonly List<MockRequest> _mockRequests = new();
 
 #pragma warning disable CS1998
-            internal override async Task<HttpResponseMessage> ExecuteRequest(HttpRequestMessage request)
+            internal override async Task<HttpResponseMessage> ExecuteRequest(HttpRequestMessage request, CancellationToken cancellationToken)
 #pragma warning restore CS1998
             {
                 MockRequest? mockRequest = FindMatchingMockRequest(request);

--- a/EasyPost/BetaFeatures/Parameters/Reports/All.cs
+++ b/EasyPost/BetaFeatures/Parameters/Reports/All.cs
@@ -14,6 +14,12 @@ namespace EasyPost.BetaFeatures.Parameters.Reports
         #region Request Parameters
 
         /// <summary>
+        ///     What type of report to return. Required.
+        /// </summary>
+        // This parameter is not included in the request body, but is used to determine the endpoint to call.
+        public string? Type { get; set; }
+
+        /// <summary>
         ///     Only records created after the given ID will be included. May not be used with <see cref="BeforeId"/>.
         /// </summary>
         [TopLevelRequestParameter(Necessity.Optional, "after_id")]
@@ -43,12 +49,6 @@ namespace EasyPost.BetaFeatures.Parameters.Reports
         [TopLevelRequestParameter(Necessity.Optional, "start_datetime")]
         public string? StartDatetime { get; set; }
 
-        /// <summary>
-        ///     The type of reports to retrieve.
-        /// </summary>
-        // This is not set by the end-user, but stored for reference when getting the next page of results.
-        internal string? ReportType { get; set; }
-
         #endregion
 
         protected override TParameters FromDictionaryProtected<TParameters>(Dictionary<string, object> dictionary)
@@ -60,6 +60,7 @@ namespace EasyPost.BetaFeatures.Parameters.Reports
                 AfterId = dictionary.GetOrNull<string>("after_id"),
                 StartDatetime = dictionary.GetOrNull<string>("start_datetime"),
                 EndDatetime = dictionary.GetOrNull<string>("end_datetime"),
+                Type = dictionary.GetOrNull<string>("type"),
             };
 
             return (parameters as TParameters)!;

--- a/EasyPost/BetaFeatures/Parameters/Reports/Create.cs
+++ b/EasyPost/BetaFeatures/Parameters/Reports/Create.cs
@@ -12,6 +12,12 @@ namespace EasyPost.BetaFeatures.Parameters.Reports
     {
         #region Request Parameters
 
+        /// <summary>
+        ///     What type of report to create. Required.
+        /// </summary>
+        // This parameter is not included in the request body, but is used to determine the endpoint to call.
+        public string? Type { get; set; }
+
         [TopLevelRequestParameter(Necessity.Optional, "report", "additional_columns")]
         public List<string>? AdditionalColumns { get; set; }
 

--- a/EasyPost/Services/AddressService.cs
+++ b/EasyPost/Services/AddressService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.BetaFeatures.Parameters;
@@ -41,7 +42,7 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>EasyPost.Address instance.</returns>
         [CrudOperations.Create]
-        public async Task<Address> Create(Dictionary<string, object> parameters)
+        public async Task<Address> Create(Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
             // Check verify and verify_strict presence in parameters
             bool verify = parameters.ContainsKey("verify");
@@ -64,7 +65,7 @@ namespace EasyPost.Services
                 parameters.Add("verify_strict", true);
             }
 
-            return await RequestAsync<Address>(Method.Post, "addresses", parameters);
+            return await RequestAsync<Address>(Method.Post, "addresses", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -73,10 +74,10 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Addresses.Create"/> parameter set.</param>
         /// <returns><see cref="Address"/> instance.</returns>
         [CrudOperations.Create]
-        public async Task<Address> Create(BetaFeatures.Parameters.Addresses.Create parameters)
+        public async Task<Address> Create(BetaFeatures.Parameters.Addresses.Create parameters, CancellationToken cancellationToken = default)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await RequestAsync<Address>(Method.Post, "addresses", parameters.ToDictionary());
+            return await RequestAsync<Address>(Method.Post, "addresses", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -98,7 +99,7 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>An Address object.</returns>
         [CrudOperations.Create]
-        public async Task<Address> CreateAndVerify(Dictionary<string, object> parameters) => await RequestAsync<Address>(Method.Post, "addresses/create_and_verify", parameters, "address");
+        public async Task<Address> CreateAndVerify(Dictionary<string, object> parameters, CancellationToken cancellationToken = default) => await RequestAsync<Address>(Method.Post, "addresses/create_and_verify", cancellationToken, parameters, "address");
 
         /// <summary>
         ///     Create and verify an <see cref="Address"/>.
@@ -106,10 +107,10 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Addresses.Create"/> parameter set.</param>
         /// <returns><see cref="Address"/> instance.</returns>
         [CrudOperations.Create]
-        public async Task<Address> CreateAndVerify(BetaFeatures.Parameters.Addresses.Create parameters)
+        public async Task<Address> CreateAndVerify(BetaFeatures.Parameters.Addresses.Create parameters, CancellationToken cancellationToken = default)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await RequestAsync<Address>(Method.Post, "addresses/create_and_verify", parameters.ToDictionary(), "address");
+            return await RequestAsync<Address>(Method.Post, "addresses/create_and_verify", cancellationToken, parameters.ToDictionary(), "address");
         }
 
         /// <summary>
@@ -128,9 +129,9 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>An EasyPost.AddressCollection instance.</returns>
         [CrudOperations.Read]
-        public async Task<AddressCollection> All(Dictionary<string, object>? parameters = null)
+        public async Task<AddressCollection> All(Dictionary<string, object>? parameters = null, CancellationToken cancellationToken = default)
         {
-            AddressCollection collection = await RequestAsync<AddressCollection>(Method.Get, "addresses", parameters);
+            AddressCollection collection = await RequestAsync<AddressCollection>(Method.Get, "addresses", cancellationToken, parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.Addresses.All>(parameters);
             return collection;
         }
@@ -141,7 +142,12 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Addresses.All"/> parameter set.</param>
         /// <returns><see cref="AddressCollection"/> instance.</returns>
         [CrudOperations.Read]
-        public async Task<AddressCollection> All(BetaFeatures.Parameters.Addresses.All parameters) => await All(parameters.ToDictionary());
+        public async Task<AddressCollection> All(BetaFeatures.Parameters.Addresses.All parameters, CancellationToken cancellationToken = default)
+        {
+            AddressCollection collection = await RequestAsync<AddressCollection>(Method.Get, "addresses", cancellationToken, parameters.ToDictionary());
+            collection.Filters = parameters;
+            return collection;
+        }
 
         /// <summary>
         ///     Get the next page of a paginated <see cref="AddressCollection"/>.
@@ -151,7 +157,7 @@ namespace EasyPost.Services
         /// <returns>The next page, as a <see cref="AddressCollection"/> instance.</returns>
         /// <exception cref="EndOfPaginationError">Thrown if there is no next page to retrieve.</exception>
         [CrudOperations.Read]
-        public async Task<AddressCollection> GetNextPage(AddressCollection collection, int? pageSize = null) => await collection.GetNextPage<AddressCollection, BetaFeatures.Parameters.Addresses.All>(async parameters => await All(parameters), collection.Addresses, pageSize);
+        public async Task<AddressCollection> GetNextPage(AddressCollection collection, int? pageSize = null, CancellationToken cancellationToken = default) => await collection.GetNextPage<AddressCollection, BetaFeatures.Parameters.Addresses.All>(async parameters => await All(parameters, cancellationToken), collection.Addresses, pageSize);
 
         /// <summary>
         ///     Retrieve an Address from its id.
@@ -159,7 +165,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing an Address. Starts with "adr_".</param>
         /// <returns>EasyPost.Address instance.</returns>
         [CrudOperations.Read]
-        public async Task<Address> Retrieve(string id) => await RequestAsync<Address>(Method.Get, $"addresses/{id}");
+        public async Task<Address> Retrieve(string id, CancellationToken cancellationToken = default) => await RequestAsync<Address>(Method.Get, $"addresses/{id}", cancellationToken);
 
         /// <summary>
         ///     Verify an Address.
@@ -167,9 +173,9 @@ namespace EasyPost.Services
         /// <param name="id">ID of the address to verify.</param>
         /// <returns>EasyPost.Address instance. Check message for verification failures.</returns>
         [CrudOperations.Update]
-        public async Task<Address> Verify(string id)
+        public async Task<Address> Verify(string id, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<Address>(Method.Get, $"addresses/{id}/verify", null, "address");
+            return await RequestAsync<Address>(Method.Get, $"addresses/{id}/verify", cancellationToken, rootElement: "address");
         }
 
         #endregion

--- a/EasyPost/Services/ApiKeyService.cs
+++ b/EasyPost/Services/ApiKeyService.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.Http;
@@ -21,7 +22,7 @@ namespace EasyPost.Services
         /// </summary>
         /// <returns>An EasyPost.ApiKeyCollection instances.</returns>
         [CrudOperations.Read]
-        public async Task<ApiKeyCollection> All() => await RequestAsync<ApiKeyCollection>(Method.Get, "api_keys");
+        public async Task<ApiKeyCollection> All(CancellationToken cancellationToken = default) => await RequestAsync<ApiKeyCollection>(Method.Get, "api_keys", cancellationToken);
 
         #endregion
     }

--- a/EasyPost/Services/BatchService.cs
+++ b/EasyPost/Services/BatchService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.BetaFeatures.Parameters;
@@ -32,10 +33,10 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>EasyPost.Batch instance.</returns>
         [CrudOperations.Create]
-        public async Task<Batch> Create(Dictionary<string, object>? parameters = null)
+        public async Task<Batch> Create(Dictionary<string, object>? parameters = null, CancellationToken cancellationToken = default)
         {
             parameters = parameters?.Wrap("batch");
-            return await RequestAsync<Batch>(Method.Post, "batches", parameters);
+            return await RequestAsync<Batch>(Method.Post, "batches", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -44,10 +45,10 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Batches.Create"/> parameter set.</param>
         /// <returns><see cref="Batch"/> instance.</returns>
         [CrudOperations.Create]
-        public async Task<Batch> Create(BetaFeatures.Parameters.Batches.Create parameters)
+        public async Task<Batch> Create(BetaFeatures.Parameters.Batches.Create parameters, CancellationToken cancellationToken = default)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await RequestAsync<Batch>(Method.Post, "batches", parameters.ToDictionary());
+            return await RequestAsync<Batch>(Method.Post, "batches", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -61,10 +62,10 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>EasyPost.Batch instance.</returns>
         [CrudOperations.Create]
-        public async Task<Batch> CreateAndBuy(Dictionary<string, object> parameters)
+        public async Task<Batch> CreateAndBuy(Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
             parameters = parameters.Wrap("batch");
-            return await RequestAsync<Batch>(Method.Post, "batches/create_and_buy", parameters);
+            return await RequestAsync<Batch>(Method.Post, "batches/create_and_buy", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -73,10 +74,10 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Batches.Create"/> parameter set.</param>
         /// <returns><see cref="Batch"/> instance.</returns>
         [CrudOperations.Create]
-        public async Task<Batch> CreateAndBuy(BetaFeatures.Parameters.Batches.Create parameters)
+        public async Task<Batch> CreateAndBuy(BetaFeatures.Parameters.Batches.Create parameters, CancellationToken cancellationToken = default)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await RequestAsync<Batch>(Method.Post, "batches/create_and_buy", parameters.ToDictionary());
+            return await RequestAsync<Batch>(Method.Post, "batches/create_and_buy", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -95,9 +96,9 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>An EasyPost.BatchCollection instance.</returns>
         [CrudOperations.Read]
-        public async Task<BatchCollection> All(Dictionary<string, object>? parameters = null)
+        public async Task<BatchCollection> All(Dictionary<string, object>? parameters = null, CancellationToken cancellationToken = default)
         {
-            BatchCollection collection = await RequestAsync<BatchCollection>(Method.Get, "batches", parameters);
+            BatchCollection collection = await RequestAsync<BatchCollection>(Method.Get, "batches", cancellationToken, parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.Batches.All>(parameters);
             return collection;
         }
@@ -108,7 +109,12 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Batches.All"/> parameter set.</param>
         /// <returns><see cref="BatchCollection"/> instance.</returns>
         [CrudOperations.Read]
-        public async Task<BatchCollection> All(BetaFeatures.Parameters.Batches.All parameters) => await All(parameters.ToDictionary());
+        public async Task<BatchCollection> All(BetaFeatures.Parameters.Batches.All parameters, CancellationToken cancellationToken = default)
+        {
+            BatchCollection collection = await RequestAsync<BatchCollection>(Method.Get, "batches", cancellationToken, parameters.ToDictionary());
+            collection.Filters = parameters;
+            return collection;
+        }
 
         // TODO: Add GetNextPage function when Batches are sorted newest to oldest.
 
@@ -118,9 +124,9 @@ namespace EasyPost.Services
         /// <param name="parameters">Update shipment parameters.</param>
         /// <returns>The updated Batch.</returns>
         [CrudOperations.Update]
-        public async Task<Batch> AddShipments(string id, Dictionary<string, object> parameters)
+        public async Task<Batch> AddShipments(string id, Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/add_shipments", parameters);
+            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/add_shipments", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -129,7 +135,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a Batch. Starts with "batch_".</param>
         /// <returns>EasyPost.Batch instance.</returns>
         [CrudOperations.Read]
-        public async Task<Batch> Retrieve(string id) => await RequestAsync<Batch>(Method.Get, $"batches/{id}");
+        public async Task<Batch> Retrieve(string id, CancellationToken cancellationToken = default) => await RequestAsync<Batch>(Method.Get, $"batches/{id}", cancellationToken);
 
         /// <summary>
         ///     Add <see cref="Shipment"/>s to this <see cref="Batch"/>.
@@ -137,9 +143,9 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Batches.AddShipments"/> parameter set.</param>
         /// <returns>This updated <see cref="Batch"/> instance.</returns>
         [CrudOperations.Update]
-        public async Task<Batch> AddShipments(string id, BetaFeatures.Parameters.Batches.AddShipments parameters)
+        public async Task<Batch> AddShipments(string id, BetaFeatures.Parameters.Batches.AddShipments parameters, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/add_shipments", parameters.ToDictionary());
+            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/add_shipments", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -148,10 +154,10 @@ namespace EasyPost.Services
         /// <param name="shipmentsToAdd">List of Shipment objects to be added.</param>
         /// <returns>The updated Batch.</returns>
         [CrudOperations.Update]
-        public async Task<Batch> AddShipments(string id, List<Shipment> shipmentsToAdd)
+        public async Task<Batch> AddShipments(string id, List<Shipment> shipmentsToAdd, CancellationToken cancellationToken = default)
         {
             Dictionary<string, object> parameters = new() { { "shipments", shipmentsToAdd } };
-            return await AddShipments(id, parameters);
+            return await AddShipments(id, parameters, cancellationToken);
         }
 
         /// <summary>
@@ -160,10 +166,10 @@ namespace EasyPost.Services
         /// <param name="shipmentIds">List of shipment ids to be added.</param>
         /// <returns>The updated Batch.</returns>
         [CrudOperations.Update]
-        public async Task<Batch> AddShipments(string id, IEnumerable<string> shipmentIds)
+        public async Task<Batch> AddShipments(string id, IEnumerable<string> shipmentIds, CancellationToken cancellationToken = default)
         {
             List<Shipment> shipments = shipmentIds.Select(shipmentId => new Shipment { Id = shipmentId }).ToList();
-            return await AddShipments(id, shipments);
+            return await AddShipments(id, shipments, cancellationToken);
         }
 
         /// <summary>
@@ -171,9 +177,9 @@ namespace EasyPost.Services
         /// </summary>
         /// <returns>The updated Batch.</returns>
         [CrudOperations.Update]
-        public async Task<Batch> Buy(string id)
+        public async Task<Batch> Buy(string id, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/buy");
+            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/buy", cancellationToken);
         }
 
         /// <summary>
@@ -182,10 +188,10 @@ namespace EasyPost.Services
         /// <param name="fileFormat">Format to generate the label in. Valid formats: "pdf", "zpl" and "epl2".</param>
         /// <returns>The updated Batch.</returns>
         [CrudOperations.Update]
-        public async Task<Batch> GenerateLabel(string id, string fileFormat = "pdf") // TODO: Remove default value (breaking change)
+        public async Task<Batch> GenerateLabel(string id, string fileFormat, CancellationToken cancellationToken = default)
         {
             Dictionary<string, object> parameters = new() { { "file_format", fileFormat } };
-            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/label", parameters);
+            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/label", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -194,9 +200,9 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Batches.GenerateLabel"/> parameter set.</param>
         /// <returns>This updated <see cref="Batch"/> instance.</returns>
         [CrudOperations.Update]
-        public async Task<Batch> GenerateLabel(string id, BetaFeatures.Parameters.Batches.GenerateLabel parameters)
+        public async Task<Batch> GenerateLabel(string id, BetaFeatures.Parameters.Batches.GenerateLabel parameters, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/label", parameters.ToDictionary());
+            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/label", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -205,10 +211,10 @@ namespace EasyPost.Services
         /// <param name="fileFormat">Format to generate the label in. Valid formats: "pdf", "zpl" and "epl2".</param>
         /// <returns>The updated Batch.</returns>
         [CrudOperations.Update]
-        public async Task<Batch> GenerateScanForm(string id, string fileFormat = "pdf") // TODO: Remove default value (breaking change)
+        public async Task<Batch> GenerateScanForm(string id, string fileFormat, CancellationToken cancellationToken = default)
         {
             Dictionary<string, object> parameters = new() { { "file_format", fileFormat } };
-            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/scan_form", parameters);
+            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/scan_form", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -217,9 +223,9 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Batches.GenerateScanForm"/> parameter set.</param>
         /// <returns>This updated <see cref="Batch"/> instance.</returns>
         [CrudOperations.Update]
-        public async Task<Batch> GenerateScanForm(string id, BetaFeatures.Parameters.Batches.GenerateScanForm parameters)
+        public async Task<Batch> GenerateScanForm(string id, BetaFeatures.Parameters.Batches.GenerateScanForm parameters, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/scan_form", parameters.ToDictionary());
+            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/scan_form", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -228,9 +234,9 @@ namespace EasyPost.Services
         /// <param name="parameters">Update shipment parameters.</param>
         /// <returns>The updated Batch.</returns>
         [CrudOperations.Update]
-        public async Task<Batch> RemoveShipments(string id, Dictionary<string, object> parameters)
+        public async Task<Batch> RemoveShipments(string id, Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/remove_shipments", parameters);
+            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/remove_shipments", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -239,9 +245,9 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Batches.RemoveShipments"/> parameter set.</param>
         /// <returns>This updated <see cref="Batch"/> instance.</returns>
         [CrudOperations.Update]
-        public async Task<Batch> RemoveShipments(string id, BetaFeatures.Parameters.Batches.RemoveShipments parameters)
+        public async Task<Batch> RemoveShipments(string id, BetaFeatures.Parameters.Batches.RemoveShipments parameters, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/remove_shipments", parameters.ToDictionary());
+            return await RequestAsync<Batch>(Method.Post, $"batches/{id}/remove_shipments", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -250,10 +256,10 @@ namespace EasyPost.Services
         /// <param name="shipmentsToRemove">List of Shipment objects to be removed.</param>
         /// <returns>The updated Batch.</returns>
         [CrudOperations.Update]
-        public async Task<Batch> RemoveShipments(string id, List<Shipment> shipmentsToRemove)
+        public async Task<Batch> RemoveShipments(string id, List<Shipment> shipmentsToRemove, CancellationToken cancellationToken = default)
         {
             Dictionary<string, object> parameters = new() { { "shipments", shipmentsToRemove } };
-            return await RemoveShipments(id, parameters);
+            return await RemoveShipments(id, parameters, cancellationToken);
         }
 
         /// <summary>
@@ -262,10 +268,10 @@ namespace EasyPost.Services
         /// <param name="shipmentIds">List of shipment ids to be removed.</param>
         /// <returns>The updated Batch.</returns>
         [CrudOperations.Update]
-        public async Task<Batch> RemoveShipments(string id, IEnumerable<string> shipmentIds)
+        public async Task<Batch> RemoveShipments(string id, IEnumerable<string> shipmentIds, CancellationToken cancellationToken = default)
         {
             List<Shipment> shipments = shipmentIds.Select(shipmentId => new Shipment { Id = shipmentId }).ToList();
-            return await RemoveShipments(id, shipments);
+            return await RemoveShipments(id, shipments, cancellationToken);
         }
 
         #endregion

--- a/EasyPost/Services/Beta/CarrierMetadataService.cs
+++ b/EasyPost/Services/Beta/CarrierMetadataService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.Http;
@@ -23,11 +24,11 @@ namespace EasyPost.Services.Beta
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Beta.CarrierMetadata.Retrieve"/> parameter set.</param>
         /// <returns>A list of <see cref="Carrier"/> objects.</returns>
         [CrudOperations.Read]
-        public async Task<List<Carrier>> RetrieveCarrierMetadata(BetaFeatures.Parameters.Beta.CarrierMetadata.Retrieve? parameters = null)
+        public async Task<List<Carrier>> RetrieveCarrierMetadata(BetaFeatures.Parameters.Beta.CarrierMetadata.Retrieve? parameters = null, CancellationToken cancellationToken = default)
         {
             Dictionary<string, object> data = parameters?.ToDictionary() ?? new Dictionary<string, object>();
 
-            return await RequestAsync<List<Carrier>>(Method.Get, "metadata", data, "carriers", ApiVersion.Beta);
+            return await RequestAsync<List<Carrier>>(Method.Get, "metadata", cancellationToken, data, "carriers", ApiVersion.Beta);
         }
 
         #endregion

--- a/EasyPost/Services/Beta/RateService.cs
+++ b/EasyPost/Services/Beta/RateService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.Http;
@@ -40,10 +41,10 @@ namespace EasyPost.Services.Beta
         /// </param>
         /// <returns>A list of <see cref="StatelessRate"/> objects.</returns>
         [CrudOperations.Create]
-        public async Task<List<StatelessRate>> RetrieveStatelessRates(Dictionary<string, object> parameters)
+        public async Task<List<StatelessRate>> RetrieveStatelessRates(Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
             parameters = parameters.Wrap("shipment");
-            return await RequestAsync<List<StatelessRate>>(Method.Post, "rates", parameters, "rates", ApiVersion.Beta);
+            return await RequestAsync<List<StatelessRate>>(Method.Post, "rates", cancellationToken, parameters, "rates", ApiVersion.Beta);
         }
 
         /// <summary>
@@ -52,9 +53,9 @@ namespace EasyPost.Services.Beta
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Beta.Rates.Retrieve"/> parameter set.</param>
         /// <returns>A list of <see cref="StatelessRate"/> objects.</returns>
         [CrudOperations.Create]
-        public async Task<List<StatelessRate>> RetrieveStatelessRates(BetaFeatures.Parameters.Beta.Rates.Retrieve parameters)
+        public async Task<List<StatelessRate>> RetrieveStatelessRates(BetaFeatures.Parameters.Beta.Rates.Retrieve parameters, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<List<StatelessRate>>(Method.Post, "rates", parameters.ToDictionary(), "rates", ApiVersion.Beta);
+            return await RequestAsync<List<StatelessRate>>(Method.Post, "rates", cancellationToken, parameters.ToDictionary(), "rates", ApiVersion.Beta);
         }
 
         #endregion

--- a/EasyPost/Services/Beta/ReferralCustomerService.cs
+++ b/EasyPost/Services/Beta/ReferralCustomerService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.Exceptions.API;
@@ -29,7 +30,7 @@ namespace EasyPost.Services.Beta
         /// <returns>A <see cref="PaymentMethod"/> object.</returns>
         /// <exception cref="ApiError">When the request fails.</exception>
         [CrudOperations.Update]
-        public async Task<PaymentMethod> AddPaymentMethod(string stripeCustomerId, string paymentMethodReference, PaymentMethod.Priority? priority = null)
+        public async Task<PaymentMethod> AddPaymentMethod(string stripeCustomerId, string paymentMethodReference, PaymentMethod.Priority? priority = null, CancellationToken cancellationToken = default)
         {
             priority ??= PaymentMethod.Priority.Primary;
 
@@ -46,7 +47,7 @@ namespace EasyPost.Services.Beta
                 },
             };
 
-            return await RequestAsync<PaymentMethod>(Method.Post, "referral_customers/payment_method", parameters, overrideApiVersion: ApiVersion.Beta);
+            return await RequestAsync<PaymentMethod>(Method.Post, "referral_customers/payment_method", cancellationToken, parameters, overrideApiVersion: ApiVersion.Beta);
         }
 
         /// <summary>
@@ -58,9 +59,9 @@ namespace EasyPost.Services.Beta
         /// <returns>A <see cref="PaymentMethod"/> object.</returns>
         /// <exception cref="ApiError">When the request fails.</exception>
         [CrudOperations.Update]
-        public async Task<PaymentMethod> AddPaymentMethod(BetaFeatures.Parameters.ReferralCustomers.AddPaymentMethod parameters)
+        public async Task<PaymentMethod> AddPaymentMethod(BetaFeatures.Parameters.ReferralCustomers.AddPaymentMethod parameters, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<PaymentMethod>(Method.Post, "referral_customers/payment_method", parameters.ToDictionary(), overrideApiVersion: ApiVersion.Beta);
+            return await RequestAsync<PaymentMethod>(Method.Post, "referral_customers/payment_method", cancellationToken, parameters.ToDictionary(), overrideApiVersion: ApiVersion.Beta);
         }
 
         /// <summary>
@@ -70,14 +71,14 @@ namespace EasyPost.Services.Beta
         /// <param name="amount">Amount in cents to refund the Referral Customer.</param>
         /// <returns>A <see cref="PaymentRefund"/> object.</returns>
         [CrudOperations.Update]
-        public async Task<PaymentRefund> RefundByAmount(int amount)
+        public async Task<PaymentRefund> RefundByAmount(int amount, CancellationToken cancellationToken = default)
         {
             Dictionary<string, object> parameters = new()
             {
                 { "refund_amount", amount },
             };
 
-            return await RequestAsync<PaymentRefund>(Method.Post, "referral_customers/refunds", parameters, overrideApiVersion: ApiVersion.Beta);
+            return await RequestAsync<PaymentRefund>(Method.Post, "referral_customers/refunds", cancellationToken, parameters, overrideApiVersion: ApiVersion.Beta);
         }
 
         /// <summary>
@@ -86,9 +87,9 @@ namespace EasyPost.Services.Beta
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.ReferralCustomers.RefundByAmount"/> parameter set.</param>
         /// <returns>A <see cref="PaymentRefund"/> object.</returns>
         [CrudOperations.Update]
-        public async Task<PaymentRefund> RefundByAmount(BetaFeatures.Parameters.ReferralCustomers.RefundByAmount parameters)
+        public async Task<PaymentRefund> RefundByAmount(BetaFeatures.Parameters.ReferralCustomers.RefundByAmount parameters, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<PaymentRefund>(Method.Post, "referral_customers/refunds", parameters.ToDictionary(), overrideApiVersion: ApiVersion.Beta);
+            return await RequestAsync<PaymentRefund>(Method.Post, "referral_customers/refunds", cancellationToken, parameters.ToDictionary(), overrideApiVersion: ApiVersion.Beta);
         }
 
         /// <summary>
@@ -98,14 +99,14 @@ namespace EasyPost.Services.Beta
         /// <param name="paymentLogId">Payment log ID to refund.</param>
         /// <returns>A <see cref="PaymentRefund"/> object.</returns>
         [CrudOperations.Update]
-        public async Task<PaymentRefund> RefundByPaymentLog(string paymentLogId)
+        public async Task<PaymentRefund> RefundByPaymentLog(string paymentLogId, CancellationToken cancellationToken = default)
         {
             Dictionary<string, object> parameters = new()
             {
                 { "payment_log_id", paymentLogId },
             };
 
-            return await RequestAsync<PaymentRefund>(Method.Post, "referral_customers/refunds", parameters, overrideApiVersion: ApiVersion.Beta);
+            return await RequestAsync<PaymentRefund>(Method.Post, "referral_customers/refunds", cancellationToken, parameters, overrideApiVersion: ApiVersion.Beta);
         }
 
         /// <summary>
@@ -114,9 +115,9 @@ namespace EasyPost.Services.Beta
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.ReferralCustomers.RefundByPaymentLog"/> parameter set.</param>
         /// <returns>A <see cref="PaymentRefund"/> object.</returns>
         [CrudOperations.Update]
-        public async Task<PaymentRefund> RefundByPaymentLog(BetaFeatures.Parameters.ReferralCustomers.RefundByPaymentLog parameters)
+        public async Task<PaymentRefund> RefundByPaymentLog(BetaFeatures.Parameters.ReferralCustomers.RefundByPaymentLog parameters, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<PaymentRefund>(Method.Post, "referral_customers/refunds", parameters.ToDictionary(), overrideApiVersion: ApiVersion.Beta);
+            return await RequestAsync<PaymentRefund>(Method.Post, "referral_customers/refunds", cancellationToken, parameters.ToDictionary(), overrideApiVersion: ApiVersion.Beta);
         }
 
         #endregion

--- a/EasyPost/Services/CarrierAccountService.cs
+++ b/EasyPost/Services/CarrierAccountService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.Exceptions.General;
@@ -36,7 +37,7 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>EasyPost.CarrierAccount instance.</returns>
         [CrudOperations.Create]
-        public async Task<CarrierAccount> Create(Dictionary<string, object> parameters)
+        public async Task<CarrierAccount> Create(Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
             if (parameters["type"] is not string carrierType)
             {
@@ -47,7 +48,7 @@ namespace EasyPost.Services
 
             parameters = parameters.Wrap("carrier_account");
 
-            return await RequestAsync<CarrierAccount>(Method.Post, endpoint, parameters);
+            return await RequestAsync<CarrierAccount>(Method.Post, endpoint, cancellationToken, parameters);
         }
 
         /// <summary>
@@ -56,7 +57,7 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.CarrierAccounts.Create"/> parameter set.</param>
         /// <returns><see cref="CarrierAccount"/> instance.</returns>
         [CrudOperations.Create]
-        public async Task<CarrierAccount> Create(BetaFeatures.Parameters.CarrierAccounts.Create parameters)
+        public async Task<CarrierAccount> Create(BetaFeatures.Parameters.CarrierAccounts.Create parameters, CancellationToken cancellationToken = default)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
             if (parameters.Type == null)
@@ -66,7 +67,7 @@ namespace EasyPost.Services
 
             string endpoint = SelectCarrierAccountCreationEndpoint(parameters.Type);
 
-            return await RequestAsync<CarrierAccount>(Method.Post, endpoint, parameters.ToDictionary());
+            return await RequestAsync<CarrierAccount>(Method.Post, endpoint, cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -74,7 +75,7 @@ namespace EasyPost.Services
         /// </summary>
         /// <returns>A list of EasyPost.CarrierAccount instances.</returns>
         [CrudOperations.Read]
-        public async Task<List<CarrierAccount>> All() => await RequestAsync<List<CarrierAccount>>(Method.Get, "carrier_accounts");
+        public async Task<List<CarrierAccount>> All(CancellationToken cancellationToken = default) => await RequestAsync<List<CarrierAccount>>(Method.Get, "carrier_accounts", cancellationToken);
 
         /// <summary>
         ///     Retrieve a CarrierAccount from its id.
@@ -82,7 +83,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a carrier account. Starts with "ca_".</param>
         /// <returns>EasyPost.CarrierAccount instance.</returns>
         [CrudOperations.Read]
-        public async Task<CarrierAccount> Retrieve(string id) => await RequestAsync<CarrierAccount>(Method.Get, $"carrier_accounts/{id}");
+        public async Task<CarrierAccount> Retrieve(string id, CancellationToken cancellationToken = default) => await RequestAsync<CarrierAccount>(Method.Get, $"carrier_accounts/{id}", cancellationToken);
 
         /// <summary>
         ///     Update this CarrierAccount.
@@ -90,10 +91,10 @@ namespace EasyPost.Services
         /// <param name="parameters">See CarrierAccount.Create for more details.</param>
         /// <returns>The updated CarrierAccount.</returns>
         [CrudOperations.Update]
-        public async Task<CarrierAccount> Update(string id, Dictionary<string, object> parameters)
+        public async Task<CarrierAccount> Update(string id, Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
             parameters = parameters.Wrap("carrier_account");
-            return await RequestAsync<CarrierAccount>(Method.Put, $"carrier_accounts/{id}", parameters);
+            return await RequestAsync<CarrierAccount>(Method.Put, $"carrier_accounts/{id}", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -102,9 +103,9 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.CarrierAccounts.Update"/> parameter set.</param>
         /// <returns>This updated <see cref="CarrierAccount"/> instance.</returns>
         [CrudOperations.Update]
-        public async Task<CarrierAccount> Update(string id, BetaFeatures.Parameters.CarrierAccounts.Update parameters)
+        public async Task<CarrierAccount> Update(string id, BetaFeatures.Parameters.CarrierAccounts.Update parameters, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<CarrierAccount>(Method.Put, $"carrier_accounts/{id}", parameters.ToDictionary());
+            return await RequestAsync<CarrierAccount>(Method.Put, $"carrier_accounts/{id}", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -112,7 +113,7 @@ namespace EasyPost.Services
         /// </summary>
         /// <returns>Whether the request was successful or not.</returns>
         [CrudOperations.Delete]
-        public async Task Delete(string id) => await RequestAsync(Method.Delete, $"carrier_accounts/{id}");
+        public async Task Delete(string id, CancellationToken cancellationToken = default) => await RequestAsync(Method.Delete, $"carrier_accounts/{id}", cancellationToken);
 
         #endregion
 

--- a/EasyPost/Services/CarrierTypeService.cs
+++ b/EasyPost/Services/CarrierTypeService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.Http;
@@ -22,7 +23,7 @@ namespace EasyPost.Services
         /// </summary>
         /// <returns>A list of EasyPost.CarrierType instances.</returns>
         [CrudOperations.Read]
-        public async Task<List<CarrierType>> All() => await RequestAsync<List<CarrierType>>(Method.Get, "carrier_types");
+        public async Task<List<CarrierType>> All(CancellationToken cancellationToken = default) => await RequestAsync<List<CarrierType>>(Method.Get, "carrier_types", cancellationToken);
 
         #endregion
     }

--- a/EasyPost/Services/CustomsInfoService.cs
+++ b/EasyPost/Services/CustomsInfoService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.Http;
@@ -35,10 +36,10 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>EasyPost.CustomsInfo instance.</returns>
         [CrudOperations.Create]
-        public async Task<CustomsInfo> Create(Dictionary<string, object> parameters)
+        public async Task<CustomsInfo> Create(Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
             parameters = parameters.Wrap("customs_info");
-            return await RequestAsync<CustomsInfo>(Method.Post, "customs_infos", parameters);
+            return await RequestAsync<CustomsInfo>(Method.Post, "customs_infos", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -47,10 +48,10 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.CustomsInfo.Create"/> parameter set.</param>
         /// <returns><see cref="CustomsInfo"/> instance.</returns>
         [CrudOperations.Create]
-        public async Task<CustomsInfo> Create(BetaFeatures.Parameters.CustomsInfo.Create parameters)
+        public async Task<CustomsInfo> Create(BetaFeatures.Parameters.CustomsInfo.Create parameters, CancellationToken cancellationToken = default)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await RequestAsync<CustomsInfo>(Method.Post, "customs_infos", parameters.ToDictionary());
+            return await RequestAsync<CustomsInfo>(Method.Post, "customs_infos", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -59,7 +60,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a CustomsInfo. Starts with "cstinfo_".</param>
         /// <returns>EasyPost.CustomsInfo instance.</returns>
         [CrudOperations.Read]
-        public async Task<CustomsInfo> Retrieve(string id) => await RequestAsync<CustomsInfo>(Method.Get, $"customs_infos/{id}");
+        public async Task<CustomsInfo> Retrieve(string id, CancellationToken cancellationToken = default) => await RequestAsync<CustomsInfo>(Method.Get, $"customs_infos/{id}", cancellationToken);
 
         #endregion
     }

--- a/EasyPost/Services/CustomsItemService.cs
+++ b/EasyPost/Services/CustomsItemService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.Http;
@@ -33,10 +34,10 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>EasyPost.CustomsItem instance.</returns>
         [CrudOperations.Create]
-        public async Task<CustomsItem> Create(Dictionary<string, object> parameters)
+        public async Task<CustomsItem> Create(Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
             parameters = parameters.Wrap("customs_item");
-            return await RequestAsync<CustomsItem>(Method.Post, "customs_items", parameters);
+            return await RequestAsync<CustomsItem>(Method.Post, "customs_items", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -45,10 +46,10 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.CustomsItems.Create"/> parameter set.</param>
         /// <returns><see cref="CustomsItem"/> instance.</returns>
         [CrudOperations.Create]
-        public async Task<CustomsItem> Create(BetaFeatures.Parameters.CustomsItems.Create parameters)
+        public async Task<CustomsItem> Create(BetaFeatures.Parameters.CustomsItems.Create parameters, CancellationToken cancellationToken = default)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await RequestAsync<CustomsItem>(Method.Post, "customs_items", parameters.ToDictionary());
+            return await RequestAsync<CustomsItem>(Method.Post, "customs_items", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -57,7 +58,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a CustomsItem. Starts with "cstitem_".</param>
         /// <returns>EasyPost.CustomsItem instance.</returns>
         [CrudOperations.Read]
-        public async Task<CustomsItem> Retrieve(string id) => await RequestAsync<CustomsItem>(Method.Get, $"customs_items/{id}");
+        public async Task<CustomsItem> Retrieve(string id, CancellationToken cancellationToken = default) => await RequestAsync<CustomsItem>(Method.Get, $"customs_items/{id}", cancellationToken);
 
         #endregion
     }

--- a/EasyPost/Services/EndShipperService.cs
+++ b/EasyPost/Services/EndShipperService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.BetaFeatures.Parameters;
@@ -39,10 +40,10 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>EasyPost.EndShipper instance.</returns>
         [CrudOperations.Create]
-        public async Task<EndShipper> Create(Dictionary<string, object> parameters)
+        public async Task<EndShipper> Create(Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
             parameters = parameters.Wrap("address");
-            return await RequestAsync<EndShipper>(Method.Post, "end_shippers", parameters);
+            return await RequestAsync<EndShipper>(Method.Post, "end_shippers", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -51,10 +52,10 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.EndShippers.Create"/> parameter set.</param>
         /// <returns><see cref="EndShipper"/> instance.</returns>
         [CrudOperations.Create]
-        public async Task<EndShipper> Create(BetaFeatures.Parameters.EndShippers.Create parameters)
+        public async Task<EndShipper> Create(BetaFeatures.Parameters.EndShippers.Create parameters, CancellationToken cancellationToken = default)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await RequestAsync<EndShipper>(Method.Post, "end_shippers", parameters.ToDictionary());
+            return await RequestAsync<EndShipper>(Method.Post, "end_shippers", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -74,9 +75,9 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>An EasyPost.EndShipperCollection instance.</returns>
         [CrudOperations.Read]
-        public async Task<EndShipperCollection> All(Dictionary<string, object>? parameters = null)
+        public async Task<EndShipperCollection> All(Dictionary<string, object>? parameters = null, CancellationToken cancellationToken = default)
         {
-            EndShipperCollection collection = await RequestAsync<EndShipperCollection>(Method.Get, "end_shippers", parameters);
+            EndShipperCollection collection = await RequestAsync<EndShipperCollection>(Method.Get, "end_shippers", cancellationToken, parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.EndShippers.All>(parameters);
             return collection;
         }
@@ -87,7 +88,12 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.EndShippers.All"/> parameter set.</param>
         /// <returns><see cref="EndShipperCollection"/> instance.</returns>
         [CrudOperations.Read]
-        public async Task<EndShipperCollection> All(BetaFeatures.Parameters.EndShippers.All parameters) => await All(parameters.ToDictionary());
+        public async Task<EndShipperCollection> All(BetaFeatures.Parameters.EndShippers.All parameters, CancellationToken cancellationToken = default)
+        {
+            EndShipperCollection collection = await RequestAsync<EndShipperCollection>(Method.Get, "end_shippers", cancellationToken, parameters.ToDictionary());
+            collection.Filters = parameters;
+            return collection;
+        }
 
         // TODO: Add GetNextPage function when "before_id" available for EndShipper All endpoint.
 
@@ -97,7 +103,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing an EndShipper. Starts with "es_".</param>
         /// <returns>EasyPost.EndShipper instance.</returns>
         [CrudOperations.Read]
-        public async Task<EndShipper> Retrieve(string id) => await RequestAsync<EndShipper>(Method.Get, $"end_shippers/{id}");
+        public async Task<EndShipper> Retrieve(string id, CancellationToken cancellationToken = default) => await RequestAsync<EndShipper>(Method.Get, $"end_shippers/{id}", cancellationToken);
 
         /// <summary>
         ///     Update this EndShipper. Must pass in all properties (new and existing).
@@ -105,11 +111,11 @@ namespace EasyPost.Services
         /// <param name="parameters">See EndShipper.Create for more details.</param>
         /// <returns>The updated EndShipper.</returns>
         [CrudOperations.Update]
-        public async Task<EndShipper> Update(string id, Dictionary<string, object> parameters)
+        public async Task<EndShipper> Update(string id, Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
             parameters = parameters.Wrap("address");
 
-            return await RequestAsync<EndShipper>(Method.Put, $"end_shippers/{id}", parameters);
+            return await RequestAsync<EndShipper>(Method.Put, $"end_shippers/{id}", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -118,9 +124,9 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.EndShippers.Update"/> parameter set.</param>
         /// <returns>This updated <see cref="EndShipper"/> instance.</returns>
         [CrudOperations.Update]
-        public async Task<EndShipper> Update(string id, BetaFeatures.Parameters.EndShippers.Update parameters)
+        public async Task<EndShipper> Update(string id, BetaFeatures.Parameters.EndShippers.Update parameters, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<EndShipper>(Method.Put, $"end_shippers/{id}", parameters.ToDictionary());
+            return await RequestAsync<EndShipper>(Method.Put, $"end_shippers/{id}", cancellationToken, parameters.ToDictionary());
         }
 
         #endregion

--- a/EasyPost/Services/EventService.cs
+++ b/EasyPost/Services/EventService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.BetaFeatures.Parameters;
@@ -36,9 +37,9 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>An EasyPost.EventCollection instance.</returns>
         [CrudOperations.Read]
-        public async Task<EventCollection> All(Dictionary<string, object>? parameters = null)
+        public async Task<EventCollection> All(Dictionary<string, object>? parameters = null, CancellationToken cancellationToken = default)
         {
-            EventCollection collection = await RequestAsync<EventCollection>(Method.Get, "events", parameters);
+            EventCollection collection = await RequestAsync<EventCollection>(Method.Get, "events", cancellationToken, parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.Events.All>(parameters);
             return collection;
         }
@@ -49,7 +50,12 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Events.All"/> parameter set.</param>
         /// <returns><see cref="EventCollection"/> instance.</returns>
         [CrudOperations.Read]
-        public async Task<EventCollection> All(BetaFeatures.Parameters.Events.All parameters) => await All(parameters.ToDictionary());
+        public async Task<EventCollection> All(BetaFeatures.Parameters.Events.All parameters, CancellationToken cancellationToken = default)
+        {
+            EventCollection collection = await RequestAsync<EventCollection>(Method.Get, "events", cancellationToken, parameters.ToDictionary());
+            collection.Filters = parameters;
+            return collection;
+        }
 
         /// <summary>
         ///     Get the next page of a paginated <see cref="EventCollection"/>.
@@ -59,7 +65,7 @@ namespace EasyPost.Services
         /// <returns>The next page, as a <see cref="EventCollection"/> instance.</returns>
         /// <exception cref="EndOfPaginationError">Thrown if there is no next page to retrieve.</exception>
         [CrudOperations.Read]
-        public async Task<EventCollection> GetNextPage(EventCollection collection, int? pageSize = null) => await collection.GetNextPage<EventCollection, BetaFeatures.Parameters.Events.All>(async parameters => await All(parameters), collection.Events, pageSize);
+        public async Task<EventCollection> GetNextPage(EventCollection collection, int? pageSize = null, CancellationToken cancellationToken = default) => await collection.GetNextPage<EventCollection, BetaFeatures.Parameters.Events.All>(async parameters => await All(parameters, cancellationToken), collection.Events, pageSize);
 
         /// <summary>
         ///     Retrieve an Event from its id.
@@ -67,14 +73,14 @@ namespace EasyPost.Services
         /// <param name="id">String representing a Event. Starts with "evt_".</param>
         /// <returns>EasyPost.Event instance.</returns>
         [CrudOperations.Read]
-        public async Task<Event> Retrieve(string id) => await RequestAsync<Event>(Method.Get, $"events/{id}");
+        public async Task<Event> Retrieve(string id, CancellationToken cancellationToken = default) => await RequestAsync<Event>(Method.Get, $"events/{id}", cancellationToken);
 
         /// <summary>
         ///     Retrieve all <see cref="Payload"/>s for an <see cref="Event"/>.
         /// </summary>
         /// <param name="eventId">ID of the <see cref="Event"/> to retrieve payloads for.</param>
         /// <returns>A list of <see cref="Payload"/> objects.</returns>
-        public async Task<List<Payload>> RetrieveAllPayloads(string eventId) => await RequestAsync<List<Payload>>(Method.Get, $"events/{eventId}/payloads", rootElement: "payloads");
+        public async Task<List<Payload>> RetrieveAllPayloads(string eventId, CancellationToken cancellationToken = default) => await RequestAsync<List<Payload>>(Method.Get, $"events/{eventId}/payloads", cancellationToken: cancellationToken, rootElement: "payloads");
 
         /// <summary>
         ///     Retrieve a specific <see cref="Payload"/> for an <see cref="Event"/>.
@@ -84,7 +90,7 @@ namespace EasyPost.Services
         /// <returns>A <see cref="Payload"/> object.</returns>
         /// <exception cref="InvalidRequestError">Thrown if the specified payload ID is malformed.</exception>
         /// <exception cref="NotFoundError">Thrown if the specified payload is not found.</exception>
-        public async Task<Payload> RetrievePayload(string eventId, string payloadId) => await RequestAsync<Payload>(Method.Get, $"events/{eventId}/payloads/{payloadId}");
+        public async Task<Payload> RetrievePayload(string eventId, string payloadId, CancellationToken cancellationToken = default) => await RequestAsync<Payload>(Method.Get, $"events/{eventId}/payloads/{payloadId}", cancellationToken);
 
         #endregion
     }

--- a/EasyPost/Services/InsuranceService.cs
+++ b/EasyPost/Services/InsuranceService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.BetaFeatures.Parameters;
@@ -38,10 +39,10 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>EasyPost.Insurance instance.</returns>
         [CrudOperations.Create]
-        public async Task<Insurance> Create(Dictionary<string, object> parameters)
+        public async Task<Insurance> Create(Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
             parameters = parameters.Wrap("insurance");
-            return await RequestAsync<Insurance>(Method.Post, "insurances", parameters);
+            return await RequestAsync<Insurance>(Method.Post, "insurances", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -50,10 +51,10 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Insurance.Create"/> parameter set.</param>
         /// <returns><see cref="Insurance"/> instance.</returns>
         [CrudOperations.Create]
-        public async Task<Insurance> Create(BetaFeatures.Parameters.Insurance.Create parameters)
+        public async Task<Insurance> Create(BetaFeatures.Parameters.Insurance.Create parameters, CancellationToken cancellationToken = default)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await RequestAsync<Insurance>(Method.Post, "insurances", parameters.ToDictionary());
+            return await RequestAsync<Insurance>(Method.Post, "insurances", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -73,15 +74,20 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>An EasyPost.InsuranceCollection instance.</returns>
         [CrudOperations.Read]
-        public async Task<InsuranceCollection> All(Dictionary<string, object>? parameters = null)
+        public async Task<InsuranceCollection> All(Dictionary<string, object>? parameters = null, CancellationToken cancellationToken = default)
         {
-            InsuranceCollection collection = await RequestAsync<InsuranceCollection>(Method.Get, "insurances", parameters);
+            InsuranceCollection collection = await RequestAsync<InsuranceCollection>(Method.Get, "insurances", cancellationToken, parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.Insurance.All>(parameters);
             return collection;
         }
 
         [CrudOperations.Read]
-        public async Task<InsuranceCollection> All(BetaFeatures.Parameters.Insurance.All parameters) => await All(parameters.ToDictionary());
+        public async Task<InsuranceCollection> All(BetaFeatures.Parameters.Insurance.All parameters, CancellationToken cancellationToken = default)
+        {
+            InsuranceCollection collection = await RequestAsync<InsuranceCollection>(Method.Get, "insurances", cancellationToken, parameters.ToDictionary());
+            collection.Filters = parameters;
+            return collection;
+        }
 
         /// <summary>
         ///     Get the next page of a paginated <see cref="InsuranceCollection"/>.
@@ -91,7 +97,7 @@ namespace EasyPost.Services
         /// <returns>The next page, as a <see cref="InsuranceCollection"/> instance.</returns>
         /// <exception cref="EndOfPaginationError">Thrown if there is no next page to retrieve.</exception>
         [CrudOperations.Read]
-        public async Task<InsuranceCollection> GetNextPage(InsuranceCollection collection, int? pageSize = null) => await collection.GetNextPage<InsuranceCollection, BetaFeatures.Parameters.Insurance.All>(async parameters => await All(parameters), collection.Insurances, pageSize);
+        public async Task<InsuranceCollection> GetNextPage(InsuranceCollection collection, int? pageSize = null, CancellationToken cancellationToken = default) => await collection.GetNextPage<InsuranceCollection, BetaFeatures.Parameters.Insurance.All>(async parameters => await All(parameters, cancellationToken), collection.Insurances, pageSize);
 
         /// <summary>
         ///     Retrieve an Insurance from its id.
@@ -99,7 +105,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing an Insurance. Starts with "ins_".</param>
         /// <returns>EasyPost.Insurance instance.</returns>
         [CrudOperations.Read]
-        public async Task<Insurance> Retrieve(string id) => await RequestAsync<Insurance>(Method.Get, $"insurances/{id}");
+        public async Task<Insurance> Retrieve(string id, CancellationToken cancellationToken = default) => await RequestAsync<Insurance>(Method.Get, $"insurances/{id}", cancellationToken);
 
         #endregion
     }

--- a/EasyPost/Services/OrderService.cs
+++ b/EasyPost/Services/OrderService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.Exceptions.General;
@@ -39,10 +40,10 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>EasyPost.Order instance.</returns>
         [CrudOperations.Create]
-        public async Task<Order> Create(Dictionary<string, object> parameters)
+        public async Task<Order> Create(Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
             parameters = parameters.Wrap("order");
-            return await RequestAsync<Order>(Method.Post, "orders", parameters);
+            return await RequestAsync<Order>(Method.Post, "orders", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -51,10 +52,10 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Orders.Create"/> parameter set.</param>
         /// <returns><see cref="Order"/> instance.</returns>
         [CrudOperations.Create]
-        public async Task<Order> Create(BetaFeatures.Parameters.Orders.Create parameters)
+        public async Task<Order> Create(BetaFeatures.Parameters.Orders.Create parameters, CancellationToken cancellationToken = default)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await RequestAsync<Order>(Method.Post, "orders", parameters.ToDictionary());
+            return await RequestAsync<Order>(Method.Post, "orders", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -63,7 +64,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a Order. Starts with "order_" if passing an id.</param>
         /// <returns>EasyPost.Order instance.</returns>
         [CrudOperations.Read]
-        public async Task<Order> Retrieve(string id) => await RequestAsync<Order>(Method.Get, $"orders/{id}");
+        public async Task<Order> Retrieve(string id, CancellationToken cancellationToken = default) => await RequestAsync<Order>(Method.Get, $"orders/{id}", cancellationToken);
 
         /// <summary>
         ///     Purchase the shipments within this order with a carrier and service.
@@ -72,7 +73,7 @@ namespace EasyPost.Services
         /// <param name="withService">The service to purchase.</param>
         /// <returns>The updated Order.</returns>
         [CrudOperations.Update]
-        public async Task<Order> Buy(string id, string withCarrier, string withService)
+        public async Task<Order> Buy(string id, string withCarrier, string withService, CancellationToken cancellationToken = default)
         {
             Dictionary<string, object> parameters = new()
             {
@@ -80,7 +81,7 @@ namespace EasyPost.Services
                 { "service", withService },
             };
 
-            return await RequestAsync<Order>(Method.Post, $"orders/{id}/buy", parameters);
+            return await RequestAsync<Order>(Method.Post, $"orders/{id}/buy", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -89,7 +90,7 @@ namespace EasyPost.Services
         /// <param name="rate">EasyPost.Rate object instance to purchase the shipment with.</param>
         /// <returns>The updated Order.</returns>
         [CrudOperations.Update]
-        public async Task<Order> Buy(string id, Rate rate)
+        public async Task<Order> Buy(string id, Rate rate, CancellationToken cancellationToken = default)
         {
             if (rate.Carrier == null)
             {
@@ -103,7 +104,7 @@ namespace EasyPost.Services
                 throw new MissingPropertyError(rate, nameof(rate.Service));
             }
 
-            return await Buy(id, rate.Carrier, rate.Service);
+            return await Buy(id, rate.Carrier, rate.Service, cancellationToken);
         }
 
         /// <summary>
@@ -112,9 +113,9 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Orders.Buy"/> parameters set.</param>
         /// <returns>This updated <see cref="Order"/> instance.</returns>
         [CrudOperations.Update]
-        public async Task<Order> Buy(string id, BetaFeatures.Parameters.Orders.Buy parameters)
+        public async Task<Order> Buy(string id, BetaFeatures.Parameters.Orders.Buy parameters, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<Order>(Method.Post, $"orders/{id}/buy", parameters.ToDictionary());
+            return await RequestAsync<Order>(Method.Post, $"orders/{id}/buy", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -122,10 +123,10 @@ namespace EasyPost.Services
         /// </summary>
         /// <returns>The task to refresh this Order's rates.</returns>
         [CrudOperations.Update]
-        public async Task<Order> RefreshRates(string id)
+        public async Task<Order> RefreshRates(string id, CancellationToken cancellationToken = default)
         {
             // TODO: Make consistent with Shipment, Pickup and Order: GetRates, RefreshRates, RegenerateRates?
-            return await RequestAsync<Order>(Method.Get, $"orders/{id}/rates");
+            return await RequestAsync<Order>(Method.Get, $"orders/{id}/rates", cancellationToken);
         }
 
         #endregion

--- a/EasyPost/Services/ParcelService.cs
+++ b/EasyPost/Services/ParcelService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.Http;
@@ -32,10 +33,10 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>EasyPost.Parcel instance.</returns>
         [CrudOperations.Create]
-        public async Task<Parcel> Create(Dictionary<string, object> parameters)
+        public async Task<Parcel> Create(Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
             parameters = parameters.Wrap("parcel");
-            return await RequestAsync<Parcel>(Method.Post, "parcels", parameters);
+            return await RequestAsync<Parcel>(Method.Post, "parcels", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -44,10 +45,10 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Parcels.Create"/> parameter set.</param>
         /// <returns><see cref="Parcel"/> instance.</returns>
         [CrudOperations.Create]
-        public async Task<Parcel> Create(BetaFeatures.Parameters.Parcels.Create parameters)
+        public async Task<Parcel> Create(BetaFeatures.Parameters.Parcels.Create parameters, CancellationToken cancellationToken = default)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await RequestAsync<Parcel>(Method.Post, "parcels", parameters.ToDictionary());
+            return await RequestAsync<Parcel>(Method.Post, "parcels", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -56,7 +57,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a Parcel. Starts with "prcl_".</param>
         /// <returns>EasyPost.Parcel instance.</returns>
         [CrudOperations.Read]
-        public async Task<Parcel> Retrieve(string id) => await RequestAsync<Parcel>(Method.Get, $"parcels/{id}");
+        public async Task<Parcel> Retrieve(string id, CancellationToken cancellationToken = default) => await RequestAsync<Parcel>(Method.Get, $"parcels/{id}", cancellationToken);
 
         #endregion
     }

--- a/EasyPost/Services/PickupService.cs
+++ b/EasyPost/Services/PickupService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.BetaFeatures.Parameters;
@@ -38,10 +39,10 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>EasyPost.Pickup instance.</returns>
         [CrudOperations.Create]
-        public async Task<Pickup> Create(Dictionary<string, object> parameters)
+        public async Task<Pickup> Create(Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
             parameters = parameters.Wrap("pickup");
-            return await RequestAsync<Pickup>(Method.Post, "pickups", parameters);
+            return await RequestAsync<Pickup>(Method.Post, "pickups", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -50,10 +51,10 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Pickups.Create"/> parameter set.</param>
         /// <returns><see cref="Pickup"/> instance.</returns>
         [CrudOperations.Create]
-        public async Task<Pickup> Create(BetaFeatures.Parameters.Pickups.Create parameters)
+        public async Task<Pickup> Create(BetaFeatures.Parameters.Pickups.Create parameters, CancellationToken cancellationToken = default)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await RequestAsync<Pickup>(Method.Post, "pickups", parameters.ToDictionary());
+            return await RequestAsync<Pickup>(Method.Post, "pickups", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -62,7 +63,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a Pickup. Starts with "pickup_".</param>
         /// <returns>EasyPost.Pickup instance.</returns>
         [CrudOperations.Read]
-        public async Task<Pickup> Retrieve(string id) => await RequestAsync<Pickup>(Method.Get, $"pickups/{id}");
+        public async Task<Pickup> Retrieve(string id, CancellationToken cancellationToken = default) => await RequestAsync<Pickup>(Method.Get, $"pickups/{id}", cancellationToken);
 
         /// <summary>
         ///     Get a paginated list of <see cref="Pickup"/>s.
@@ -81,9 +82,9 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>An <see cref="PickupCollection"/> object.</returns>
         [CrudOperations.Read]
-        public async Task<PickupCollection> All(Dictionary<string, object>? parameters = null)
+        public async Task<PickupCollection> All(Dictionary<string, object>? parameters = null, CancellationToken cancellationToken = default)
         {
-            PickupCollection collection = await RequestAsync<PickupCollection>(Method.Get, "pickups", parameters);
+            PickupCollection collection = await RequestAsync<PickupCollection>(Method.Get, "pickups", cancellationToken, parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.Pickups.All>(parameters);
             return collection;
         }
@@ -94,7 +95,12 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Pickups.All"/> parameter set.</param>
         /// <returns><see cref="PickupCollection"/> instance.</returns>
         [CrudOperations.Read]
-        public async Task<PickupCollection> All(BetaFeatures.Parameters.Pickups.All parameters) => await All(parameters.ToDictionary());
+        public async Task<PickupCollection> All(BetaFeatures.Parameters.Pickups.All parameters, CancellationToken cancellationToken = default)
+        {
+            PickupCollection collection = await RequestAsync<PickupCollection>(Method.Get, "pickups", cancellationToken, parameters.ToDictionary());
+            collection.Filters = parameters;
+            return collection;
+        }
 
         /// <summary>
         ///     Get the next page of a paginated <see cref="PickupCollection"/>.
@@ -104,7 +110,7 @@ namespace EasyPost.Services
         /// <returns>The next page, as a <see cref="PickupCollection"/> instance.</returns>
         /// <exception cref="EndOfPaginationError">Thrown if there is no next page to retrieve.</exception>
         [CrudOperations.Read]
-        public async Task<PickupCollection> GetNextPage(PickupCollection collection, int? pageSize = null) => await collection.GetNextPage<PickupCollection, BetaFeatures.Parameters.Pickups.All>(async parameters => await All(parameters), collection.Pickups, pageSize);
+        public async Task<PickupCollection> GetNextPage(PickupCollection collection, int? pageSize = null, CancellationToken cancellationToken = default) => await collection.GetNextPage<PickupCollection, BetaFeatures.Parameters.Pickups.All>(async parameters => await All(parameters, cancellationToken), collection.Pickups, pageSize);
 
         /// <summary>
         ///     Purchase this pickup.
@@ -113,7 +119,7 @@ namespace EasyPost.Services
         /// <param name="withService">The name of the service to purchase.</param>
         /// <returns>The updated Pickup.</returns>
         [CrudOperations.Update]
-        public async Task<Pickup> Buy(string id, string withCarrier, string withService)
+        public async Task<Pickup> Buy(string id, string withCarrier, string withService, CancellationToken cancellationToken = default)
         {
             Dictionary<string, object> parameters = new()
             {
@@ -121,7 +127,7 @@ namespace EasyPost.Services
                 { "service", withService },
             };
 
-            return await RequestAsync<Pickup>(Method.Post, $"pickups/{id}/buy", parameters);
+            return await RequestAsync<Pickup>(Method.Post, $"pickups/{id}/buy", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -130,9 +136,9 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Pickups.Buy"/> parameters set.</param>
         /// <returns>This updated <see cref="Pickup"/> instance.</returns>
         [CrudOperations.Update]
-        public async Task<Pickup> Buy(string id, BetaFeatures.Parameters.Pickups.Buy parameters)
+        public async Task<Pickup> Buy(string id, BetaFeatures.Parameters.Pickups.Buy parameters, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<Pickup>(Method.Post, $"pickups/{id}/buy", parameters.ToDictionary());
+            return await RequestAsync<Pickup>(Method.Post, $"pickups/{id}/buy", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -140,9 +146,9 @@ namespace EasyPost.Services
         /// </summary>
         /// <returns>The updated Pickup.</returns>
         [CrudOperations.Update]
-        public async Task<Pickup> Cancel(string id)
+        public async Task<Pickup> Cancel(string id, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<Pickup>(Method.Post, $"pickups/{id}/cancel");
+            return await RequestAsync<Pickup>(Method.Post, $"pickups/{id}/cancel", cancellationToken);
         }
 
         #endregion

--- a/EasyPost/Services/RateService.cs
+++ b/EasyPost/Services/RateService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.Http;
@@ -24,7 +25,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a rate. Starts with `rate_`.</param>
         /// <returns>EasyPost.Rate instance.</returns>
         [CrudOperations.Read]
-        public async Task<Rate> Retrieve(string id) => await RequestAsync<Rate>(Method.Get, $"rates/{id}");
+        public async Task<Rate> Retrieve(string id, CancellationToken cancellationToken = default) => await RequestAsync<Rate>(Method.Get, $"rates/{id}", cancellationToken);
 
         #endregion
 

--- a/EasyPost/Services/ReferralCustomerService.cs
+++ b/EasyPost/Services/ReferralCustomerService.cs
@@ -159,7 +159,8 @@ namespace EasyPost.Services
             Dictionary<string, object> parameters = new()
             {
                 {
-                    "credit_card", new Dictionary<string, object>
+                    "credit_card",
+                    new Dictionary<string, object>
                     {
                         { "stripe_object_id", stripeObjectId },
                         { "priority", priority.ToString().ToLowerInvariant() },

--- a/EasyPost/Services/RefundService.cs
+++ b/EasyPost/Services/RefundService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.BetaFeatures.Parameters;
@@ -29,10 +30,10 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>A list of EasyPost.Refund instances.</returns>
         [CrudOperations.Create]
-        public async Task<List<Refund>> Create(Dictionary<string, object> parameters)
+        public async Task<List<Refund>> Create(Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
             parameters = parameters.Wrap("refund");
-            return await RequestAsync<List<Refund>>(Method.Post, "refunds", parameters);
+            return await RequestAsync<List<Refund>>(Method.Post, "refunds", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -41,10 +42,10 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Refunds.Create"/> parameter set.</param>
         /// <returns><see cref="Refund"/> instance.</returns>
         [CrudOperations.Create]
-        public async Task<List<Refund>> Create(BetaFeatures.Parameters.Refunds.Create parameters)
+        public async Task<List<Refund>> Create(BetaFeatures.Parameters.Refunds.Create parameters, CancellationToken cancellationToken = default)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await RequestAsync<List<Refund>>(Method.Post, "refunds", parameters.ToDictionary());
+            return await RequestAsync<List<Refund>>(Method.Post, "refunds", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -56,9 +57,9 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>An EasyPost.RefundCollection instance.</returns>
         [CrudOperations.Read]
-        public async Task<RefundCollection> All(Dictionary<string, object>? parameters = null)
+        public async Task<RefundCollection> All(Dictionary<string, object>? parameters = null, CancellationToken cancellationToken = default)
         {
-            RefundCollection collection = await RequestAsync<RefundCollection>(Method.Get, "refunds", parameters);
+            RefundCollection collection = await RequestAsync<RefundCollection>(Method.Get, "refunds", cancellationToken, parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.Refunds.All>(parameters);
             return collection;
         }
@@ -69,7 +70,12 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Refunds.All"/> parameter set.</param>
         /// <returns><see cref="RefundCollection"/> instance.</returns>
         [CrudOperations.Read]
-        public async Task<RefundCollection> All(BetaFeatures.Parameters.Refunds.All parameters) => await All(parameters.ToDictionary());
+        public async Task<RefundCollection> All(BetaFeatures.Parameters.Refunds.All parameters, CancellationToken cancellationToken = default)
+        {
+            RefundCollection collection = await RequestAsync<RefundCollection>(Method.Get, "refunds", cancellationToken, parameters.ToDictionary());
+            collection.Filters = parameters;
+            return collection;
+        }
 
         /// <summary>
         ///     Get the next page of a paginated <see cref="RefundCollection"/>.
@@ -79,7 +85,7 @@ namespace EasyPost.Services
         /// <returns>The next page, as a <see cref="RefundCollection"/> instance.</returns>
         /// <exception cref="EndOfPaginationError">Thrown if there is no next page to retrieve.</exception>
         [CrudOperations.Read]
-        public async Task<RefundCollection> GetNextPage(RefundCollection collection, int? pageSize = null) => await collection.GetNextPage<RefundCollection, BetaFeatures.Parameters.Refunds.All>(async parameters => await All(parameters), collection.Refunds, pageSize);
+        public async Task<RefundCollection> GetNextPage(RefundCollection collection, int? pageSize = null, CancellationToken cancellationToken = default) => await collection.GetNextPage<RefundCollection, BetaFeatures.Parameters.Refunds.All>(async parameters => await All(parameters, cancellationToken), collection.Refunds, pageSize);
 
         /// <summary>
         ///     Retrieve a Refund from its id.
@@ -87,7 +93,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a Refund. Starts with "rfnd_".</param>
         /// <returns>EasyPost.Refund instance.</returns>
         [CrudOperations.Read]
-        public async Task<Refund> Retrieve(string id) => await RequestAsync<Refund>(Method.Get, $"refunds/{id}");
+        public async Task<Refund> Retrieve(string id, CancellationToken cancellationToken = default) => await RequestAsync<Refund>(Method.Get, $"refunds/{id}", cancellationToken);
 
         #endregion
     }

--- a/EasyPost/Services/ReportService.cs
+++ b/EasyPost/Services/ReportService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.BetaFeatures.Parameters;
@@ -37,17 +38,17 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>EasyPost.Report instance.</returns>
         [CrudOperations.Create]
-        public async Task<Report> Create(string type, Dictionary<string, object>? parameters = null) => await RequestAsync<Report>(Method.Post, $"reports/{type}", parameters);
+        public async Task<Report> Create(string type, Dictionary<string, object>? parameters = null, CancellationToken cancellationToken = default) => await RequestAsync<Report>(Method.Post, $"reports/{type}", cancellationToken, parameters);
 
         [CrudOperations.Create]
-        public async Task<Report> Create(BetaFeatures.Parameters.Reports.Create parameters)
+        public async Task<Report> Create(BetaFeatures.Parameters.Reports.Create parameters, CancellationToken cancellationToken = default)
         {
             if (parameters.Type == null)
             {
                 throw new MissingParameterError("Type");
             }
 
-            return await Create(parameters.Type, parameters.ToDictionary());
+            return await RequestAsync<Report>(Method.Post, $"reports/{parameters.Type}", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -66,9 +67,9 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>An EasyPost.ReportCollection instance.</returns>
         [CrudOperations.Read]
-        public async Task<ReportCollection> All(string type, Dictionary<string, object>? parameters = null)
+        public async Task<ReportCollection> All(string type, Dictionary<string, object>? parameters = null, CancellationToken cancellationToken = default)
         {
-            ReportCollection collection = await RequestAsync<ReportCollection>(Method.Get, $"reports/{type}", parameters);
+            ReportCollection collection = await RequestAsync<ReportCollection>(Method.Get, $"reports/{type}", cancellationToken, parameters);
             // Copy the report type into the dictionary before we store the dictionary in the collection
             parameters ??= new Dictionary<string, object>();
             parameters["type"] = type;
@@ -77,14 +78,16 @@ namespace EasyPost.Services
         }
 
         [CrudOperations.Read]
-        public async Task<ReportCollection> All(BetaFeatures.Parameters.Reports.All parameters)
+        public async Task<ReportCollection> All(BetaFeatures.Parameters.Reports.All parameters, CancellationToken cancellationToken = default)
         {
             if (parameters.Type == null)
             {
                 throw new MissingParameterError("Type");
             }
 
-            return await All(parameters.Type, parameters.ToDictionary());
+            ReportCollection collection = await RequestAsync<ReportCollection>(Method.Get, $"reports/{parameters.Type}", cancellationToken, parameters.ToDictionary());
+            collection.Filters = parameters;
+            return collection;
         }
 
         /// <summary>
@@ -96,7 +99,7 @@ namespace EasyPost.Services
         /// <exception cref="EndOfPaginationError">Thrown if there is no next page to retrieve.</exception>
         [CrudOperations.Read]
         // Reuse the same report type as the current page of the collection (will not be null)
-        public async Task<ReportCollection> GetNextPage(ReportCollection collection, int? pageSize = null) => await collection.GetNextPage<ReportCollection, BetaFeatures.Parameters.Reports.All>(async parameters => await All(parameters), collection.Reports, pageSize);
+        public async Task<ReportCollection> GetNextPage(ReportCollection collection, int? pageSize = null, CancellationToken cancellationToken = default) => await collection.GetNextPage<ReportCollection, BetaFeatures.Parameters.Reports.All>(async parameters => await All(parameters, cancellationToken), collection.Reports, pageSize);
 
         /// <summary>
         ///     Retrieve a Report from its id.
@@ -104,7 +107,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a report.</param>
         /// <returns>EasyPost.Report instance.</returns>
         [CrudOperations.Read]
-        public async Task<Report> Retrieve(string id) => await RequestAsync<Report>(Method.Get, $"reports/{id}");
+        public async Task<Report> Retrieve(string id, CancellationToken cancellationToken = default) => await RequestAsync<Report>(Method.Get, $"reports/{id}", cancellationToken);
 
         /// <summary>
         ///     Retrieve a Report from its id and type.
@@ -113,7 +116,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a report.</param>
         /// <returns>EasyPost.Report instance.</returns>
         [CrudOperations.Read]
-        public async Task<Report> Retrieve(string type, string id) => await RequestAsync<Report>(Method.Get, $"reports/{type}/{id}");
+        public async Task<Report> Retrieve(string type, string id, CancellationToken cancellationToken = default) => await RequestAsync<Report>(Method.Get, $"reports/{type}/{id}", cancellationToken);
 
         #endregion
     }

--- a/EasyPost/Services/ScanFormService.cs
+++ b/EasyPost/Services/ScanFormService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.BetaFeatures.Parameters;
@@ -25,10 +26,10 @@ namespace EasyPost.Services
         /// <param name="shipments">Shipments to be associated with the ScanForm. Only id is required.</param>
         /// <returns>EasyPost.ScanForm instance.</returns>
         [CrudOperations.Create]
-        public async Task<ScanForm> Create(List<Shipment> shipments)
+        public async Task<ScanForm> Create(List<Shipment> shipments, CancellationToken cancellationToken = default)
         {
             Dictionary<string, object> parameters = new() { { "shipments", shipments } };
-            return await RequestAsync<ScanForm>(Method.Post, "scan_forms", parameters);
+            return await RequestAsync<ScanForm>(Method.Post, "scan_forms", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -37,10 +38,10 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.ScanForms.Create"/> parameter set.</param>
         /// <returns><see cref="ScanForm"/> instance.</returns>
         [CrudOperations.Create]
-        public async Task<ScanForm> Create(BetaFeatures.Parameters.ScanForms.Create parameters)
+        public async Task<ScanForm> Create(BetaFeatures.Parameters.ScanForms.Create parameters, CancellationToken cancellationToken = default)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await RequestAsync<ScanForm>(Method.Post, "scan_forms", parameters.ToDictionary());
+            return await RequestAsync<ScanForm>(Method.Post, "scan_forms", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -59,9 +60,9 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>An EasyPost.ScanFormCollection instance.</returns>
         [CrudOperations.Read]
-        public async Task<ScanFormCollection> All(Dictionary<string, object>? parameters = null)
+        public async Task<ScanFormCollection> All(Dictionary<string, object>? parameters = null, CancellationToken cancellationToken = default)
         {
-            ScanFormCollection collection = await RequestAsync<ScanFormCollection>(Method.Get, "scan_forms", parameters);
+            ScanFormCollection collection = await RequestAsync<ScanFormCollection>(Method.Get, "scan_forms", cancellationToken, parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.ScanForms.All>(parameters);
             return collection;
         }
@@ -72,7 +73,12 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.ScanForms.All"/> parameter set.</param>
         /// <returns><see cref="ScanFormCollection"/> instance.</returns>
         [CrudOperations.Read]
-        public async Task<ScanFormCollection> All(BetaFeatures.Parameters.ScanForms.All parameters) => await All(parameters.ToDictionary());
+        public async Task<ScanFormCollection> All(BetaFeatures.Parameters.ScanForms.All parameters, CancellationToken cancellationToken = default)
+        {
+            ScanFormCollection collection = await RequestAsync<ScanFormCollection>(Method.Get, "scan_forms", cancellationToken, parameters.ToDictionary());
+            collection.Filters = parameters;
+            return collection;
+        }
 
         /// <summary>
         ///     Get the next page of a paginated <see cref="ScanFormCollection"/>.
@@ -82,7 +88,7 @@ namespace EasyPost.Services
         /// <returns>The next page, as a <see cref="ScanFormCollection"/> instance.</returns>
         /// <exception cref="EndOfPaginationError">Thrown if there is no next page to retrieve.</exception>
         [CrudOperations.Read]
-        public async Task<ScanFormCollection> GetNextPage(ScanFormCollection collection, int? pageSize = null) => await collection.GetNextPage<ScanFormCollection, BetaFeatures.Parameters.ScanForms.All>(async parameters => await All(parameters), collection.ScanForms, pageSize);
+        public async Task<ScanFormCollection> GetNextPage(ScanFormCollection collection, int? pageSize = null, CancellationToken cancellationToken = default) => await collection.GetNextPage<ScanFormCollection, BetaFeatures.Parameters.ScanForms.All>(async parameters => await All(parameters, cancellationToken), collection.ScanForms, pageSize);
 
         /// <summary>
         ///     Retrieve a ScanForm from its id.
@@ -90,7 +96,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a scan form, starts with "sf_".</param>
         /// <returns>EasyPost.ScanForm instance.</returns>
         [CrudOperations.Read]
-        public async Task<ScanForm> Retrieve(string id) => await RequestAsync<ScanForm>(Method.Get, $"scan_forms/{id}");
+        public async Task<ScanForm> Retrieve(string id, CancellationToken cancellationToken = default) => await RequestAsync<ScanForm>(Method.Get, $"scan_forms/{id}", cancellationToken);
 
         #endregion
     }

--- a/EasyPost/Services/TrackerService.cs
+++ b/EasyPost/Services/TrackerService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.BetaFeatures.Parameters;
@@ -28,7 +29,7 @@ namespace EasyPost.Services
         /// <param name="trackingCode">Tracking code for the tracker.</param>
         /// <returns>An EasyPost.Tracker instance.</returns>
         [CrudOperations.Create]
-        public async Task<Tracker> Create(string carrier, string trackingCode)
+        public async Task<Tracker> Create(string carrier, string trackingCode, CancellationToken cancellationToken = default)
         {
             Dictionary<string, object> parameters = new()
             {
@@ -36,7 +37,7 @@ namespace EasyPost.Services
                 { "tracking_code", trackingCode },
             };
             parameters = parameters.Wrap("tracker");
-            return await RequestAsync<Tracker>(Method.Post, "trackers", parameters);
+            return await RequestAsync<Tracker>(Method.Post, "trackers", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -45,10 +46,10 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Trackers.Create"/> parameter set.</param>
         /// <returns><see cref="Tracker"/> instance.</returns>
         [CrudOperations.Create]
-        public async Task<Tracker> Create(BetaFeatures.Parameters.Trackers.Create parameters)
+        public async Task<Tracker> Create(BetaFeatures.Parameters.Trackers.Create parameters, CancellationToken cancellationToken = default)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await RequestAsync<Tracker>(Method.Post, "trackers", parameters.ToDictionary());
+            return await RequestAsync<Tracker>(Method.Post, "trackers", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -57,11 +58,11 @@ namespace EasyPost.Services
         /// <param name="parameters">A dictionary of tracking codes and carriers.</param>
         /// <returns>True if successful, False otherwise.</returns>
         [CrudOperations.Create]
-        public async Task CreateList(Dictionary<string, object> parameters)
+        public async Task CreateList(Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
             parameters = parameters.Wrap("trackers");
             // This endpoint does not return a response, so we simply send the request and only throw an exception if the API returns an error.
-            await RequestAsync(Method.Post, "trackers/create_list", parameters);
+            await RequestAsync(Method.Post, "trackers/create_list", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -71,9 +72,9 @@ namespace EasyPost.Services
         /// <returns>True if successful, False otherwise.</returns>
         [CrudOperations.Create]
         [Obsolete("This method is deprecated. Please use TrackerService.Create() instead. This method will be removed in a future version.", false)]
-        public async Task CreateList(BetaFeatures.Parameters.Trackers.CreateList parameters)
+        public async Task CreateList(BetaFeatures.Parameters.Trackers.CreateList parameters, CancellationToken cancellationToken = default)
         {
-            await RequestAsync(Method.Post, "trackers/create_list", parameters.ToDictionary());
+            await RequestAsync(Method.Post, "trackers/create_list", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -96,10 +97,10 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>A EasyPost.TrackerCollection instance.</returns>
         [CrudOperations.Read]
-        public async Task<TrackerCollection> All(Dictionary<string, object>? parameters = null)
+        public async Task<TrackerCollection> All(Dictionary<string, object>? parameters = null, CancellationToken cancellationToken = default)
         {
             // TODO: When we adopt parameter objects as the only way to pass parameters, we don't need to do this object -> dictionary -> object conversion to store the filters.
-            TrackerCollection collection = await RequestAsync<TrackerCollection>(Method.Get, "trackers", parameters);
+            TrackerCollection collection = await RequestAsync<TrackerCollection>(Method.Get, "trackers", cancellationToken, parameters);
             collection.Filters = BaseAllParameters.FromDictionary<BetaFeatures.Parameters.Trackers.All>(parameters);
             return collection;
         }
@@ -110,7 +111,12 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Trackers.All"/> parameter set.</param>
         /// <returns><see cref="TrackerCollection"/> instance.</returns>
         [CrudOperations.Read]
-        public async Task<TrackerCollection> All(BetaFeatures.Parameters.Trackers.All parameters) => await All(parameters.ToDictionary());
+        public async Task<TrackerCollection> All(BetaFeatures.Parameters.Trackers.All parameters, CancellationToken cancellationToken = default)
+        {
+            TrackerCollection collection = await RequestAsync<TrackerCollection>(Method.Get, "trackers", cancellationToken, parameters.ToDictionary());
+            collection.Filters = parameters;
+            return collection;
+        }
 
         /// <summary>
         ///     Get the next page of a paginated <see cref="TrackerCollection"/>.
@@ -120,7 +126,7 @@ namespace EasyPost.Services
         /// <returns>The next page, as a <see cref="TrackerCollection"/> instance.</returns>
         /// <exception cref="EndOfPaginationError">Thrown if there is no next page to retrieve.</exception>
         [CrudOperations.Read]
-        public async Task<TrackerCollection> GetNextPage(TrackerCollection collection, int? pageSize = null) => await collection.GetNextPage<TrackerCollection, BetaFeatures.Parameters.Trackers.All>(async parameters => await All(parameters), collection.Trackers, pageSize);
+        public async Task<TrackerCollection> GetNextPage(TrackerCollection collection, int? pageSize = null, CancellationToken cancellationToken = default) => await collection.GetNextPage<TrackerCollection, BetaFeatures.Parameters.Trackers.All>(async parameters => await All(parameters, cancellationToken), collection.Trackers, pageSize);
 
         /// <summary>
         ///     Retrieve a Tracker from its id.
@@ -128,7 +134,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a Tracker. Starts with "trk_".</param>
         /// <returns>EasyPost.Tracker instance.</returns>
         [CrudOperations.Read]
-        public async Task<Tracker> Retrieve(string id) => await RequestAsync<Tracker>(Method.Get, $"trackers/{id}");
+        public async Task<Tracker> Retrieve(string id, CancellationToken cancellationToken = default) => await RequestAsync<Tracker>(Method.Get, $"trackers/{id}", cancellationToken);
 
         #endregion
     }

--- a/EasyPost/Services/UserService.cs
+++ b/EasyPost/Services/UserService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.Http;
@@ -28,10 +29,10 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>EasyPost.User instance.</returns>
         [CrudOperations.Create]
-        public async Task<User> CreateChild(Dictionary<string, object> parameters)
+        public async Task<User> CreateChild(Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
             parameters = parameters.Wrap("user");
-            return await RequestAsync<User>(Method.Post, "users", parameters);
+            return await RequestAsync<User>(Method.Post, "users", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -40,26 +41,26 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Users.CreateChild"/> parameter set.</param>
         /// <returns><see cref="User"/> instance.</returns>
         [CrudOperations.Create]
-        public async Task<User> CreateChild(BetaFeatures.Parameters.Users.CreateChild parameters)
+        public async Task<User> CreateChild(BetaFeatures.Parameters.Users.CreateChild parameters, CancellationToken cancellationToken = default)
         {
             // Because the normal CreateChild method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await RequestAsync<User>(Method.Post, "users", parameters.ToDictionary());
+            return await RequestAsync<User>(Method.Post, "users", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
-        ///     Retrieve a User from its id. If no id is specified, it returns the user for the api_key specified.
+        ///     Retrieve a User from its ID.
         /// </summary>
         /// <param name="id">String representing a user. Starts with "user_".</param>
         /// <returns>EasyPost.User instance.</returns>
         [CrudOperations.Read]
-        public async Task<User> Retrieve(string? id = null) => id == null ? await RequestAsync<User>(Method.Get, "users") : await RequestAsync<User>(Method.Get, $"users/{id}");
+        public async Task<User> Retrieve(string id, CancellationToken cancellationToken = default) => await RequestAsync<User>(Method.Get, $"users/{id}", cancellationToken);
 
         /// <summary>
         ///     Retrieve the current user.
         /// </summary>
         /// <returns>EasyPost.User instance.</returns>
         [CrudOperations.Read]
-        public async Task<User> RetrieveMe() => await Retrieve();
+        public async Task<User> RetrieveMe(CancellationToken cancellationToken = default) => await RequestAsync<User>(Method.Get, "users", cancellationToken);
 
         /// <summary>
         ///     Update the User's brand.
@@ -77,10 +78,10 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>EasyPost.Brand instance.</returns>
         [CrudOperations.Create]
-        public async Task<Brand> UpdateBrand(string? id, Dictionary<string, object> parameters)
+        public async Task<Brand> UpdateBrand(string id, Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
             parameters = parameters.Wrap("brand");
-            return await RequestAsync<Brand>(Method.Put, $"users/{id}/brand", parameters);
+            return await RequestAsync<Brand>(Method.Put, $"users/{id}/brand", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -89,9 +90,9 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Users.UpdateBrand"/> parameter set.</param>
         /// <returns>This updated <see cref="Brand"/> instance.</returns>
         [CrudOperations.Create]
-        public async Task<Brand> UpdateBrand(string id, BetaFeatures.Parameters.Users.UpdateBrand parameters)
+        public async Task<Brand> UpdateBrand(string id, BetaFeatures.Parameters.Users.UpdateBrand parameters, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<Brand>(Method.Put, $"users/{id}/brand", parameters.ToDictionary());
+            return await RequestAsync<Brand>(Method.Put, $"users/{id}/brand", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -111,9 +112,9 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>The updated User.</returns>
         [CrudOperations.Update]
-        public async Task<User> Update(string? id, Dictionary<string, object> parameters)
+        public async Task<User> Update(string id, Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<User>(Method.Put, $"users/{id}", parameters);
+            return await RequestAsync<User>(Method.Put, $"users/{id}", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -122,9 +123,9 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Users.Update"/> parameter set.</param>
         /// <returns>This updated <see cref="User"/> instance.</returns>
         [CrudOperations.Update]
-        public async Task<User> Update(string id, BetaFeatures.Parameters.Users.Update parameters)
+        public async Task<User> Update(string id, BetaFeatures.Parameters.Users.Update parameters, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<User>(Method.Put, $"users/{id}", parameters.ToDictionary());
+            return await RequestAsync<User>(Method.Put, $"users/{id}", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -132,7 +133,7 @@ namespace EasyPost.Services
         /// </summary>
         /// <returns>Whether the request was successful or not.</returns>
         [CrudOperations.Delete]
-        public async Task Delete(string? id) => await RequestAsync(Method.Delete, $"users/{id}");
+        public async Task Delete(string id, CancellationToken cancellationToken = default) => await RequestAsync(Method.Delete, $"users/{id}", cancellationToken);
 
         #endregion
     }

--- a/EasyPost/Services/UserService.cs
+++ b/EasyPost/Services/UserService.cs
@@ -59,7 +59,7 @@ namespace EasyPost.Services
             {
                 return await RetrieveMe(cancellationToken);
             }
-            
+
             return await RequestAsync<User>(Method.Get, $"users/{id}", cancellationToken);
         }
 

--- a/EasyPost/Services/UserService.cs
+++ b/EasyPost/Services/UserService.cs
@@ -89,7 +89,7 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Users.UpdateBrand"/> parameter set.</param>
         /// <returns>This updated <see cref="Brand"/> instance.</returns>
         [CrudOperations.Create]
-        public async Task<Brand> UpdateBrand(string? id, BetaFeatures.Parameters.Users.UpdateBrand parameters)
+        public async Task<Brand> UpdateBrand(string id, BetaFeatures.Parameters.Users.UpdateBrand parameters)
         {
             return await RequestAsync<Brand>(Method.Put, $"users/{id}/brand", parameters.ToDictionary());
         }
@@ -122,7 +122,7 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Users.Update"/> parameter set.</param>
         /// <returns>This updated <see cref="User"/> instance.</returns>
         [CrudOperations.Update]
-        public async Task<User> Update(string? id, BetaFeatures.Parameters.Users.Update parameters)
+        public async Task<User> Update(string id, BetaFeatures.Parameters.Users.Update parameters)
         {
             return await RequestAsync<User>(Method.Put, $"users/{id}", parameters.ToDictionary());
         }

--- a/EasyPost/Services/UserService.cs
+++ b/EasyPost/Services/UserService.cs
@@ -48,12 +48,20 @@ namespace EasyPost.Services
         }
 
         /// <summary>
-        ///     Retrieve a User from its ID.
+        ///     Retrieve a User from its ID. If no ID is specified, the current User will be returned.
         /// </summary>
         /// <param name="id">String representing a user. Starts with "user_".</param>
         /// <returns>EasyPost.User instance.</returns>
         [CrudOperations.Read]
-        public async Task<User> Retrieve(string id, CancellationToken cancellationToken = default) => await RequestAsync<User>(Method.Get, $"users/{id}", cancellationToken);
+        public async Task<User> Retrieve(string? id = null, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                return await RetrieveMe(cancellationToken);
+            }
+            
+            return await RequestAsync<User>(Method.Get, $"users/{id}", cancellationToken);
+        }
 
         /// <summary>
         ///     Retrieve the current user.

--- a/EasyPost/Services/WebhookService.cs
+++ b/EasyPost/Services/WebhookService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost._base;
 using EasyPost.Exceptions.General;
@@ -32,10 +33,10 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>EasyPost.Webhook instance.</returns>
         [CrudOperations.Create]
-        public async Task<Webhook> Create(Dictionary<string, object> parameters)
+        public async Task<Webhook> Create(Dictionary<string, object> parameters, CancellationToken cancellationToken = default)
         {
             parameters = parameters.Wrap("webhook");
-            return await RequestAsync<Webhook>(Method.Post, "webhooks", parameters);
+            return await RequestAsync<Webhook>(Method.Post, "webhooks", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -44,10 +45,10 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Webhooks.Create"/> parameter set.</param>
         /// <returns><see cref="Webhook"/> instance.</returns>
         [CrudOperations.Create]
-        public async Task<Webhook> Create(BetaFeatures.Parameters.Webhooks.Create parameters)
+        public async Task<Webhook> Create(BetaFeatures.Parameters.Webhooks.Create parameters, CancellationToken cancellationToken = default)
         {
             // Because the normal Create method does wrapping internally, we can't simply pass the parameters object to it, otherwise it will wrap the parameters twice.
-            return await RequestAsync<Webhook>(Method.Post, "webhooks", parameters.ToDictionary());
+            return await RequestAsync<Webhook>(Method.Post, "webhooks", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -56,7 +57,7 @@ namespace EasyPost.Services
         /// <param name="parameters">A optional dictionary of parameters to include in the API request.</param>
         /// <returns>List of EasyPost.Webhook instances.</returns>
         [CrudOperations.Read]
-        public async Task<List<Webhook>> All(Dictionary<string, object>? parameters = null) => await RequestAsync<List<Webhook>>(Method.Get, "webhooks", parameters, "webhooks");
+        public async Task<List<Webhook>> All(Dictionary<string, object>? parameters = null, CancellationToken cancellationToken = default) => await RequestAsync<List<Webhook>>(Method.Get, "webhooks", cancellationToken, parameters, "webhooks");
 
         /// <summary>
         ///     List all <see cref="Webhook"/> objects.
@@ -64,7 +65,7 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Webhooks.All"/> parameter set.</param>
         /// <returns>List of <see cref="Webhook"/> instances.</returns>
         [CrudOperations.Read]
-        public async Task<List<Webhook>> All(BetaFeatures.Parameters.Webhooks.All parameters) => await RequestAsync<List<Webhook>>(Method.Get, "webhooks", parameters.ToDictionary(), "webhooks");
+        public async Task<List<Webhook>> All(BetaFeatures.Parameters.Webhooks.All parameters, CancellationToken cancellationToken = default) => await RequestAsync<List<Webhook>>(Method.Get, "webhooks", cancellationToken, parameters.ToDictionary(), "webhooks");
 
         /// <summary>
         ///     Retrieve a Webhook from its id.
@@ -72,7 +73,7 @@ namespace EasyPost.Services
         /// <param name="id">String representing a webhook. Starts with "hook_".</param>
         /// <returns>EasyPost.User instance.</returns>
         [CrudOperations.Read]
-        public async Task<Webhook> Retrieve(string id) => await RequestAsync<Webhook>(Method.Get, $"webhooks/{id}");
+        public async Task<Webhook> Retrieve(string id, CancellationToken cancellationToken = default) => await RequestAsync<Webhook>(Method.Get, $"webhooks/{id}", cancellationToken);
 
         /// <summary>
         ///     Update a Webhook. A disabled webhook will be enabled.
@@ -85,9 +86,9 @@ namespace EasyPost.Services
         /// </param>
         /// <returns>The updated Webhook.</returns>
         [CrudOperations.Update]
-        public async Task<Webhook> Update(string id, Dictionary<string, object>? parameters = null)
+        public async Task<Webhook> Update(string id, Dictionary<string, object>? parameters = null, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<Webhook>(Method.Put, $"webhooks/{id}", parameters);
+            return await RequestAsync<Webhook>(Method.Put, $"webhooks/{id}", cancellationToken, parameters);
         }
 
         /// <summary>
@@ -96,9 +97,9 @@ namespace EasyPost.Services
         /// <param name="parameters"><see cref="BetaFeatures.Parameters.Webhooks.Update"/> parameter set.</param>
         /// <returns>This updated <see cref="Webhook"/> instance.</returns>
         [CrudOperations.Update]
-        public async Task<Webhook> Update(string id, BetaFeatures.Parameters.Webhooks.Update parameters)
+        public async Task<Webhook> Update(string id, BetaFeatures.Parameters.Webhooks.Update parameters, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<Webhook>(Method.Put, $"webhooks/{id}", parameters.ToDictionary());
+            return await RequestAsync<Webhook>(Method.Put, $"webhooks/{id}", cancellationToken, parameters.ToDictionary());
         }
 
         /// <summary>
@@ -106,7 +107,7 @@ namespace EasyPost.Services
         /// </summary>
         /// <returns>Whether the request was successful or not.</returns>
         [CrudOperations.Delete]
-        public async Task Delete(string id) => await RequestAsync(Method.Delete, $"webhooks/{id}");
+        public async Task Delete(string id, CancellationToken cancellationToken = default) => await RequestAsync(Method.Delete, $"webhooks/{id}", cancellationToken);
 
         /// <summary>
         ///     Validate a received webhook's HMAC signature.

--- a/EasyPost/_base/EasyPostClient.cs
+++ b/EasyPost/_base/EasyPostClient.cs
@@ -102,7 +102,7 @@ namespace EasyPost._base
             // Check the response's status code
             if (response.ReturnedError())
             {
-                throw await ApiError.FromErrorResponse(response);
+                throw await ApiError.FromErrorResponse(response).ConfigureAwait(false);
             }
 
             // Prepare the list of root elements to use during deserialization

--- a/EasyPost/_base/EasyPostClient.cs
+++ b/EasyPost/_base/EasyPostClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using EasyPost.Exceptions.API;
 using EasyPost.Exceptions.General;
@@ -62,7 +63,7 @@ namespace EasyPost._base
         /// </summary>
         /// <param name="request">Request to execute.</param>
         /// <returns>An <see cref="HttpResponseMessage"/> object.</returns>
-        internal virtual async Task<HttpResponseMessage> ExecuteRequest(HttpRequestMessage request)
+        internal virtual async Task<HttpResponseMessage> ExecuteRequest(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             // This method actually executes the request and returns the response.
             // Everything up to this point has been pre-request, and everything after this point is post-request.
@@ -71,7 +72,7 @@ namespace EasyPost._base
             // try to execute the request, catch and rethrow an HTTP timeout exception, all other exceptions are thrown as-is
             try
             {
-                return await HttpClient.SendAsync(request).ConfigureAwait(false);
+                return await HttpClient.SendAsync(request, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             catch (TaskCanceledException)
             {
@@ -89,7 +90,7 @@ namespace EasyPost._base
         /// <param name="rootElement">Optional root element for the JSON to begin deserialization at.</param>
         /// <typeparam name="T">Type of object to deserialize response data into. Must be subclass of EasyPostObject.</typeparam>
         /// <returns>An instance of a T type object.</returns>
-        internal async Task<T> RequestAsync<T>(Method method, string endpoint, ApiVersion apiVersion, Dictionary<string, object>? parameters = null, string? rootElement = null)
+        internal async Task<T> RequestAsync<T>(Method method, string endpoint, ApiVersion apiVersion, CancellationToken cancellationToken, Dictionary<string, object>? parameters = null, string? rootElement = null)
             where T : class
         {
             // Build the request
@@ -97,7 +98,7 @@ namespace EasyPost._base
             Request request = new(ApiBaseInUse, endpoint, method, apiVersion, parameters, headers);
 
             // Execute the request
-            HttpResponseMessage response = await ExecuteRequest(request.AsHttpRequestMessage());
+            HttpResponseMessage response = await ExecuteRequest(request.AsHttpRequestMessage(), cancellationToken);
 
             // Check the response's status code
             if (response.ReturnedError())
@@ -139,14 +140,14 @@ namespace EasyPost._base
         /// <param name="parameters">Optional parameters to use for the request.</param>
         /// <returns>Whether request was successful.</returns>
         // ReSharper disable once UnusedMethodReturnValue.Global
-        internal async Task<bool> RequestAsync(Method method, string endpoint, ApiVersion apiVersion, Dictionary<string, object>? parameters = null)
+        internal async Task<bool> RequestAsync(Method method, string endpoint, ApiVersion apiVersion, CancellationToken cancellationToken, Dictionary<string, object>? parameters = null)
         {
             // Build the request
             Dictionary<string, string> headers = _configuration.GetHeaders(apiVersion);
             Request request = new(ApiBaseInUse, endpoint, method, apiVersion, parameters, headers);
 
             // Execute the request
-            HttpResponseMessage response = await ExecuteRequest(request.AsHttpRequestMessage());
+            HttpResponseMessage response = await ExecuteRequest(request.AsHttpRequestMessage(), cancellationToken);
 
             // Check whether the HTTP request produced an error (3xx, 4xx or 5xx status code) or not
             bool errorRaised = response.ReturnedNoError();

--- a/EasyPost/_base/EasyPostService.cs
+++ b/EasyPost/_base/EasyPostService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 #pragma warning disable SA1300
@@ -27,9 +28,9 @@ namespace EasyPost._base
         /// <param name="overrideApiVersion">Override API version hit for HTTP request. Defaults to general availability.</param>
         /// <typeparam name="T">Type of object to return from request.</typeparam>
         /// <returns>A T-type object.</returns>
-        protected async Task<T> RequestAsync<T>(Http.Method method, string endpoint, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null)
+        protected async Task<T> RequestAsync<T>(Http.Method method, string endpoint, CancellationToken cancellationToken, Dictionary<string, object>? parameters = null, string? rootElement = null, ApiVersion? overrideApiVersion = null)
             where T : class
-            => await Client.RequestAsync<T>(method, endpoint, overrideApiVersion ?? ApiVersion.Current, parameters, rootElement).ConfigureAwait(false);
+            => await Client.RequestAsync<T>(method, endpoint, overrideApiVersion ?? ApiVersion.Current, cancellationToken, parameters, rootElement).ConfigureAwait(false);
 
         /// <summary>
         ///     Make an HTTP request to the EasyPost API.
@@ -40,7 +41,7 @@ namespace EasyPost._base
         /// <param name="overrideApiVersion">Override API version hit for HTTP request. Defaults to general availability.</param>
         /// <returns>None.</returns>
         // ReSharper disable once MemberCanBePrivate.Global
-        protected async Task RequestAsync(Http.Method method, string url, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Client.RequestAsync(method, url, overrideApiVersion ?? ApiVersion.Current, parameters).ConfigureAwait(false);
+        protected async Task RequestAsync(Http.Method method, string url, CancellationToken cancellationToken, Dictionary<string, object>? parameters = null, ApiVersion? overrideApiVersion = null) => await Client.RequestAsync(method, url, overrideApiVersion ?? ApiVersion.Current, cancellationToken, parameters).ConfigureAwait(false);
 
         private bool _isDisposed;
 


### PR DESCRIPTION
# Description

- Add optional cancellation token parameter to all HTTP functions, to allow end users to cancel operations if needed. This is [standard practice for async functions](https://medium.com/geekculture/how-to-support-the-http-request-cancelation-in-net-core-4b5561d9605d), especially network-related ones.
  - Stripe does it: https://github.com/stripe/stripe-dotnet/blob/c8bc4fce820ed394de85254a7e5a8302fe7b8182/src/Stripe.net/Services/TestHelpers/Issuing/Cards/CardService.cs#L28
- For functions that use the Parameters objects rather than dictionaries, consolidate all explicit parameters into the Parameters object, so that all functions accepting Parameters objects have one of these two signatures:
```csharp
Create(myParameterSet)
```

```csharp
Update(objectId, myParameterSet)
```
  - This only impacts the `All` function for retrieving all reports, which had an explicit separate `type` parameter that is now part of the `Report.All` parameter set passed into the function.
- Parameter-object functions no longer redirect to the Dictionary equivalent, but instead are self-contained. This makes them easier to maintain and read, and will make migration easier when Dictionary functions are eventually dropped entirely.
- Removed default "pdf" value for file format for labels and scan forms. Users must now explicitly declare what format they want.
- Removed ability to use `Retrieve` function in User service without passing in an ID to retrieve self.
  - `Retrieve` now requires a user ID be provided. To retrieve self, users should use the `RetreiveMe` function explicitly.
 

# Testing

- Updated unit tests as needed (file format required parameter)
  - No cassettes needed re-recording, suggesting that parameter changes do not impact the final HTTP request

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
