### PR TITLE
[chore] Can update a Webhook without parameters

### DIFF
--- a/EasyPost.Tests/ServicesTests/WebhookServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/WebhookServiceTest.cs
@@ -161,7 +161,7 @@ namespace EasyPost.Tests.ServicesTests
                 Thread.Sleep(10000); // Wait enough time to process
             }
 
-            webhook = await Client.Webhook.Update(webhook.Id);
+            webhook = await Client.Webhook.Update(webhook.Id, new Dictionary<string, object>());
 
             Assert.IsType<Webhook>(webhook);
             Assert.StartsWith("hook_", webhook.Id);

--- a/EasyPost/Services/WebhookService.cs
+++ b/EasyPost/Services/WebhookService.cs
@@ -92,8 +92,8 @@ namespace EasyPost.Services
         ///     Enable a disabled <see cref="Webhook"/> or alter its secret.
         ///     <a href="https://www.easypost.com/docs/api#update-a-webhook">Related API documentation</a>.
         /// </summary>
-        /// <param name="parameters">Data to update <see cref="Webhook"/> with.</param>
         /// <param name="id">The ID of the <see cref="Webhook"/> to update.</param>
+        /// <param name="parameters">Data to update <see cref="Webhook"/> with.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> to use for the HTTP request.</param>
         /// <returns>The updated <see cref="Webhook"/>.</returns>
         [CrudOperations.Update]
@@ -106,14 +106,14 @@ namespace EasyPost.Services
         ///     Enable a disabled <see cref="Webhook"/> or alter its secret.
         ///     <a href="https://www.easypost.com/docs/api#update-a-webhook">Related API documentation</a>.
         /// </summary>
-        /// <param name="parameters">Data to update <see cref="Webhook"/> with.</param>
         /// <param name="id">The ID of the <see cref="Webhook"/> to update.</param>
+        /// <param name="parameters">Optional data to update <see cref="Webhook"/> with.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> to use for the HTTP request.</param>
         /// <returns>The updated <see cref="Webhook"/>.</returns>
         [CrudOperations.Update]
-        public async Task<Webhook> Update(string id, Parameters.Webhook.Update parameters, CancellationToken cancellationToken = default)
+        public async Task<Webhook> Update(string id, Parameters.Webhook.Update? parameters = null, CancellationToken cancellationToken = default)
         {
-            return await RequestAsync<Webhook>(Method.Put, $"webhooks/{id}", cancellationToken, parameters.ToDictionary());
+            return await RequestAsync<Webhook>(Method.Put, $"webhooks/{id}", cancellationToken, parameters?.ToDictionary());
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

Users can call `client.Webhook.Update` without a parameter set.

Also fix ordering of parameters in docstrings

# Testing

- Unit test updated as needed

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
