### PR TITLE
[chore] Open parameter set .ToDictionary() function to downsteam mods

### DIFF
--- a/EasyPost/Parameters/BaseParameters.cs
+++ b/EasyPost/Parameters/BaseParameters.cs
@@ -39,7 +39,7 @@ namespace EasyPost.Parameters
         ///     Convert this parameter object to a dictionary for an HTTP request.
         /// </summary>
         /// <returns><see cref="Dictionary{String,TValue}" /> of parameters.</returns>
-        internal virtual Dictionary<string, object> ToDictionary()
+        public virtual Dictionary<string, object> ToDictionary()
         {
             // NOTE: This method is marked internally on purpose.
             // Bad stuff could happen if we allow end-users to convert a parameter object to a dictionary themselves and try to use it in the normal functions

--- a/EasyPost/Parameters/Beta/CarrierMetadata/Retrieve.cs
+++ b/EasyPost/Parameters/Beta/CarrierMetadata/Retrieve.cs
@@ -29,7 +29,7 @@ namespace EasyPost.Parameters.Beta.CarrierMetadata
         ///     Override the default <see cref="BaseParameters.ToDictionary"/> method to handle the unique serialization requirements for this parameter set.
         /// </summary>
         /// <returns>A <see cref="Dictionary{TKey,TValue}"/>.</returns>
-        internal override Dictionary<string, object> ToDictionary()
+        public override Dictionary<string, object> ToDictionary()
         {
             Dictionary<string, object> data = new();
 

--- a/EasyPost/Parameters/Shipment/GenerateForm.cs
+++ b/EasyPost/Parameters/Shipment/GenerateForm.cs
@@ -29,7 +29,7 @@ namespace EasyPost.Parameters.Shipment
         /// </summary>
         /// <returns>A <see cref="Dictionary{TKey,TValue}"/>.</returns>
         /// <exception cref="MissingParameterError">Thrown when the form type was not provided.</exception>
-        internal override Dictionary<string, object> ToDictionary()
+        public override Dictionary<string, object> ToDictionary()
         {
             if (Type == null)
             {

--- a/EasyPost/Parameters/Tracker/CreateList.cs
+++ b/EasyPost/Parameters/Tracker/CreateList.cs
@@ -40,7 +40,7 @@ namespace EasyPost.Parameters.Tracker
         ///     Override the default <see cref="BaseParameters.ToDictionary"/> method to handle the unique serialization requirements for this parameter set.
         /// </summary>
         /// <returns>A <see cref="Dictionary{TKey,TValue}"/>.</returns>
-        internal override Dictionary<string, object> ToDictionary()
+        public override Dictionary<string, object> ToDictionary()
         {
             Dictionary<string, object> data = new Dictionary<string, object>();
             Trackers.Each((index, tracker) =>


### PR DESCRIPTION
# Description

Follow-up to https://github.com/EasyPost/easypost-csharp/pull/468, the internal `.ToDictionary()` function needs to be public so end-users can override it as needed for custom Parameter sets.

# Testing

- N/A

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
