### PR TITLE
[fix] Make response object constructors public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Constructors for all response objects (e.g. `EasyPost.Models.API.Address`) are publicly available for end-users to construct their own objects for testing purposes.
+
 ## v5.0.0 (2023-05-15)
 
 ### Breaking Changes

--- a/EasyPost.Integration/Basics.cs
+++ b/EasyPost.Integration/Basics.cs
@@ -16,7 +16,7 @@ public class Basics
     {
         var address = new Address();
         var addressCollection = new AddressCollection();
-        var apiKey  = new ApiKey();
+        var apiKey = new ApiKey();
         var apiKeyCollection = new ApiKeyCollection();
         var batch = new Batch();
         var batchCollection = new BatchCollection();

--- a/EasyPost.Integration/Basics.cs
+++ b/EasyPost.Integration/Basics.cs
@@ -1,11 +1,84 @@
+using EasyPost.Integration.Utilities.Attributes;
+using EasyPost.Models.API;
+using EasyPost.Models.API.Beta;
 using Xunit;
 
 namespace EasyPost.Integration;
 
 public class Basics
 {
-    [Fact]
-    public void Test1()
+    /// <summary>
+    ///     Test that an end-user can locally construct a response object without needing to call the API (response objects have public constructors).
+    ///     If this test can be compiled, then the response objects have public constructors.
+    /// </summary>
+    [Fact, Testing.Access, Testing.Compile]
+    public void TestUserCanLocallyConstructResponseObject()
     {
+        var address = new Address();
+        var addressCollection = new AddressCollection();
+        var apiKey  = new ApiKey();
+        var apiKeyCollection = new ApiKeyCollection();
+        var batch = new Batch();
+        var batchCollection = new BatchCollection();
+        var batchShipment = new BatchShipment();
+        var brand = new Brand();
+        var carbonOffset = new CarbonOffset();
+        var carrier = new Carrier();
+        var carrierAccount = new CarrierAccount();
+        var carrierDetail = new CarrierDetail();
+        var carrierField = new CarrierField();
+        var carrierFields = new CarrierFields();
+        var carrierMetadata = new CarrierMetadata();
+        var carrierType = new CarrierType();
+        var customsInfo = new CustomsInfo();
+        var customsItem = new CustomsItem();
+        var endShipper = new EndShipper();
+        var endShipperCollection = new EndShipperCollection();
+        var error = new Error();
+        var @event = new Event();
+        var eventCollection = new EventCollection();
+        var fee = new Fee();
+        var form = new Form();
+        var insurance = new Insurance();
+        var insuranceCollection = new InsuranceCollection();
+        var message = new Message();
+        var options = new Options();
+        var order = new Order();
+        var parcel = new Parcel();
+        var payload = new Payload();
+        var paymentMethod = new PaymentMethod();
+        var paymentMethodsSummary = new PaymentMethodsSummary();
+        var paymentRefund = new PaymentRefund();
+        var pickup = new Pickup();
+        var pickupCollection = new PickupCollection();
+        var pickupRate = new PickupRate();
+        var postageLabel = new PostageLabel();
+        var predefinedPackage = new PredefinedPackage();
+        var rate = new Rate();
+        var rateWithEstimatedDeliveryDate = new RateWithEstimatedDeliveryDate();
+        var referralCustomer = new ReferralCustomer();
+        var refund = new Refund();
+        var report = new Report();
+        var reportCollection = new ReportCollection();
+        var scanForm = new ScanForm();
+        var scanFormCollection = new ScanFormCollection();
+        var serviceLevel = new ServiceLevel();
+        var shipment = new Shipment();
+        var shipmentCollection = new ShipmentCollection();
+        var shipmentOption = new ShipmentOption();
+        var smartRate = new SmartRate();
+        var statelessRate = new StatelessRate();
+        var supportedFeature = new SupportedFeature();
+        var taxIdentifier = new TaxIdentifier();
+        var timeInTransit = new TimeInTransit();
+        var tracker = new Tracker();
+        var trackerCollection = new TrackerCollection();
+        var trackingDetail = new TrackingDetail();
+        var trackingLocation = new TrackingLocation();
+        var user = new User();
+        var verification = new Verification();
+        var verificationDetails = new VerificationDetails();
+        var verifications = new Verifications();
+        var webhook = new Webhook();
     }
 }

--- a/EasyPost.Integration/EasyPost.Integration.csproj
+++ b/EasyPost.Integration/EasyPost.Integration.csproj
@@ -24,4 +24,8 @@
         </PackageReference>
     </ItemGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\EasyPost\EasyPost.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/EasyPost.Integration/Utilities/Attributes/TestType.cs
+++ b/EasyPost.Integration/Utilities/Attributes/TestType.cs
@@ -13,7 +13,7 @@ namespace EasyPost.Integration.Utilities.Attributes
         internal sealed class Access : BaseCustomAttribute
         {
         }
-        
+
         /// <summary>
         ///     Marks an integration test that is testing compile-time behavior (test that code as written will compile)
         /// </summary>

--- a/EasyPost.Integration/Utilities/Attributes/TestType.cs
+++ b/EasyPost.Integration/Utilities/Attributes/TestType.cs
@@ -1,0 +1,25 @@
+using EasyPost.Utilities.Internal.Attributes;
+
+// ReSharper disable InconsistentNaming
+
+namespace EasyPost.Integration.Utilities.Attributes
+{
+    internal static class Testing
+    {
+        /// <summary>
+        ///     Marks an integration test that is testing access levels (test that users can/cannot access a function or property as expected)
+        /// </summary>
+        [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+        internal sealed class Access : BaseCustomAttribute
+        {
+        }
+        
+        /// <summary>
+        ///     Marks an integration test that is testing compile-time behavior (test that code as written will compile)
+        /// </summary>
+        [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+        internal sealed class Compile : BaseCustomAttribute
+        {
+        }
+    }
+}

--- a/EasyPost/Models/API/Address.cs
+++ b/EasyPost/Models/API/Address.cs
@@ -117,13 +117,6 @@ namespace EasyPost.Models.API
         public string? Zip { get; set; }
 
         #endregion
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Address"/> class.
-        /// </summary>
-        internal Address()
-        {
-        }
     }
 #pragma warning restore CA1724 // Naming conflicts with Parameters.Address
 
@@ -141,13 +134,6 @@ namespace EasyPost.Models.API
         public List<Address>? Addresses { get; set; }
 
         #endregion
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="AddressCollection"/> class.
-        /// </summary>
-        internal AddressCollection()
-        {
-        }
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/ApiKey.cs
+++ b/EasyPost/Models/API/ApiKey.cs
@@ -18,13 +18,6 @@ namespace EasyPost.Models.API
         public string? Key { get; set; }
 
         #endregion
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="ApiKey"/> class.
-        /// </summary>
-        internal ApiKey()
-        {
-        }
     }
 
     /// <summary>
@@ -47,12 +40,5 @@ namespace EasyPost.Models.API
         public List<ApiKey>? Keys { get; set; }
 
         #endregion
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="ApiKeyCollection"/> class.
-        /// </summary>
-        internal ApiKeyCollection()
-        {
-        }
     }
 }

--- a/EasyPost/Models/API/Batch.cs
+++ b/EasyPost/Models/API/Batch.cs
@@ -85,13 +85,6 @@ namespace EasyPost.Models.API
         public Dictionary<string, int>? Status { get; set; }
 
         #endregion
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Batch"/> class.
-        /// </summary>
-        internal Batch()
-        {
-        }
     }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.Batch
 
@@ -109,13 +102,6 @@ namespace EasyPost.Models.API
         public List<Batch>? Batches { get; set; }
 
         #endregion
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="BatchCollection"/> class.
-        /// </summary>
-        internal BatchCollection()
-        {
-        }
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/BatchShipment.cs
+++ b/EasyPost/Models/API/BatchShipment.cs
@@ -44,12 +44,5 @@ namespace EasyPost.Models.API
         public string? TrackingCode { get; set; }
 
         #endregion
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="BatchShipment"/> class.
-        /// </summary>
-        internal BatchShipment()
-        {
-        }
     }
 }

--- a/EasyPost/Models/API/Beta/PaymentRefund.cs
+++ b/EasyPost/Models/API/Beta/PaymentRefund.cs
@@ -43,12 +43,5 @@ namespace EasyPost.Models.API.Beta
         public List<Error>? Errors { get; set; }
 
         #endregion
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="PaymentRefund"/> class.
-        /// </summary>
-        internal PaymentRefund()
-        {
-        }
     }
 }

--- a/EasyPost/Models/API/Beta/StatelessRate.cs
+++ b/EasyPost/Models/API/Beta/StatelessRate.cs
@@ -43,9 +43,5 @@ namespace EasyPost.Models.API.Beta
         public string? ShipmentId { get; set; }
 
         #endregion
-
-        internal StatelessRate()
-        {
-        }
     }
 }

--- a/EasyPost/Models/API/Brand.cs
+++ b/EasyPost/Models/API/Brand.cs
@@ -67,12 +67,5 @@ namespace EasyPost.Models.API
         public string? UserId { get; set; }
 
         #endregion
-
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Brand"/> class.
-        /// </summary>
-        internal Brand()
-        {
-        }
     }
 }

--- a/EasyPost/Models/API/CarbonOffset.cs
+++ b/EasyPost/Models/API/CarbonOffset.cs
@@ -30,12 +30,5 @@ namespace EasyPost.Models.API
         public string? Price { get; set; }
 
         #endregion
-
-        /// <summary>
-        ///   Initializes a new instance of the <see cref="CarbonOffset"/> class.
-        /// </summary>
-        internal CarbonOffset()
-        {
-        }
     }
 }

--- a/EasyPost/Models/API/CarrierAccount.cs
+++ b/EasyPost/Models/API/CarrierAccount.cs
@@ -70,7 +70,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.CarrierAccount

--- a/EasyPost/Models/API/CarrierAccount.cs
+++ b/EasyPost/Models/API/CarrierAccount.cs
@@ -70,12 +70,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="CarrierAccount"/> class.
-        /// </summary>
-        internal CarrierAccount()
-        {
-        }
+        
     }
 }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.CarrierAccount

--- a/EasyPost/Models/API/CarrierDetail.cs
+++ b/EasyPost/Models/API/CarrierDetail.cs
@@ -79,11 +79,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="CarrierDetail"/> class.
-        /// </summary>
-        internal CarrierDetail()
-        {
-        }
+        
     }
 }

--- a/EasyPost/Models/API/CarrierDetail.cs
+++ b/EasyPost/Models/API/CarrierDetail.cs
@@ -79,6 +79,5 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }

--- a/EasyPost/Models/API/CarrierType.cs
+++ b/EasyPost/Models/API/CarrierType.cs
@@ -52,6 +52,5 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }

--- a/EasyPost/Models/API/CarrierType.cs
+++ b/EasyPost/Models/API/CarrierType.cs
@@ -52,11 +52,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="CarrierType"/> class.
-        /// </summary>
-        internal CarrierType()
-        {
-        }
+        
     }
 }

--- a/EasyPost/Models/API/CustomsInfo.cs
+++ b/EasyPost/Models/API/CustomsInfo.cs
@@ -140,12 +140,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="CustomsInfo"/> class.
-        /// </summary>
-        internal CustomsInfo()
-        {
-        }
+        
     }
 #pragma warning restore CA1724 // Naming conflicts with Parameters.CustomInfo
 }

--- a/EasyPost/Models/API/CustomsInfo.cs
+++ b/EasyPost/Models/API/CustomsInfo.cs
@@ -140,7 +140,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 #pragma warning restore CA1724 // Naming conflicts with Parameters.CustomInfo
 }

--- a/EasyPost/Models/API/CustomsItem.cs
+++ b/EasyPost/Models/API/CustomsItem.cs
@@ -64,12 +64,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="CustomsItem"/> class.
-        /// </summary>
-        internal CustomsItem()
-        {
-        }
+        
     }
 }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.CustomsItem

--- a/EasyPost/Models/API/CustomsItem.cs
+++ b/EasyPost/Models/API/CustomsItem.cs
@@ -64,7 +64,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.CustomsItem

--- a/EasyPost/Models/API/EndShipper.cs
+++ b/EasyPost/Models/API/EndShipper.cs
@@ -89,7 +89,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.EndShipper
 
@@ -107,8 +106,6 @@ namespace EasyPost.Models.API
         public List<EndShipper>? EndShippers { get; set; }
 
         #endregion
-
-        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/EndShipper.cs
+++ b/EasyPost/Models/API/EndShipper.cs
@@ -89,12 +89,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="EndShipper"/> class.
-        /// </summary>
-        internal EndShipper()
-        {
-        }
+        
     }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.EndShipper
 
@@ -113,12 +108,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="EndShipperCollection"/> class.
-        /// </summary>
-        internal EndShipperCollection()
-        {
-        }
+        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/Error.cs
+++ b/EasyPost/Models/API/Error.cs
@@ -70,12 +70,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Error"/> class.
-        /// </summary>
-        internal Error()
-        {
-        }
+        
 
         /// <summary>
         ///     Traverse the returned element for error messages.

--- a/EasyPost/Models/API/Error.cs
+++ b/EasyPost/Models/API/Error.cs
@@ -70,8 +70,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
-
         /// <summary>
         ///     Traverse the returned element for error messages.
         ///     This will handle potential inconsistent data structures in EasyPost error messages.

--- a/EasyPost/Models/API/Event.cs
+++ b/EasyPost/Models/API/Event.cs
@@ -64,12 +64,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Event"/> class.
-        /// </summary>
-        internal Event()
-        {
-        }
+        
     }
 #pragma warning restore CA1716
 #pragma warning restore CA1724 // Naming conflicts with Parameters.Event
@@ -89,12 +84,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="EventCollection"/> class.
-        /// </summary>
-        internal EventCollection()
-        {
-        }
+        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/Event.cs
+++ b/EasyPost/Models/API/Event.cs
@@ -64,7 +64,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 #pragma warning restore CA1716
 #pragma warning restore CA1724 // Naming conflicts with Parameters.Event
@@ -83,8 +82,6 @@ namespace EasyPost.Models.API
         public List<Event>? Events { get; set; }
 
         #endregion
-
-        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/Fee.cs
+++ b/EasyPost/Models/API/Fee.cs
@@ -37,11 +37,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Fee"/> class.
-        /// </summary>
-        internal Fee()
-        {
-        }
+        
     }
 }

--- a/EasyPost/Models/API/Fee.cs
+++ b/EasyPost/Models/API/Fee.cs
@@ -37,6 +37,5 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }

--- a/EasyPost/Models/API/Form.cs
+++ b/EasyPost/Models/API/Form.cs
@@ -31,11 +31,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Form"/> class.
-        /// </summary>
-        internal Form()
-        {
-        }
+        
     }
 }

--- a/EasyPost/Models/API/Form.cs
+++ b/EasyPost/Models/API/Form.cs
@@ -31,6 +31,5 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }

--- a/EasyPost/Models/API/Insurance.cs
+++ b/EasyPost/Models/API/Insurance.cs
@@ -88,7 +88,6 @@ namespace EasyPost.Models.API
         public Fee? Fee { get; set; }
         #endregion
 
-        
     }
 #pragma warning restore CA1724 // Naming conflicts with Parameters.Insurance
 
@@ -106,8 +105,6 @@ namespace EasyPost.Models.API
         public List<Insurance>? Insurances { get; set; }
 
         #endregion
-
-        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/Insurance.cs
+++ b/EasyPost/Models/API/Insurance.cs
@@ -88,12 +88,7 @@ namespace EasyPost.Models.API
         public Fee? Fee { get; set; }
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Insurance"/> class.
-        /// </summary>
-        internal Insurance()
-        {
-        }
+        
     }
 #pragma warning restore CA1724 // Naming conflicts with Parameters.Insurance
 
@@ -112,12 +107,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="InsuranceCollection"/> class.
-        /// </summary>
-        internal InsuranceCollection()
-        {
-        }
+        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/Message.cs
+++ b/EasyPost/Models/API/Message.cs
@@ -37,6 +37,5 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }

--- a/EasyPost/Models/API/Message.cs
+++ b/EasyPost/Models/API/Message.cs
@@ -37,11 +37,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Message"/> class.
-        /// </summary>
-        internal Message()
-        {
-        }
+        
     }
 }

--- a/EasyPost/Models/API/Options.cs
+++ b/EasyPost/Models/API/Options.cs
@@ -947,6 +947,5 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }

--- a/EasyPost/Models/API/Options.cs
+++ b/EasyPost/Models/API/Options.cs
@@ -950,7 +950,7 @@ namespace EasyPost.Models.API
         /// <summary>
         ///     Initializes a new instance of the <see cref="Options" /> class.
         /// </summary>
-        internal Options()
+        public Options()
         {
         }
     }

--- a/EasyPost/Models/API/Options.cs
+++ b/EasyPost/Models/API/Options.cs
@@ -947,11 +947,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Options" /> class.
-        /// </summary>
-        public Options()
-        {
-        }
+        
     }
 }

--- a/EasyPost/Models/API/Order.cs
+++ b/EasyPost/Models/API/Order.cs
@@ -44,12 +44,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Order"/> class.
-        /// </summary>
-        internal Order()
-        {
-        }
+        
 
         /// <summary>
         ///     Get the lowest rate for this Order.

--- a/EasyPost/Models/API/Order.cs
+++ b/EasyPost/Models/API/Order.cs
@@ -44,8 +44,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
-
         /// <summary>
         ///     Get the lowest rate for this Order.
         /// </summary>

--- a/EasyPost/Models/API/Parcel.cs
+++ b/EasyPost/Models/API/Parcel.cs
@@ -24,7 +24,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.Parcel

--- a/EasyPost/Models/API/Parcel.cs
+++ b/EasyPost/Models/API/Parcel.cs
@@ -24,12 +24,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Parcel"/> class.
-        /// </summary>
-        internal Parcel()
-        {
-        }
+        
     }
 }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.Parcel

--- a/EasyPost/Models/API/Payload.cs
+++ b/EasyPost/Models/API/Payload.cs
@@ -28,6 +28,5 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }

--- a/EasyPost/Models/API/Payload.cs
+++ b/EasyPost/Models/API/Payload.cs
@@ -28,11 +28,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Payload"/> class.
-        /// </summary>
-        internal Payload()
-        {
-        }
+        
     }
 }

--- a/EasyPost/Models/API/PaymentMethod.cs
+++ b/EasyPost/Models/API/PaymentMethod.cs
@@ -76,10 +76,6 @@ namespace EasyPost.Models.API
             }
         }
 
-        internal PaymentMethod()
-        {
-        }
-
         /// <summary>
         ///     Payment method priority.
         /// </summary>

--- a/EasyPost/Models/API/PaymentMethodsSummary.cs
+++ b/EasyPost/Models/API/PaymentMethodsSummary.cs
@@ -17,11 +17,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="PaymentMethodsSummary"/> class.
-        /// </summary>
-        internal PaymentMethodsSummary()
-        {
-        }
+        
     }
 }

--- a/EasyPost/Models/API/PaymentMethodsSummary.cs
+++ b/EasyPost/Models/API/PaymentMethodsSummary.cs
@@ -17,6 +17,5 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }

--- a/EasyPost/Models/API/Pickup.cs
+++ b/EasyPost/Models/API/Pickup.cs
@@ -52,8 +52,6 @@ namespace EasyPost.Models.API
         /// <returns>List of Rate objects.</returns>
         private IEnumerable<Rate> Rates => PickupRates != null ? PickupRates.Cast<Rate>().ToList() : new List<Rate>();
 
-        
-
         /// <summary>
         ///     Get the lowest rate for this Pickup.
         /// </summary>
@@ -80,8 +78,6 @@ namespace EasyPost.Models.API
         public List<Pickup>? Pickups { get; set; }
 
         #endregion
-
-        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/Pickup.cs
+++ b/EasyPost/Models/API/Pickup.cs
@@ -52,12 +52,7 @@ namespace EasyPost.Models.API
         /// <returns>List of Rate objects.</returns>
         private IEnumerable<Rate> Rates => PickupRates != null ? PickupRates.Cast<Rate>().ToList() : new List<Rate>();
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Pickup"/> class.
-        /// </summary>
-        internal Pickup()
-        {
-        }
+        
 
         /// <summary>
         ///     Get the lowest rate for this Pickup.
@@ -86,12 +81,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="PickupCollection"/> class.
-        /// </summary>
-        internal PickupCollection()
-        {
-        }
+        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/PickupRate.cs
+++ b/EasyPost/Models/API/PickupRate.cs
@@ -14,6 +14,5 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }

--- a/EasyPost/Models/API/PickupRate.cs
+++ b/EasyPost/Models/API/PickupRate.cs
@@ -14,11 +14,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="PickupRate"/> class.
-        /// </summary>
-        internal PickupRate()
-        {
-        }
+        
     }
 }

--- a/EasyPost/Models/API/PostageLabel.cs
+++ b/EasyPost/Models/API/PostageLabel.cs
@@ -38,6 +38,5 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }

--- a/EasyPost/Models/API/PostageLabel.cs
+++ b/EasyPost/Models/API/PostageLabel.cs
@@ -38,11 +38,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="PostageLabel"/> class.
-        /// </summary>
-        internal PostageLabel()
-        {
-        }
+        
     }
 }

--- a/EasyPost/Models/API/Rate.cs
+++ b/EasyPost/Models/API/Rate.cs
@@ -47,12 +47,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Rate"/> class.
-        /// </summary>
-        internal Rate()
-        {
-        }
+        
     }
 }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.Beta.Rate

--- a/EasyPost/Models/API/Rate.cs
+++ b/EasyPost/Models/API/Rate.cs
@@ -47,7 +47,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.Beta.Rate

--- a/EasyPost/Models/API/RateWithEstimatedDeliveryDate.cs
+++ b/EasyPost/Models/API/RateWithEstimatedDeliveryDate.cs
@@ -24,12 +24,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="RateWithEstimatedDeliveryDate"/> class.
-        /// </summary>
-        internal RateWithEstimatedDeliveryDate()
-        {
-        }
+        
     }
 
     /// <summary>
@@ -59,11 +54,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="TimeInTransitDetails"/> class.
-        /// </summary>
-        internal TimeInTransitDetails()
-        {
-        }
+        
     }
 }

--- a/EasyPost/Models/API/RateWithEstimatedDeliveryDate.cs
+++ b/EasyPost/Models/API/RateWithEstimatedDeliveryDate.cs
@@ -24,7 +24,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 
     /// <summary>
@@ -54,6 +53,5 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }

--- a/EasyPost/Models/API/ReferralCustomer.cs
+++ b/EasyPost/Models/API/ReferralCustomer.cs
@@ -11,7 +11,6 @@ namespace EasyPost.Models.API
     /// </summary>
     public class ReferralCustomer : BaseUser, Parameters.IReferralCustomerParameter
     {
-        
     }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.ReferralCustomer
 
@@ -29,8 +28,6 @@ namespace EasyPost.Models.API
         public List<ReferralCustomer>? ReferralCustomers { get; set; }
 
         #endregion
-
-        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/ReferralCustomer.cs
+++ b/EasyPost/Models/API/ReferralCustomer.cs
@@ -11,12 +11,7 @@ namespace EasyPost.Models.API
     /// </summary>
     public class ReferralCustomer : BaseUser, Parameters.IReferralCustomerParameter
     {
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="ReferralCustomer"/> class.
-        /// </summary>
-        internal ReferralCustomer()
-        {
-        }
+        
     }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.ReferralCustomer
 
@@ -35,12 +30,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="ReferralCustomerCollection"/> class.
-        /// </summary>
-        internal ReferralCustomerCollection()
-        {
-        }
+        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/Refund.cs
+++ b/EasyPost/Models/API/Refund.cs
@@ -27,7 +27,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.Refund
 
@@ -45,8 +44,6 @@ namespace EasyPost.Models.API
         public List<Refund>? Refunds { get; set; }
 
         #endregion
-
-        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/Refund.cs
+++ b/EasyPost/Models/API/Refund.cs
@@ -27,12 +27,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Refund"/> class.
-        /// </summary>
-        internal Refund()
-        {
-        }
+        
     }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.Refund
 
@@ -51,12 +46,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="RefundCollection"/> class.
-        /// </summary>
-        internal RefundCollection()
-        {
-        }
+        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/Report.cs
+++ b/EasyPost/Models/API/Report.cs
@@ -30,7 +30,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.Report
 
@@ -48,8 +47,6 @@ namespace EasyPost.Models.API
         public List<Report>? Reports { get; set; }
 
         #endregion
-
-        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/Report.cs
+++ b/EasyPost/Models/API/Report.cs
@@ -30,12 +30,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Report"/> class.
-        /// </summary>
-        internal Report()
-        {
-        }
+        
     }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.Report
 
@@ -54,12 +49,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="ReportCollection"/> class.
-        /// </summary>
-        internal ReportCollection()
-        {
-        }
+        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/ScanForm.cs
+++ b/EasyPost/Models/API/ScanForm.cs
@@ -35,12 +35,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="ScanForm"/> class.
-        /// </summary>
-        internal ScanForm()
-        {
-        }
+        
     }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.ScanForm
 
@@ -59,12 +54,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="ScanFormCollection"/> class.
-        /// </summary>
-        internal ScanFormCollection()
-        {
-        }
+        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/ScanForm.cs
+++ b/EasyPost/Models/API/ScanForm.cs
@@ -35,7 +35,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.ScanForm
 
@@ -53,8 +52,6 @@ namespace EasyPost.Models.API
         public List<ScanForm>? ScanForms { get; set; }
 
         #endregion
-
-        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/Shipment.cs
+++ b/EasyPost/Models/API/Shipment.cs
@@ -80,8 +80,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
-
         /// <summary>
         ///     Get the lowest rate for this Shipment.
         /// </summary>
@@ -118,8 +116,6 @@ namespace EasyPost.Models.API
         public List<Shipment>? Shipments { get; set; }
 
         #endregion
-
-        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/Shipment.cs
+++ b/EasyPost/Models/API/Shipment.cs
@@ -80,12 +80,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Shipment"/> class.
-        /// </summary>
-        internal Shipment()
-        {
-        }
+        
 
         /// <summary>
         ///     Get the lowest rate for this Shipment.
@@ -124,12 +119,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="ShipmentCollection" /> class.
-        /// </summary>
-        internal ShipmentCollection()
-        {
-        }
+        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/SmartRate.cs
+++ b/EasyPost/Models/API/SmartRate.cs
@@ -46,6 +46,5 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }

--- a/EasyPost/Models/API/SmartRate.cs
+++ b/EasyPost/Models/API/SmartRate.cs
@@ -46,11 +46,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="SmartRate"/> class.
-        /// </summary>
-        internal SmartRate()
-        {
-        }
+        
     }
 }

--- a/EasyPost/Models/API/TaxIdentifier.cs
+++ b/EasyPost/Models/API/TaxIdentifier.cs
@@ -22,12 +22,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="TaxIdentifier"/> class.
-        /// </summary>
-        internal TaxIdentifier()
-        {
-        }
+        
     }
 }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.TaxIdentifier

--- a/EasyPost/Models/API/TaxIdentifier.cs
+++ b/EasyPost/Models/API/TaxIdentifier.cs
@@ -22,7 +22,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.TaxIdentifier

--- a/EasyPost/Models/API/TimeInTransit.cs
+++ b/EasyPost/Models/API/TimeInTransit.cs
@@ -27,12 +27,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="TimeInTransit"/> class.
-        /// </summary>
-        internal TimeInTransit()
-        {
-        }
+        
 
         /// <summary>
         ///     Get the value of a specific percentile by its corresponding SmartRateAccuracy enum.

--- a/EasyPost/Models/API/TimeInTransit.cs
+++ b/EasyPost/Models/API/TimeInTransit.cs
@@ -27,8 +27,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
-
         /// <summary>
         ///     Get the value of a specific percentile by its corresponding SmartRateAccuracy enum.
         /// </summary>

--- a/EasyPost/Models/API/Tracker.cs
+++ b/EasyPost/Models/API/Tracker.cs
@@ -42,7 +42,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.Tracker
 
@@ -60,8 +59,6 @@ namespace EasyPost.Models.API
         public List<Tracker>? Trackers { get; set; }
 
         #endregion
-
-        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/Tracker.cs
+++ b/EasyPost/Models/API/Tracker.cs
@@ -42,12 +42,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Tracker"/> class.
-        /// </summary>
-        internal Tracker()
-        {
-        }
+        
     }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.Tracker
 
@@ -66,12 +61,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="TrackerCollection"/> class.
-        /// </summary>
-        internal TrackerCollection()
-        {
-        }
+        
 
         /// <summary>
         ///     Construct the parameter set for retrieving the next page of this paginated collection.

--- a/EasyPost/Models/API/TrackingDetail.cs
+++ b/EasyPost/Models/API/TrackingDetail.cs
@@ -28,6 +28,5 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }

--- a/EasyPost/Models/API/TrackingDetail.cs
+++ b/EasyPost/Models/API/TrackingDetail.cs
@@ -28,11 +28,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="TrackingDetail"/> class.
-        /// </summary>
-        internal TrackingDetail()
-        {
-        }
+        
     }
 }

--- a/EasyPost/Models/API/TrackingLocation.cs
+++ b/EasyPost/Models/API/TrackingLocation.cs
@@ -21,11 +21,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="TrackingLocation"/> class.
-        /// </summary>
-        internal TrackingLocation()
-        {
-        }
+        
     }
 }

--- a/EasyPost/Models/API/TrackingLocation.cs
+++ b/EasyPost/Models/API/TrackingLocation.cs
@@ -21,6 +21,5 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }

--- a/EasyPost/Models/API/User.cs
+++ b/EasyPost/Models/API/User.cs
@@ -8,9 +8,6 @@ namespace EasyPost.Models.API
     /// </summary>
     public class User : BaseUser, Parameters.IUserParameter
     {
-        internal User()
-        {
-        }
     }
 }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.User

--- a/EasyPost/Models/API/Verification.cs
+++ b/EasyPost/Models/API/Verification.cs
@@ -20,6 +20,5 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }

--- a/EasyPost/Models/API/Verification.cs
+++ b/EasyPost/Models/API/Verification.cs
@@ -20,11 +20,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Verification"/> class.
-        /// </summary>
-        internal Verification()
-        {
-        }
+        
     }
 }

--- a/EasyPost/Models/API/VerificationDetails.cs
+++ b/EasyPost/Models/API/VerificationDetails.cs
@@ -19,6 +19,5 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }

--- a/EasyPost/Models/API/VerificationDetails.cs
+++ b/EasyPost/Models/API/VerificationDetails.cs
@@ -19,11 +19,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="VerificationDetails"/> class.
-        /// </summary>
-        internal VerificationDetails()
-        {
-        }
+        
     }
 }

--- a/EasyPost/Models/API/Verifications.cs
+++ b/EasyPost/Models/API/Verifications.cs
@@ -17,11 +17,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Verifications"/> class.
-        /// </summary>
-        internal Verifications()
-        {
-        }
+        
     }
 }

--- a/EasyPost/Models/API/Verifications.cs
+++ b/EasyPost/Models/API/Verifications.cs
@@ -17,6 +17,5 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }

--- a/EasyPost/Models/API/Webhook.cs
+++ b/EasyPost/Models/API/Webhook.cs
@@ -19,7 +19,6 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        
     }
 }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.Webhook

--- a/EasyPost/Models/API/Webhook.cs
+++ b/EasyPost/Models/API/Webhook.cs
@@ -19,12 +19,7 @@ namespace EasyPost.Models.API
 
         #endregion
 
-        /// <summary>
-        ///     Initializes a new instance of the <see cref="Webhook"/> class.
-        /// </summary>
-        internal Webhook()
-        {
-        }
+        
     }
 }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.Webhook


### PR DESCRIPTION
# Description

RE: #480 and comments in #380 , fixes #481 

All constructors for response objects are now public, so end-users can construct objects locally without needing to go through the internally-locked-down process of calling the API to retrieve, e.g., an `Address` object.

# Testing

- New integration test to confirm that all constructors for response objects are accessible to end-users

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
