### PR TITLE
[fix] Make `Id` property of all EasyPostObject publicly settable

### DIFF
--- a/EasyPost.Integration/Basics.cs
+++ b/EasyPost.Integration/Basics.cs
@@ -91,7 +91,7 @@ public class Basics
     ///     Test that an end-user can locally construct an object and set its ID.
     /// </summary>
     [Fact, Testing.Access, Testing.Compile]
-    public void UsersCanSetObjectId()
+    public void UserCanSetObjectId()
     {
         // Construct a local object, setting its ID
         var address = new Address { Id = "some_id" };

--- a/EasyPost.Integration/Basics.cs
+++ b/EasyPost.Integration/Basics.cs
@@ -1,6 +1,5 @@
 using EasyPost.Integration.Utilities.Attributes;
 using EasyPost.Models.API;
-using EasyPost.Parameters.Order;
 using Xunit;
 
 namespace EasyPost.Integration;
@@ -163,27 +162,5 @@ public class Basics
         });
 
         // Cannot edit hooks via a constructed client
-    }
-
-    [Fact]
-    public async Task Scratch()
-    {
-        var client = new EasyPost.Client(new ClientConfiguration("not-a-real-api-key"));
-
-        var order = await client.Order.Create(
-            new EasyPost.Parameters.Order.Create
-            {
-                CarrierAccounts = new List<CarrierAccount>
-                {
-                    new CarrierAccount
-                    {
-                        Id = "ca_1",
-                    },
-                    new CarrierAccount
-                    {
-                        Id = "ca_2",
-                    },
-                },
-            });
     }
 }

--- a/EasyPost.Integration/Basics.cs
+++ b/EasyPost.Integration/Basics.cs
@@ -1,5 +1,6 @@
 using EasyPost.Integration.Utilities.Attributes;
 using EasyPost.Models.API;
+using EasyPost.Parameters.Order;
 using Xunit;
 
 namespace EasyPost.Integration;
@@ -11,7 +12,7 @@ public class Basics
     ///     If this test can be compiled, then the response objects have public constructors.
     /// </summary>
     [Fact, Testing.Access, Testing.Compile]
-    public void TestUserCanLocallyConstructResponseObject()
+    public void UserCanLocallyConstructResponseObject()
     {
         var address = new Address();
         var addressCollection = new AddressCollection();
@@ -88,11 +89,24 @@ public class Basics
     }
 
     /// <summary>
+    ///     Test that an end-user can locally construct an object and set its ID.
+    /// </summary>
+    [Fact, Testing.Access, Testing.Compile]
+    public void UsersCanSetObjectId()
+    {
+        // Construct a local object, setting its ID
+        var address = new Address { Id = "some_id" };
+
+        // Assert that the ID was set
+        Assert.Equal("some_id", address.Id);
+    }
+
+    /// <summary>
     ///     Test that an end-user can locally construct all available hooks.
     ///     If this test can be compiled, then the hooks are publicly accessible.
     /// </summary>
     [Fact, Testing.Access, Testing.Compile]
-    public void TestUserCanCreateHooks()
+    public void UserCanCreateHooks()
     {
         // Can set up each hook event handler during construction
         var hooks = new Hooks()
@@ -149,5 +163,27 @@ public class Basics
         });
 
         // Cannot edit hooks via a constructed client
+    }
+
+    [Fact]
+    public async Task Scratch()
+    {
+        var client = new EasyPost.Client(new ClientConfiguration("not-a-real-api-key"));
+
+        var order = await client.Order.Create(
+            new EasyPost.Parameters.Order.Create
+            {
+                CarrierAccounts = new List<CarrierAccount>
+                {
+                    new CarrierAccount
+                    {
+                        Id = "ca_1",
+                    },
+                    new CarrierAccount
+                    {
+                        Id = "ca_2",
+                    },
+                },
+            });
     }
 }

--- a/EasyPost.Integration/Synchronous.cs
+++ b/EasyPost.Integration/Synchronous.cs
@@ -15,7 +15,7 @@ public class Synchronous
     ///     Test that an end-user can run asynchronous code asynchronously
     /// </summary>
     [Fact, Testing.Run]
-    public async void TestUserCanRunAsyncCodeAsynchronously()
+    public async void UserCanRunAsyncCodeAsynchronously()
     {
         var client = Vcr.SetUpTest("async");
 
@@ -42,7 +42,7 @@ public class Synchronous
     ///     Test that an end-user can run asynchronous code synchronously via .Result
     /// </summary>
     [Fact, Testing.Run]
-    public void TestUserCanRunAsyncCodeSynchronouslyViaResult()
+    public void UserCanRunAsyncCodeSynchronouslyViaResult()
     {
         var client = Vcr.SetUpTest("via_result");
 
@@ -69,7 +69,7 @@ public class Synchronous
     ///     Test that an end-user can run asynchronous code synchronously via .GetAwaiter().GetResult()
     /// </summary>
     [Fact, Testing.Run]
-    public void TestUserCanRunAsyncCodeSynchronouslyViaGetAwaiter()
+    public void UserCanRunAsyncCodeSynchronouslyViaGetAwaiter()
     {
         var client = Vcr.SetUpTest("via_get_awaiter");
 
@@ -105,7 +105,7 @@ public class SynchronousMvcController : System.Web.Mvc.Controller
     ///     Test that an end-user can run asynchronous code asynchronously
     /// </summary>
     [Fact, Testing.Run]
-    public async Task<ActionResult> TestUserCanRunAsyncCodeAsynchronously()
+    public async Task<ActionResult> UserCanRunAsyncCodeAsynchronously()
     {
         var client = Vcr.SetUpTest("async");
 
@@ -135,7 +135,7 @@ public class SynchronousMvcController : System.Web.Mvc.Controller
     ///     Ref: https://gist.github.com/leonardochaia/98ce57bcee39c18d88682424a6ffe305
     /// </summary>
     [Fact, Testing.Run]
-    public ActionResult TestUserCanRunAsyncCodeSynchronouslyViaTaskFactory()
+    public ActionResult UserCanRunAsyncCodeSynchronouslyViaTaskFactory()
     {
         var client = Vcr.SetUpTest("via_task_factory");
 

--- a/EasyPost/_base/EasyPostObject.cs
+++ b/EasyPost/_base/EasyPostObject.cs
@@ -24,7 +24,7 @@ namespace EasyPost._base
         ///     The EasyPost ID for this object.
         /// </summary>
         [JsonProperty("id")]
-        public string? Id { get; internal set; }
+        public string? Id { get; set; }
 
         /// <summary>
         ///     The date and time this object was last updated.


### PR DESCRIPTION
# Description

- Make `Id` property of all EasyPostObject public (re #501 )

# Testing

- Add integration test to verify users can set Id of an object
- Remove "Test" prefix from integration tests

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
