### PR TITLE
[bug] Fix bad JSON property for estimated delivery date

### DIFF
--- a/EasyPost.Tests/ServicesTests/ShipmentServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/ShipmentServiceTest.cs
@@ -153,7 +153,8 @@ namespace EasyPost.Tests.ServicesTests
             const bool includeChildren = true;
             const bool purchased = false;
 
-            Dictionary<string, object> filters = new Dictionary<string, object> {
+            Dictionary<string, object> filters = new Dictionary<string, object>
+            {
                 { "include_children", includeChildren },
                 { "purchased", purchased },
             };
@@ -208,7 +209,8 @@ namespace EasyPost.Tests.ServicesTests
             const bool includeChildren = true;
             const bool purchased = false;
 
-            Dictionary<string, object> filters = new Dictionary<string, object> {
+            Dictionary<string, object> filters = new Dictionary<string, object>
+            {
                 { "include_children", includeChildren },
                 { "purchased", purchased },
             };
@@ -598,6 +600,9 @@ namespace EasyPost.Tests.ServicesTests
             foreach (var rate in ratesWithEstimatedDeliveryDates)
             {
                 Assert.NotNull(rate.EasyPostTimeInTransitData);
+                Assert.NotNull(rate.EasyPostTimeInTransitData.EasyPostEstimatedDeliveryDate);
+                Assert.NotNull(rate.EasyPostTimeInTransitData.DaysInTransit);
+                Assert.NotNull(rate.EasyPostTimeInTransitData.PlannedShipDate);
             }
         }
 

--- a/EasyPost.Tests/ServicesTests/WithParameters/ShipmentServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/WithParameters/ShipmentServiceTest.cs
@@ -417,6 +417,9 @@ namespace EasyPost.Tests.ServicesTests.WithParameters
             foreach (var rate in ratesWithEstimatedDeliveryDates)
             {
                 Assert.NotNull(rate.EasyPostTimeInTransitData);
+                Assert.NotNull(rate.EasyPostTimeInTransitData.EasyPostEstimatedDeliveryDate);
+                Assert.NotNull(rate.EasyPostTimeInTransitData.DaysInTransit);
+                Assert.NotNull(rate.EasyPostTimeInTransitData.PlannedShipDate);
             }
         }
 

--- a/EasyPost/Models/API/RateWithEstimatedDeliveryDate.cs
+++ b/EasyPost/Models/API/RateWithEstimatedDeliveryDate.cs
@@ -23,7 +23,6 @@ namespace EasyPost.Models.API
         public TimeInTransitDetails? EasyPostTimeInTransitData { get; set; }
 
         #endregion
-
     }
 
     /// <summary>
@@ -42,8 +41,8 @@ namespace EasyPost.Models.API
         /// <summary>
         ///     EasyPost's estimated delivery date for the associated <see cref="RateWithEstimatedDeliveryDate"/>.
         /// </summary>
-        [JsonProperty("easypost_time_in_transit_data")]
-        public string? EasyPostEstimatedDeliveryDate { get; set; }
+        [JsonProperty("easypost_estimated_delivery_date")]
+        public DateTime? EasyPostEstimatedDeliveryDate { get; set; }
 
         /// <summary>
         ///     The planned departure date for the shipment.
@@ -52,6 +51,5 @@ namespace EasyPost.Models.API
         public DateTime? PlannedShipDate { get; set; }
 
         #endregion
-
     }
 }


### PR DESCRIPTION
# Description

- Fixes bad JSON mapping as reported in #505 
- Sets type to `DateTime` rather than string to match `PlannedShipDate`

# Testing

- Tests updated to check for value of time-in-transit data to verify valid JSON deserialization
  - All tests pass, no re-recording needed.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
