### PR TITLE
[feat] Add ability to compare parameter set to an EasyPost object

### DIFF
--- a/EasyPost.Tests/ParametersTests/ParametersTest.cs
+++ b/EasyPost.Tests/ParametersTests/ParametersTest.cs
@@ -137,7 +137,7 @@ namespace EasyPost.Tests.ParametersTests
             Assert.Throws<Exceptions.General.MissingParameterError>(() => parametersWithOnlyOptionalParameterSet.ToDictionary());
         }
 
-        private sealed class ParameterSetWithRequiredAndOptionalParameters : Parameters.BaseParameters
+        private sealed class ParameterSetWithRequiredAndOptionalParameters : Parameters.BaseParameters<EasyPostObject>
         {
             [TopLevelRequestParameter(Necessity.Required, "test", "required")]
             public string? RequiredParameter { get; set; }

--- a/EasyPost/Models/API/Batch.cs
+++ b/EasyPost/Models/API/Batch.cs
@@ -112,7 +112,7 @@ namespace EasyPost.Models.API
         /// <returns>A TParameters-type parameters set.</returns>
         protected internal override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Batch> entries, int? pageSize = null)
         {
-            Parameters.Shipment.All parameters = Filters != null ? (Parameters.Shipment.All)Filters : new Parameters.Shipment.All();
+            Parameters.Batch.All parameters = Filters != null ? (Parameters.Batch.All)Filters : new Parameters.Batch.All();
 
             // TODO: Batches get returned in reverse order from everything else (oldest first instead of newest first), so this needs to be "after_id" instead of "before_id"
             parameters.AfterId = entries.Last().Id;

--- a/EasyPost/Models/API/Beta/CarrierMetadata.cs
+++ b/EasyPost/Models/API/Beta/CarrierMetadata.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using EasyPost._base;
 using EasyPost.Utilities.Internal;
 using Newtonsoft.Json;
 
@@ -10,7 +11,7 @@ namespace EasyPost.Models.API.Beta
     ///     Class representing an <a href="https://www.easypost.com/docs/api#carriermetadata-object">EasyPost carrier metadata summary</a>.
     /// </summary>
     [Obsolete("This class is deprecated. Please use EasyPost.Models.API.CarrierMetadata instead. This class will be removed in a future version.", false)]
-    public class CarrierMetadata
+    public class CarrierMetadata : EasyPostObject
     {
         #region JSON Properties
 

--- a/EasyPost/Models/API/CarrierMetadata.cs
+++ b/EasyPost/Models/API/CarrierMetadata.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using EasyPost._base;
 using EasyPost.Utilities.Internal;
 using Newtonsoft.Json;
 
@@ -8,7 +9,7 @@ namespace EasyPost.Models.API
     /// <summary>
     ///     Class representing an <a href="https://www.easypost.com/docs/api#carriermetadata-object">EasyPost carrier metadata summary</a>.
     /// </summary>
-    public class CarrierMetadata
+    public class CarrierMetadata : EphemeralEasyPostObject
     {
         #region JSON Properties
 

--- a/EasyPost/Models/Shared/PaginatedCollection.cs
+++ b/EasyPost/Models/Shared/PaginatedCollection.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using EasyPost._base;
 using EasyPost.Exceptions.General;
 using Newtonsoft.Json;
 
@@ -21,7 +22,7 @@ namespace EasyPost.Models.Shared
         /// <summary>
         ///     The filter parameters used to retrieve this collection.
         /// </summary>
-        internal Parameters.BaseParameters? Filters { get; set; }
+        internal Parameters.BaseParameters<TEntries>? Filters { get; set; }
 
         /// <summary>
         ///     Get the next page of a paginated collection.
@@ -33,7 +34,7 @@ namespace EasyPost.Models.Shared
         /// <typeparam name="TParameters">The type of <see cref="Parameters.BaseParameters"/> to construct for the API call.</typeparam>
         /// <returns>The next page of a paginated collection.</returns>
         /// <exception cref="EndOfPaginationError">Thrown if there is no next page to retrieve.</exception>
-        internal async Task<TCollection> GetNextPage<TCollection, TParameters>(Func<TParameters, Task<TCollection>> apiCallFunction, List<TEntries>? currentEntries, int? pageSize = null) where TCollection : PaginatedCollection<TEntries> where TParameters : Parameters.BaseParameters
+        internal async Task<TCollection> GetNextPage<TCollection, TParameters>(Func<TParameters, Task<TCollection>> apiCallFunction, List<TEntries>? currentEntries, int? pageSize = null) where TCollection : PaginatedCollection<TEntries> where TParameters : Parameters.BaseParameters<TEntries>
         {
             if (currentEntries == null || currentEntries.Count == 0)
             {
@@ -59,6 +60,6 @@ namespace EasyPost.Models.Shared
         /// <returns>A TParameters-type set of parameters to use for the subsequent API call.</returns>
         /// <exception cref="EndOfPaginationError">Thrown if there are no more items to retrieve for the paginated collection.</exception>
         // This method is abstract and must be implemented for each collection.
-        protected internal abstract TParameters BuildNextPageParameters<TParameters>(IEnumerable<TEntries> entries, int? pageSize = null) where TParameters : Parameters.BaseParameters;
+        protected internal abstract TParameters BuildNextPageParameters<TParameters>(IEnumerable<TEntries> entries, int? pageSize = null) where TParameters : Parameters.BaseParameters<TEntries>;
     }
 }

--- a/EasyPost/Parameters/Address/All.cs
+++ b/EasyPost/Parameters/Address/All.cs
@@ -9,7 +9,7 @@ namespace EasyPost.Parameters.Address
     ///     <a href="https://www.easypost.com/docs/api#retrieve-a-list-of-addresses">Parameters</a> for <see cref="EasyPost.Services.AddressService.All(All, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class All : BaseAllParameters
+    public class All : BaseAllParameters<Models.API.Address>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Address/Create.cs
+++ b/EasyPost/Parameters/Address/Create.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.Address
     ///     <a href="https://www.easypost.com/docs/api#create-and-verify-addresses">Parameters</a> for <see cref="EasyPost.Services.AddressService.Create(Create, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Create : BaseParameters, IAddressParameter
+    public class Create : BaseParameters<Models.API.Address>, IAddressParameter
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/BaseAllParameters.cs
+++ b/EasyPost/Parameters/BaseAllParameters.cs
@@ -1,19 +1,22 @@
 using System;
 using System.Collections.Generic;
+using EasyPost._base;
 
 namespace EasyPost.Parameters;
 
 /// <summary>
 ///     Base class for parameter sets used in `All` methods.
 /// </summary>
-public abstract class BaseAllParameters : BaseParameters
+public abstract class BaseAllParameters<TMatchInputType> : BaseParameters<TMatchInputType> where TMatchInputType : EphemeralEasyPostObject
 {
     /// <summary>
-    ///     Construct a new <see cref="BaseAllParameters"/>-based instance from a <see cref="Dictionary{TKey,TValue}"/>.
+    ///     Construct a new <see cref="BaseAllParameters{TMatchInputType}"/>-based instance from a <see cref="Dictionary{TKey,TValue}"/>.
     /// </summary>
     /// <param name="dictionary">The dictionary to parse.</param>
     /// <returns>A BaseAllParameters-subtype object.</returns>
-    public static BaseAllParameters FromDictionary(Dictionary<string, object>? dictionary)
+#pragma warning disable CA1000
+    public static BaseAllParameters<TMatchInputType> FromDictionary(Dictionary<string, object>? dictionary)
+#pragma warning restore CA1000
     {
         throw new NotImplementedException();
     }

--- a/EasyPost/Parameters/BaseParameters.cs
+++ b/EasyPost/Parameters/BaseParameters.cs
@@ -174,7 +174,7 @@ namespace EasyPost.Parameters
                 // If the given value is another base-Parameters object, serialize it as a sub-dictionary for the parent dictionary
                 // This is because the JSON schema for a sub-object is different than the JSON schema for a top-level object
                 // e.g. the schema for an address in the address create API call is different than the schema for an address in the shipment create API call
-                case IBaseParameters parameters: // todo: if issues arise with this function, look at the type constraint on BaseParameters here
+                case IBaseParameters parameters: // TODO: if issues arise with this function, look at the type constraint on BaseParameters here
                     return parameters.ToSubDictionary(GetType());
                 // If the given value is a list, serialize each element of the list
                 case IList list:

--- a/EasyPost/Parameters/BaseParameters.cs
+++ b/EasyPost/Parameters/BaseParameters.cs
@@ -15,7 +15,7 @@ namespace EasyPost.Parameters
     /// <summary>
     ///     Base class for all parameters used in functions.
     /// </summary>
-    public abstract class BaseParameters
+    public abstract class BaseParameters<TMatchInputType> : IBaseParameters where TMatchInputType : EphemeralEasyPostObject
     {
         /*
          * NOTES:
@@ -31,9 +31,22 @@ namespace EasyPost.Parameters
         private Dictionary<string, object?> _parameterDictionary;
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="BaseParameters"/> class for a new set of request parameters.
+        ///     A function to determine if a given object matches this parameter set.
+        ///     Defaults to always returning false, but can be overridden by child classes and end-users.
+        /// </summary>
+        public Func<TMatchInputType, bool> MatchFunction { get; set; } = _ => false;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="BaseParameters{TMatchInputType}"/> class for a new set of request parameters.
         /// </summary>
         protected BaseParameters() => _parameterDictionary = new Dictionary<string, object?>();
+
+        /// <summary>
+        ///     Execute the match function on a given object.
+        /// </summary>
+        /// <param name="obj">The <see cref="EasyPostObject"/> to compare this parameter set against.</param>
+        /// <returns>The result of the <see cref="MatchFunction"/></returns>
+        public bool Matches(TMatchInputType obj) => MatchFunction(obj);
 
         /// <summary>
         ///     Convert this parameter object to a dictionary for an HTTP request.
@@ -91,7 +104,7 @@ namespace EasyPost.Parameters
         ///     embedded.
         /// </param>
         /// <returns><see cref="Dictionary{TKey,TValue}" /> of parameters.</returns>
-        protected virtual Dictionary<string, object> ToSubDictionary(Type parentParameterObjectType)
+        public virtual Dictionary<string, object> ToSubDictionary(Type parentParameterObjectType)
         {
             // Construct the dictionary of all parameters
             PropertyInfo[] properties = GetType().GetProperties(BindingFlags.Instance |
@@ -161,7 +174,7 @@ namespace EasyPost.Parameters
                 // If the given value is another base-Parameters object, serialize it as a sub-dictionary for the parent dictionary
                 // This is because the JSON schema for a sub-object is different than the JSON schema for a top-level object
                 // e.g. the schema for an address in the address create API call is different than the schema for an address in the shipment create API call
-                case BaseParameters parameters:
+                case IBaseParameters parameters: // todo: if issues arise with this function, look at the type constraint on BaseParameters here
                     return parameters.ToSubDictionary(GetType());
                 // If the given value is a list, serialize each element of the list
                 case IList list:

--- a/EasyPost/Parameters/Batch/AddShipments.cs
+++ b/EasyPost/Parameters/Batch/AddShipments.cs
@@ -8,7 +8,7 @@ namespace EasyPost.Parameters.Batch
     ///     <a href="https://www.easypost.com/docs/api#add-shipments-to-a-batch">Parameters</a> for <see cref="EasyPost.Services.BatchService.AddShipments(string, AddShipments, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class AddShipments : BaseParameters
+    public class AddShipments : BaseParameters<Models.API.Batch>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Batch/All.cs
+++ b/EasyPost/Parameters/Batch/All.cs
@@ -9,7 +9,7 @@ namespace EasyPost.Parameters.Batch
     ///     <a href="https://www.easypost.com/docs/api#list-all-batches">Parameters</a> for <see cref="EasyPost.Services.BatchService.All(All, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class All : BaseAllParameters
+    public class All : BaseAllParameters<Models.API.Batch>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Batch/Create.cs
+++ b/EasyPost/Parameters/Batch/Create.cs
@@ -8,7 +8,7 @@ namespace EasyPost.Parameters.Batch
     ///     <a href="https://www.easypost.com/docs/api#create-a-batch">Parameters</a> for <see cref="EasyPost.Services.BatchService.Create(Create, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Create : BaseParameters, IBatchParameter
+    public class Create : BaseParameters<Models.API.Batch>, IBatchParameter
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Batch/GenerateLabel.cs
+++ b/EasyPost/Parameters/Batch/GenerateLabel.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.Batch
     ///     <a href="https://www.easypost.com/docs/api#batch-labels">Parameters</a> for <see cref="EasyPost.Services.BatchService.GenerateLabel(string, GenerateLabel, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class GenerateLabel : BaseParameters
+    public class GenerateLabel : BaseParameters<Models.API.Batch>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Batch/GenerateScanForm.cs
+++ b/EasyPost/Parameters/Batch/GenerateScanForm.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.Batch
     ///     <a href="https://www.easypost.com/docs/api#manifesting-scan-form">Parameters</a> for <see cref="EasyPost.Services.BatchService.GenerateScanForm(string, GenerateScanForm, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class GenerateScanForm : BaseParameters
+    public class GenerateScanForm : BaseParameters<Models.API.Batch>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Batch/RemoveShipments.cs
+++ b/EasyPost/Parameters/Batch/RemoveShipments.cs
@@ -8,7 +8,7 @@ namespace EasyPost.Parameters.Batch
     ///     <a href="https://www.easypost.com/docs/api#remove-shipments-from-a-batch">Parameters</a> for <see cref="EasyPost.Services.BatchService.RemoveShipments(string, RemoveShipments, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class RemoveShipments : BaseParameters
+    public class RemoveShipments : BaseParameters<Models.API.Batch>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Beta/CarrierMetadata/Retrieve.cs
+++ b/EasyPost/Parameters/Beta/CarrierMetadata/Retrieve.cs
@@ -11,7 +11,7 @@ namespace EasyPost.Parameters.Beta.CarrierMetadata
     /// </summary>
     [ExcludeFromCodeCoverage]
     [Obsolete("This class is deprecated. Please use EasyPost.Parameters.CarrierMetadata.Retrieve instead. This class will be removed in a future version.", false)]
-    public class Retrieve : BaseParameters
+    public class Retrieve : BaseParameters<Models.API.Beta.CarrierMetadata>
     {
         #region Request Parameters
 
@@ -28,7 +28,7 @@ namespace EasyPost.Parameters.Beta.CarrierMetadata
         #endregion
 
         /// <summary>
-        ///     Override the default <see cref="BaseParameters.ToDictionary"/> method to handle the unique serialization requirements for this parameter set.
+        ///     Override the default <see cref="BaseParameters{TMatchInputType}.ToDictionary"/> method to handle the unique serialization requirements for this parameter set.
         /// </summary>
         /// <returns>A <see cref="Dictionary{TKey,TValue}"/>.</returns>
         public override Dictionary<string, object> ToDictionary()

--- a/EasyPost/Parameters/Beta/Rate/Retrieve.cs
+++ b/EasyPost/Parameters/Beta/Rate/Retrieve.cs
@@ -8,7 +8,7 @@ namespace EasyPost.Parameters.Beta.Rate
     ///     <a href="https://www.easypost.com/docs/api#retrieve-rates-for-a-shipment">Parameters</a> for <see cref="EasyPost.Services.Beta.RateService.RetrieveStatelessRates(Retrieve, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Retrieve : BaseParameters
+    public class Retrieve : BaseParameters<Models.API.Beta.StatelessRate>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/CarrierAccount/Create.cs
+++ b/EasyPost/Parameters/CarrierAccount/Create.cs
@@ -8,7 +8,7 @@ namespace EasyPost.Parameters.CarrierAccount
     ///     <a href="https://www.easypost.com/docs/api#create-a-carrier-account">Parameters</a> for <see cref="EasyPost.Services.CarrierAccountService.Create(Create, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Create : BaseParameters, ICarrierAccountParameter
+    public class Create : BaseParameters<Models.API.CarrierAccount>, ICarrierAccountParameter
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/CarrierAccount/Update.cs
+++ b/EasyPost/Parameters/CarrierAccount/Update.cs
@@ -8,7 +8,7 @@ namespace EasyPost.Parameters.CarrierAccount
     ///     <a href="https://www.easypost.com/docs/api#update-a-carrieraccount">Parameters</a> for <see cref="EasyPost.Services.CarrierAccountService.Update(string, Update, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Update : BaseParameters
+    public class Update : BaseParameters<Models.API.CarrierAccount>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/CarrierMetadata/Retrieve.cs
+++ b/EasyPost/Parameters/CarrierMetadata/Retrieve.cs
@@ -9,7 +9,7 @@ namespace EasyPost.Parameters.CarrierMetadata
     ///     <a href="https://www.easypost.com/docs/api#retrieve-carrier-metadata">Parameters</a> for <see cref="EasyPost.Services.CarrierMetadataService.Retrieve(Retrieve, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Retrieve : BaseParameters
+    public class Retrieve : BaseParameters<Models.API.CarrierMetadata>
     {
         #region Request Parameters
 
@@ -26,7 +26,7 @@ namespace EasyPost.Parameters.CarrierMetadata
         #endregion
 
         /// <summary>
-        ///     Override the default <see cref="BaseParameters.ToDictionary"/> method to handle the unique serialization requirements for this parameter set.
+        ///     Override the default <see cref="BaseParameters{TMatchInputType}.ToDictionary"/> method to handle the unique serialization requirements for this parameter set.
         /// </summary>
         /// <returns>A <see cref="Dictionary{TKey,TValue}"/>.</returns>
         public override Dictionary<string, object> ToDictionary()

--- a/EasyPost/Parameters/CustomsInfo/Create.cs
+++ b/EasyPost/Parameters/CustomsInfo/Create.cs
@@ -8,7 +8,7 @@ namespace EasyPost.Parameters.CustomsInfo
     ///     <a href="https://www.easypost.com/docs/api#create-a-customsinfo">Parameters</a> for <see cref="EasyPost.Services.CustomsInfoService.Create(Create, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Create : BaseParameters, ICustomsInfoParameter
+    public class Create : BaseParameters<Models.API.CustomsInfo>, ICustomsInfoParameter
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/CustomsItem/Create.cs
+++ b/EasyPost/Parameters/CustomsItem/Create.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.CustomsItem
     ///     <a href="https://www.easypost.com/docs/api#create-a-customsitem">Parameters</a> for <see cref="EasyPost.Services.CustomsItemService.Create(Create, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Create : BaseParameters, ICustomsItemParameter
+    public class Create : BaseParameters<Models.API.CustomsItem>, ICustomsItemParameter
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/EndShipper/All.cs
+++ b/EasyPost/Parameters/EndShipper/All.cs
@@ -9,7 +9,7 @@ namespace EasyPost.Parameters.EndShipper
     ///     <a href="https://www.easypost.com/docs/api#retrieve-a-list-of-endshippers">Parameters</a> for <see cref="EasyPost.Services.EndShipperService.All(All, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class All : BaseAllParameters
+    public class All : BaseAllParameters<Models.API.EndShipper>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/EndShipper/Create.cs
+++ b/EasyPost/Parameters/EndShipper/Create.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.EndShipper
     ///     <a href="https://www.easypost.com/docs/api#create-an-endshipper">Parameters</a> for <see cref="EasyPost.Services.EndShipperService.Create(Create, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Create : BaseParameters, IEndShipperParameter
+    public class Create : BaseParameters<Models.API.EndShipper>, IEndShipperParameter
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/EndShipper/Update.cs
+++ b/EasyPost/Parameters/EndShipper/Update.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.EndShipper
     ///     <a href="https://www.easypost.com/docs/api#update-an-endshipper">Parameters</a> for <see cref="EasyPost.Services.EndShipperService.Update(string, Update, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Update : BaseParameters
+    public class Update : BaseParameters<Models.API.EndShipper>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Event/All.cs
+++ b/EasyPost/Parameters/Event/All.cs
@@ -9,7 +9,7 @@ namespace EasyPost.Parameters.Event
     ///     <a href="https://www.easypost.com/docs/api#retrieve-a-list-of-events">Parameters</a> for <see cref="EasyPost.Services.EventService.All(All, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class All : BaseAllParameters
+    public class All : BaseAllParameters<Models.API.Event>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/IBaseParameters.cs
+++ b/EasyPost/Parameters/IBaseParameters.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using EasyPost._base;
+using EasyPost.Exceptions.General;
+using EasyPost.Utilities.Internal;
+using EasyPost.Utilities.Internal.Attributes;
+using EasyPost.Utilities.Internal.Extensions;
+
+namespace EasyPost.Parameters
+{
+    public interface IBaseParameters
+    {
+        public Dictionary<string, object> ToDictionary();
+
+        public Dictionary<string, object> ToSubDictionary(Type parentParameterObjectType);
+    }
+}

--- a/EasyPost/Parameters/Insurance/All.cs
+++ b/EasyPost/Parameters/Insurance/All.cs
@@ -9,7 +9,7 @@ namespace EasyPost.Parameters.Insurance
     ///     <a href="https://www.easypost.com/docs/api#retrieve-a-list-of-insurances">Parameters</a> for <see cref="EasyPost.Services.InsuranceService.All(All, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class All : BaseAllParameters
+    public class All : BaseAllParameters<Models.API.Insurance>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Insurance/Create.cs
+++ b/EasyPost/Parameters/Insurance/Create.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.Insurance
     ///     <a href="https://www.easypost.com/docs/api#create-an-insurance">Parameters</a> for <see cref="EasyPost.Services.InsuranceService.Create(Create, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Create : BaseParameters, IInsuranceParameter
+    public class Create : BaseParameters<Models.API.Insurance>, IInsuranceParameter
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Order/Buy.cs
+++ b/EasyPost/Parameters/Order/Buy.cs
@@ -8,7 +8,7 @@ namespace EasyPost.Parameters.Order
     ///     <a href="https://www.easypost.com/docs/api#buy-an-order">Parameters</a> for <see cref="EasyPost.Services.OrderService.Buy(string, Buy, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Buy : BaseParameters
+    public class Buy : BaseParameters<Models.API.Order>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Order/Create.cs
+++ b/EasyPost/Parameters/Order/Create.cs
@@ -8,7 +8,7 @@ namespace EasyPost.Parameters.Order
     ///     <a href="https://www.easypost.com/docs/api#create-an-order">Parameters</a> for <see cref="EasyPost.Services.OrderService.Create(Create, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Create : BaseParameters, IOrderParameter
+    public class Create : BaseParameters<Models.API.Order>, IOrderParameter
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Parcel/Create.cs
+++ b/EasyPost/Parameters/Parcel/Create.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.Parcel
     ///     <a href="https://www.easypost.com/docs/api#create-a-parcel">Parameters</a> for <see cref="EasyPost.Services.ParcelService.Create(Create, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Create : BaseParameters, IParcelParameter
+    public class Create : BaseParameters<Models.API.Parcel>, IParcelParameter
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Pickup/All.cs
+++ b/EasyPost/Parameters/Pickup/All.cs
@@ -9,7 +9,7 @@ namespace EasyPost.Parameters.Pickup
     ///     <a href="https://www.easypost.com/docs/api#retrieve-a-list-of-pickups">Parameters</a> for <see cref="EasyPost.Services.PickupService.All(All, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class All : BaseAllParameters
+    public class All : BaseAllParameters<Models.API.Pickup>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Pickup/Buy.cs
+++ b/EasyPost/Parameters/Pickup/Buy.cs
@@ -8,7 +8,7 @@ namespace EasyPost.Parameters.Pickup
     ///     <a href="https://www.easypost.com/docs/api#buy-a-pickup">Parameters</a> for <see cref="EasyPost.Services.PickupService.Buy(string, Buy, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Buy : BaseParameters
+    public class Buy : BaseParameters<Models.API.Pickup>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Pickup/Create.cs
+++ b/EasyPost/Parameters/Pickup/Create.cs
@@ -8,7 +8,7 @@ namespace EasyPost.Parameters.Pickup
     ///     <a href="https://www.easypost.com/docs/api#create-a-pickup">Parameters</a> for <see cref="EasyPost.Services.PickupService.Create(Create, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Create : BaseParameters, IPickupParameter
+    public class Create : BaseParameters<Models.API.Pickup>, IPickupParameter
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/ReferralCustomer/AddPaymentMethod.cs
+++ b/EasyPost/Parameters/ReferralCustomer/AddPaymentMethod.cs
@@ -8,7 +8,7 @@ namespace EasyPost.Parameters.ReferralCustomer
     ///     <a href="https://www.easypost.com/docs/api#add-payment-method-to-referral-user">Parameters</a> for <see cref="EasyPost.Services.Beta.ReferralCustomerService.AddPaymentMethod(AddPaymentMethod, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class AddPaymentMethod : BaseParameters
+    public class AddPaymentMethod : BaseParameters<Models.API.ReferralCustomer>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/ReferralCustomer/All.cs
+++ b/EasyPost/Parameters/ReferralCustomer/All.cs
@@ -9,7 +9,7 @@ namespace EasyPost.Parameters.ReferralCustomer
     ///     <a href="https://www.easypost.com/docs/api#retrieve-a-list-of-referral-customers">Parameters</a> for <see cref="EasyPost.Services.ReferralCustomerService.All(All, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class All : BaseAllParameters
+    public class All : BaseAllParameters<Models.API.ReferralCustomer>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/ReferralCustomer/CreateReferralCustomer.cs
+++ b/EasyPost/Parameters/ReferralCustomer/CreateReferralCustomer.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.ReferralCustomer
     ///     <a href="https://www.easypost.com/docs/api#create-a-referral-customer">Parameters</a> for <see cref="EasyPost.Services.ReferralCustomerService.CreateReferral(CreateReferralCustomer, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class CreateReferralCustomer : BaseParameters, IReferralCustomerParameter
+    public class CreateReferralCustomer : BaseParameters<Models.API.ReferralCustomer>, IReferralCustomerParameter
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/ReferralCustomer/RefundByAmount.cs
+++ b/EasyPost/Parameters/ReferralCustomer/RefundByAmount.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.ReferralCustomer
     ///     <a href="https://www.easypost.com/docs/api#refund-a-referral-user">Parameters</a> for <see cref="EasyPost.Services.Beta.ReferralCustomerService.RefundByAmount(RefundByAmount, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class RefundByAmount : BaseParameters
+    public class RefundByAmount : BaseParameters<Models.API.ReferralCustomer>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/ReferralCustomer/RefundByPaymentLog.cs
+++ b/EasyPost/Parameters/ReferralCustomer/RefundByPaymentLog.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.ReferralCustomer
     ///     <a href="https://www.easypost.com/docs/api#refund-a-referral-user">Parameters</a> for <see cref="EasyPost.Services.Beta.ReferralCustomerService.RefundByPaymentLog(RefundByPaymentLog, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class RefundByPaymentLog : BaseParameters
+    public class RefundByPaymentLog : BaseParameters<Models.API.ReferralCustomer>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Refund/All.cs
+++ b/EasyPost/Parameters/Refund/All.cs
@@ -9,7 +9,7 @@ namespace EasyPost.Parameters.Refund
     ///     <a href="https://www.easypost.com/docs/api#retrieve-a-list-of-refunds">Parameters</a> for <see cref="EasyPost.Services.RefundService.All(All, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class All : BaseAllParameters
+    public class All : BaseAllParameters<Models.API.Refund>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Refund/Create.cs
+++ b/EasyPost/Parameters/Refund/Create.cs
@@ -8,7 +8,7 @@ namespace EasyPost.Parameters.Refund
     ///     <a href="https://www.easypost.com/docs/api#create-a-refund">Parameters</a> for <see cref="EasyPost.Services.RefundService.Create(Create, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Create : BaseParameters, IRefundParameter
+    public class Create : BaseParameters<Models.API.Refund>, IRefundParameter
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Report/All.cs
+++ b/EasyPost/Parameters/Report/All.cs
@@ -9,7 +9,7 @@ namespace EasyPost.Parameters.Report
     ///     <a href="https://www.easypost.com/docs/api#retrieve-a-list-of-reports">Parameters</a> for <see cref="EasyPost.Services.ReportService.All(All, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class All : BaseAllParameters
+    public class All : BaseAllParameters<Models.API.Report>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Report/Create.cs
+++ b/EasyPost/Parameters/Report/Create.cs
@@ -8,7 +8,7 @@ namespace EasyPost.Parameters.Report
     ///     <a href="https://www.easypost.com/docs/api#create-a-report">Parameters</a> for <see cref="EasyPost.Services.ReportService.Create(Create, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Create : BaseParameters, IReportParameter
+    public class Create : BaseParameters<Models.API.Report>, IReportParameter
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/ScanForm/All.cs
+++ b/EasyPost/Parameters/ScanForm/All.cs
@@ -9,7 +9,7 @@ namespace EasyPost.Parameters.ScanForm
     ///     <a href="https://www.easypost.com/docs/api#retrieve-a-list-of-scanforms">Parameters</a> for <see cref="EasyPost.Services.ScanFormService.All(All, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class All : BaseAllParameters
+    public class All : BaseAllParameters<Models.API.ScanForm>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/ScanForm/Create.cs
+++ b/EasyPost/Parameters/ScanForm/Create.cs
@@ -8,7 +8,7 @@ namespace EasyPost.Parameters.ScanForm
     ///     <a href="https://www.easypost.com/docs/api#create-a-scanform">Parameters</a> for <see cref="EasyPost.Services.ScanFormService.Create(Create, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Create : BaseParameters, IScanFormParameter
+    public class Create : BaseParameters<Models.API.ScanForm>, IScanFormParameter
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Shipment/All.cs
+++ b/EasyPost/Parameters/Shipment/All.cs
@@ -9,7 +9,7 @@ namespace EasyPost.Parameters.Shipment
     ///     <a href="https://www.easypost.com/docs/api#retrieve-a-list-of-shipments">Parameters</a> for <see cref="EasyPost.Services.ShipmentService.All(All, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class All : BaseAllParameters
+    public class All : BaseAllParameters<Models.API.Shipment>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Shipment/Buy.cs
+++ b/EasyPost/Parameters/Shipment/Buy.cs
@@ -8,7 +8,7 @@ namespace EasyPost.Parameters.Shipment
     ///     <a href="https://www.easypost.com/docs/api#buy-a-shipment">Parameters</a> for <see cref="EasyPost.Services.ShipmentService.Buy(string, Buy, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Buy : BaseParameters
+    public class Buy : BaseParameters<Models.API.Shipment>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Shipment/Create.cs
+++ b/EasyPost/Parameters/Shipment/Create.cs
@@ -8,7 +8,7 @@ namespace EasyPost.Parameters.Shipment
     ///     <a href="https://www.easypost.com/docs/api#create-a-shipment">Parameters</a> for <see cref="EasyPost.Services.ShipmentService.Create(Create, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Create : BaseParameters, IShipmentParameter
+    public class Create : BaseParameters<Models.API.Shipment>, IShipmentParameter
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Shipment/GenerateForm.cs
+++ b/EasyPost/Parameters/Shipment/GenerateForm.cs
@@ -9,7 +9,7 @@ namespace EasyPost.Parameters.Shipment
     ///     <a href="https://www.easypost.com/docs/api#create-form">Parameters</a> for <see cref="EasyPost.Services.ShipmentService.GenerateForm(string, GenerateForm, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class GenerateForm : BaseParameters
+    public class GenerateForm : BaseParameters<Models.API.Shipment>
     {
         #region Request Parameters
 
@@ -25,7 +25,7 @@ namespace EasyPost.Parameters.Shipment
         public Dictionary<string, object>? Data { get; set; }
 
         /// <summary>
-        ///     Override the default <see cref="BaseParameters.ToDictionary"/> method to handle the unique serialization requirements for this parameter set.
+        ///     Override the default <see cref="BaseParameters{TMatchInputType}.ToDictionary"/> method to handle the unique serialization requirements for this parameter set.
         /// </summary>
         /// <returns>A <see cref="Dictionary{TKey,TValue}"/>.</returns>
         /// <exception cref="MissingParameterError">Thrown when the form type was not provided.</exception>

--- a/EasyPost/Parameters/Shipment/GenerateLabel.cs
+++ b/EasyPost/Parameters/Shipment/GenerateLabel.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.Shipment
     ///     <a href="https://www.easypost.com/docs/api#convert-the-label-format-of-a-shipment">Parameters</a> for <see cref="EasyPost.Services.ShipmentService.GenerateLabel(string, GenerateLabel, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class GenerateLabel : BaseParameters
+    public class GenerateLabel : BaseParameters<Models.API.Shipment>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Shipment/Insure.cs
+++ b/EasyPost/Parameters/Shipment/Insure.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.Shipment
     ///     <a href="https://www.easypost.com/docs/api#insure-a-shipment">Parameters</a> for <see cref="EasyPost.Services.ShipmentService.Insure(string, Insure, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Insure : BaseParameters
+    public class Insure : BaseParameters<Models.API.Shipment>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Shipment/RegenerateRates.cs
+++ b/EasyPost/Parameters/Shipment/RegenerateRates.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.Shipment
     ///     <a href="https://www.easypost.com/docs/api#regenerate-rates-for-a-shipment">Parameters</a> for <see cref="EasyPost.Services.ShipmentService.RegenerateRates(string, RegenerateRates, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class RegenerateRates : BaseParameters
+    public class RegenerateRates : BaseParameters<Models.API.Shipment>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Shipment/RetrieveEstimatedDeliveryDate.cs
+++ b/EasyPost/Parameters/Shipment/RetrieveEstimatedDeliveryDate.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.Shipment
     ///     <a href="https://www.easypost.com/docs/api#retrieve-estimated-delivery-date-and-total-transit-days-across-all-rates-for-a-shipment">Parameters</a> for <see cref="EasyPost.Services.ShipmentService.RetrieveEstimatedDeliveryDate(string, RetrieveEstimatedDeliveryDate, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class RetrieveEstimatedDeliveryDate : BaseParameters
+    public class RetrieveEstimatedDeliveryDate : BaseParameters<Models.API.Shipment>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/TaxIdentifier/Create.cs
+++ b/EasyPost/Parameters/TaxIdentifier/Create.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.TaxIdentifier
     ///     <a href="https://www.easypost.com/docs/api#tax-identifiers">Parameters</a> for <see cref="Shipment.Create.TaxIdentifiers"/> property.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Create : BaseParameters, ITaxIdentifierParameter
+    public class Create : BaseParameters<Models.API.TaxIdentifier>, ITaxIdentifierParameter
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Tracker/All.cs
+++ b/EasyPost/Parameters/Tracker/All.cs
@@ -9,7 +9,7 @@ namespace EasyPost.Parameters.Tracker
     ///     <a href="https://www.easypost.com/docs/api#retrieve-a-list-of-trackers">Parameters</a> for <see cref="EasyPost.Services.TrackerService.All(All, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class All : BaseAllParameters
+    public class All : BaseAllParameters<Models.API.Tracker>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Tracker/Create.cs
+++ b/EasyPost/Parameters/Tracker/Create.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.Tracker
     ///     <a href="https://www.easypost.com/docs/api#create-a-tracker">Parameters</a> for <see cref="EasyPost.Services.TrackerService.Create(Create, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Create : BaseParameters, ITrackerParameter
+    public class Create : BaseParameters<Models.API.Tracker>, ITrackerParameter
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Tracker/CreateList.cs
+++ b/EasyPost/Parameters/Tracker/CreateList.cs
@@ -9,7 +9,7 @@ namespace EasyPost.Parameters.Tracker
     ///     Parameters for <see cref="EasyPost.Services.TrackerService.CreateList(CreateList, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class CreateList : BaseParameters, ITrackerParameter
+    public class CreateList : BaseParameters<Models.API.Tracker>, ITrackerParameter
     {
         #region Request Parameters
 
@@ -37,7 +37,7 @@ namespace EasyPost.Parameters.Tracker
         }
 
         /// <summary>
-        ///     Override the default <see cref="BaseParameters.ToDictionary"/> method to handle the unique serialization requirements for this parameter set.
+        ///     Override the default <see cref="BaseParameters{TMatchInputType}.ToDictionary"/> method to handle the unique serialization requirements for this parameter set.
         /// </summary>
         /// <returns>A <see cref="Dictionary{TKey,TValue}"/>.</returns>
         public override Dictionary<string, object> ToDictionary()

--- a/EasyPost/Parameters/User/CreateChild.cs
+++ b/EasyPost/Parameters/User/CreateChild.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.User
     ///     <a href="https://www.easypost.com/docs/api#create-a-child-user">Parameters</a> for <see cref="EasyPost.Services.UserService.CreateChild(CreateChild, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class CreateChild : BaseParameters, IUserParameter
+    public class CreateChild : BaseParameters<Models.API.User>, IUserParameter
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/User/Update.cs
+++ b/EasyPost/Parameters/User/Update.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.User
     ///     <a href="https://www.easypost.com/docs/api#update-a-user">Parameters</a> for <see cref="EasyPost.Services.UserService.Update(string, Update, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Update : BaseParameters
+    public class Update : BaseParameters<Models.API.User>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/User/UpdateBrand.cs
+++ b/EasyPost/Parameters/User/UpdateBrand.cs
@@ -7,7 +7,7 @@ namespace EasyPost.Parameters.User
     ///     <a href="https://www.easypost.com/docs/api#update-a-brand">Parameters</a> for <see cref="EasyPost.Services.UserService.UpdateBrand(string, UpdateBrand, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class UpdateBrand : BaseParameters
+    public class UpdateBrand : BaseParameters<Models.API.User>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Webhook/All.cs
+++ b/EasyPost/Parameters/Webhook/All.cs
@@ -9,7 +9,7 @@ namespace EasyPost.Parameters.Webhook
     ///     <a href="https://www.easypost.com/docs/api#list-a-webhooks">Parameters</a> for <see cref="EasyPost.Services.WebhookService.All(All, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class All : BaseAllParameters
+    public class All : BaseAllParameters<Models.API.Webhook>
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Webhook/Create.cs
+++ b/EasyPost/Parameters/Webhook/Create.cs
@@ -8,7 +8,7 @@ namespace EasyPost.Parameters.Webhook
     ///     <a href="https://www.easypost.com/docs/api#create-a-webhook">Parameters</a> for <see cref="EasyPost.Services.WebhookService.Create(Create, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Create : BaseParameters, IWebhookParameter
+    public class Create : BaseParameters<Models.API.Webhook>, IWebhookParameter
     {
         #region Request Parameters
 

--- a/EasyPost/Parameters/Webhook/Update.cs
+++ b/EasyPost/Parameters/Webhook/Update.cs
@@ -8,7 +8,7 @@ namespace EasyPost.Parameters.Webhook
     ///     <a href="https://www.easypost.com/docs/api#update-a-webhook">Parameters</a> for <see cref="EasyPost.Services.WebhookService.Update(string, Update, System.Threading.CancellationToken)"/> API calls.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    public class Update : BaseParameters
+    public class Update : BaseParameters<Models.API.Webhook>
     {
         #region Request Parameters
 


### PR DESCRIPTION
# Description

Re: #377 

Users can now define (and down the road we can add defaults) a `Match` function that evaluates if a parameter set object matches an EasyPost object. Some of our users have implemented their own version of this utility, to see if a prepared parameter set matches an existing object (e.g. if the address in a shipment parameter set matches the address of a given EasyPost object, they know they don't need to make a new object).

This PR:
- Add "Matches" function at base level of all parameter sets to test if a given set matches a provided EasyPostObject-based object
  - This can be implemented by library maintainers with "default" functions, or end-users can implement their own.

# Testing

- Add unit tests to confirm function can be implemented and works as expected

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
