### PR TITLE
[fix] Add missing address parameters to Shipment create parameter set

### DIFF
--- a/EasyPost/Parameters/Shipment/Create.cs
+++ b/EasyPost/Parameters/Shipment/Create.cs
@@ -100,6 +100,26 @@ namespace EasyPost.Parameters.Shipment
         public IAddressParameter? FromAddress { get; set; }
 
         /// <summary>
+        ///     The return <see cref="Models.API.Address"/> (or a <see cref="Address.Create"/> parameter set) for the new <see cref="Models.API.Shipment"/>.
+        /// </summary>
+        [TopLevelRequestParameter(Necessity.Optional, "shipment", "return_address")]
+        [NestedRequestParameter(typeof(Pickup.Create), Necessity.Optional, "return_address")]
+        [NestedRequestParameter(typeof(Batch.Create), Necessity.Optional, "return_address")]
+        [NestedRequestParameter(typeof(Order.Create), Necessity.Optional, "return_address")]
+        [NestedRequestParameter(typeof(ScanForm.Create), Necessity.Optional, "return_address")]
+        public IAddressParameter? ReturnAddress { get; set; }
+
+        /// <summary>
+        ///     The buyer <see cref="Models.API.Address"/> (or a <see cref="Address.Create"/> parameter set) for the new <see cref="Models.API.Shipment"/>.
+        /// </summary>
+        [TopLevelRequestParameter(Necessity.Optional, "shipment", "buyer_address")]
+        [NestedRequestParameter(typeof(Pickup.Create), Necessity.Optional, "buyer_address")]
+        [NestedRequestParameter(typeof(Batch.Create), Necessity.Optional, "buyer_address")]
+        [NestedRequestParameter(typeof(Order.Create), Necessity.Optional, "buyer_address")]
+        [NestedRequestParameter(typeof(ScanForm.Create), Necessity.Optional, "buyer_address")]
+        public IAddressParameter? BuyerAddress { get; set; }
+
+        /// <summary>
         ///     The physical <see cref="Models.API.Parcel"/> (or <see cref="Parcel.Create"/> parameter set) being transported in the new <see cref="Models.API.Shipment"/>.
         /// </summary>
         [TopLevelRequestParameter(Necessity.Optional, "shipment", "parcel")]


### PR DESCRIPTION
# Description

- Add missing optional `return_address` and `buyer_address` parameters for Shipment creation parameter sets

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
