### PR TITLE
[chore] Open internal methods

### DIFF
--- a/EasyPost.Integration/Extensions.cs
+++ b/EasyPost.Integration/Extensions.cs
@@ -1,0 +1,26 @@
+using EasyPost.Models.API;
+using EasyPost.Models.Shared;
+using Xunit;
+
+namespace EasyPost.Integration;
+
+public class Extensions
+{
+    /// <summary>
+    ///     Test that an end-user can inherit and override the <see cref="PaginatedCollection{T}.BuildNextPageParameters{TParameters}(IEnumerable{T}, int?)"/> method.
+    ///     If this test can be compiled, then the <see cref="PaginatedCollection{T}.BuildNextPageParameters{TParameters}(IEnumerable{T}, int?)"/> method is publicly accessible.
+    /// </summary>
+    public class CustomPaginatedCollection : PaginatedCollection<Tracker> // Using Tracker as a placeholder for any type
+    {
+        public override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Tracker> entries, int? pageSize = null) => throw new NotImplementedException();
+    }
+
+    /// <summary>
+    ///     This test simply exists to ensure this file is compiled when the test suite is run.
+    /// </summary>
+    [Fact]
+    public void Compile()
+    {
+        Assert.True(true);
+    }
+}

--- a/EasyPost/Models/API/Address.cs
+++ b/EasyPost/Models/API/Address.cs
@@ -142,7 +142,7 @@ namespace EasyPost.Models.API
         /// <param name="pageSize">The request size of the next page.</param>
         /// <typeparam name="TParameters">The type of parameters to construct.</typeparam>
         /// <returns>A TParameters-type parameters set.</returns>
-        protected internal override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Address> entries, int? pageSize = null)
+        public override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Address> entries, int? pageSize = null)
         {
             Parameters.Address.All parameters = Filters != null ? (Parameters.Address.All)Filters : new Parameters.Address.All();
 

--- a/EasyPost/Models/API/Batch.cs
+++ b/EasyPost/Models/API/Batch.cs
@@ -110,7 +110,7 @@ namespace EasyPost.Models.API
         /// <param name="pageSize">The request size of the next page.</param>
         /// <typeparam name="TParameters">The type of parameters to construct.</typeparam>
         /// <returns>A TParameters-type parameters set.</returns>
-        protected internal override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Batch> entries, int? pageSize = null)
+        public override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Batch> entries, int? pageSize = null)
         {
             Parameters.Batch.All parameters = Filters != null ? (Parameters.Batch.All)Filters : new Parameters.Batch.All();
 

--- a/EasyPost/Models/API/EndShipper.cs
+++ b/EasyPost/Models/API/EndShipper.cs
@@ -115,6 +115,6 @@ namespace EasyPost.Models.API
         /// <typeparam name="TParameters">The type of parameters to construct.</typeparam>
         /// <returns>A TParameters-type parameters set.</returns>
         // Cannot currently get the next page of EndShippers, so this is not implemented.
-        protected internal override TParameters BuildNextPageParameters<TParameters>(IEnumerable<EndShipper> entries, int? pageSize = null) => throw new EndOfPaginationError();
+        public override TParameters BuildNextPageParameters<TParameters>(IEnumerable<EndShipper> entries, int? pageSize = null) => throw new EndOfPaginationError();
     }
 }

--- a/EasyPost/Models/API/Event.cs
+++ b/EasyPost/Models/API/Event.cs
@@ -90,7 +90,7 @@ namespace EasyPost.Models.API
         /// <param name="pageSize">The request size of the next page.</param>
         /// <typeparam name="TParameters">The type of parameters to construct.</typeparam>
         /// <returns>A TParameters-type parameters set.</returns>
-        protected internal override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Event> entries, int? pageSize = null)
+        public override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Event> entries, int? pageSize = null)
         {
             Parameters.Event.All parameters = Filters != null ? (Parameters.Event.All)Filters : new Parameters.Event.All();
 

--- a/EasyPost/Models/API/Insurance.cs
+++ b/EasyPost/Models/API/Insurance.cs
@@ -113,7 +113,7 @@ namespace EasyPost.Models.API
         /// <param name="pageSize">The request size of the next page.</param>
         /// <typeparam name="TParameters">The type of parameters to construct.</typeparam>
         /// <returns>A TParameters-type parameters set.</returns>
-        protected internal override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Insurance> entries, int? pageSize = null)
+        public override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Insurance> entries, int? pageSize = null)
         {
             Parameters.Insurance.All parameters = Filters != null ? (Parameters.Insurance.All)Filters : new Parameters.Insurance.All();
 

--- a/EasyPost/Models/API/Pickup.cs
+++ b/EasyPost/Models/API/Pickup.cs
@@ -86,7 +86,7 @@ namespace EasyPost.Models.API
         /// <param name="pageSize">The request size of the next page.</param>
         /// <typeparam name="TParameters">The type of parameters to construct.</typeparam>
         /// <returns>A TParameters-type parameters set.</returns>
-        protected internal override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Pickup> entries, int? pageSize = null)
+        public override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Pickup> entries, int? pageSize = null)
         {
             Parameters.Pickup.All parameters = Filters != null ? (Parameters.Pickup.All)Filters : new Parameters.Pickup.All();
 

--- a/EasyPost/Models/API/ReferralCustomer.cs
+++ b/EasyPost/Models/API/ReferralCustomer.cs
@@ -36,7 +36,7 @@ namespace EasyPost.Models.API
         /// <param name="pageSize">The request size of the next page.</param>
         /// <typeparam name="TParameters">The type of parameters to construct.</typeparam>
         /// <returns>A TParameters-type parameters set.</returns>
-        protected internal override TParameters BuildNextPageParameters<TParameters>(IEnumerable<ReferralCustomer> entries, int? pageSize = null)
+        public override TParameters BuildNextPageParameters<TParameters>(IEnumerable<ReferralCustomer> entries, int? pageSize = null)
         {
             Parameters.ReferralCustomer.All parameters = Filters != null ? (Parameters.ReferralCustomer.All)Filters : new Parameters.ReferralCustomer.All();
 

--- a/EasyPost/Models/API/Refund.cs
+++ b/EasyPost/Models/API/Refund.cs
@@ -52,7 +52,7 @@ namespace EasyPost.Models.API
         /// <param name="pageSize">The request size of the next page.</param>
         /// <typeparam name="TParameters">The type of parameters to construct.</typeparam>
         /// <returns>A TParameters-type parameters set.</returns>
-        protected internal override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Refund> entries, int? pageSize = null)
+        public override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Refund> entries, int? pageSize = null)
         {
             Parameters.Refund.All parameters = Filters != null ? (Parameters.Refund.All)Filters : new Parameters.Refund.All();
 

--- a/EasyPost/Models/API/Report.cs
+++ b/EasyPost/Models/API/Report.cs
@@ -55,7 +55,7 @@ namespace EasyPost.Models.API
         /// <param name="pageSize">The request size of the next page.</param>
         /// <typeparam name="TParameters">The type of parameters to construct.</typeparam>
         /// <returns>A TParameters-type parameters set.</returns>
-        protected internal override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Report> entries, int? pageSize = null)
+        public override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Report> entries, int? pageSize = null)
         {
             Parameters.Report.All parameters = Filters != null ? (Parameters.Report.All)Filters : new Parameters.Report.All();
 

--- a/EasyPost/Models/API/ScanForm.cs
+++ b/EasyPost/Models/API/ScanForm.cs
@@ -60,7 +60,7 @@ namespace EasyPost.Models.API
         /// <param name="pageSize">The request size of the next page.</param>
         /// <typeparam name="TParameters">The type of parameters to construct.</typeparam>
         /// <returns>A TParameters-type parameters set.</returns>
-        protected internal override TParameters BuildNextPageParameters<TParameters>(IEnumerable<ScanForm> entries, int? pageSize = null)
+        public override TParameters BuildNextPageParameters<TParameters>(IEnumerable<ScanForm> entries, int? pageSize = null)
         {
             Parameters.ScanForm.All parameters = Filters != null ? (Parameters.ScanForm.All)Filters : new Parameters.ScanForm.All();
 

--- a/EasyPost/Models/API/Shipment.cs
+++ b/EasyPost/Models/API/Shipment.cs
@@ -124,7 +124,7 @@ namespace EasyPost.Models.API
         /// <param name="pageSize">The request size of the next page.</param>
         /// <typeparam name="TParameters">The type of parameters to construct.</typeparam>
         /// <returns>A TParameters-type parameters set.</returns>
-        protected internal override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Shipment> entries, int? pageSize = null)
+        public override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Shipment> entries, int? pageSize = null)
         {
             Parameters.Shipment.All parameters = Filters != null ? (Parameters.Shipment.All)Filters : new Parameters.Shipment.All();
 

--- a/EasyPost/Models/API/Tracker.cs
+++ b/EasyPost/Models/API/Tracker.cs
@@ -67,7 +67,7 @@ namespace EasyPost.Models.API
         /// <param name="pageSize">The request size of the next page.</param>
         /// <typeparam name="TParameters">The type of parameters to construct.</typeparam>
         /// <returns>A TParameters-type parameters set.</returns>
-        protected internal override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Tracker> entries, int? pageSize = null)
+        public override TParameters BuildNextPageParameters<TParameters>(IEnumerable<Tracker> entries, int? pageSize = null)
         {
             Parameters.Tracker.All parameters = Filters != null ? (Parameters.Tracker.All)Filters : new Parameters.Tracker.All();
 

--- a/EasyPost/Models/Shared/PaginatedCollection.cs
+++ b/EasyPost/Models/Shared/PaginatedCollection.cs
@@ -60,6 +60,6 @@ namespace EasyPost.Models.Shared
         /// <returns>A TParameters-type set of parameters to use for the subsequent API call.</returns>
         /// <exception cref="EndOfPaginationError">Thrown if there are no more items to retrieve for the paginated collection.</exception>
         // This method is abstract and must be implemented for each collection.
-        protected internal abstract TParameters BuildNextPageParameters<TParameters>(IEnumerable<TEntries> entries, int? pageSize = null) where TParameters : Parameters.BaseParameters<TEntries>;
+        public abstract TParameters BuildNextPageParameters<TParameters>(IEnumerable<TEntries> entries, int? pageSize = null) where TParameters : Parameters.BaseParameters<TEntries>;
     }
 }

--- a/EasyPost/Models/Shared/PaginatedCollection.cs
+++ b/EasyPost/Models/Shared/PaginatedCollection.cs
@@ -31,10 +31,10 @@ namespace EasyPost.Models.Shared
         /// <param name="currentEntries">The results on the current page. Used to determine the API call parameters to retrieve the next page.</param>
         /// <param name="pageSize">The size of the next page.</param>
         /// <typeparam name="TCollection">The type of <see cref="PaginatedCollection{TCollection}"/> to get the next page of.</typeparam>
-        /// <typeparam name="TParameters">The type of <see cref="Parameters.BaseParameters"/> to construct for the API call.</typeparam>
+        /// <typeparam name="TParameters">The type of <see cref="Parameters.BaseParameters{TEntries}"/> to construct for the API call.</typeparam>
         /// <returns>The next page of a paginated collection.</returns>
         /// <exception cref="EndOfPaginationError">Thrown if there is no next page to retrieve.</exception>
-        internal async Task<TCollection> GetNextPage<TCollection, TParameters>(Func<TParameters, Task<TCollection>> apiCallFunction, List<TEntries>? currentEntries, int? pageSize = null) where TCollection : PaginatedCollection<TEntries> where TParameters : Parameters.BaseParameters<TEntries>
+        public async Task<TCollection> GetNextPage<TCollection, TParameters>(Func<TParameters, Task<TCollection>> apiCallFunction, List<TEntries>? currentEntries, int? pageSize = null) where TCollection : PaginatedCollection<TEntries> where TParameters : Parameters.BaseParameters<TEntries>
         {
             if (currentEntries == null || currentEntries.Count == 0)
             {
@@ -56,7 +56,7 @@ namespace EasyPost.Models.Shared
         /// </summary>
         /// <param name="entries">The entries of the collection.</param>
         /// <param name="pageSize">The size of the next page.</param>
-        /// <typeparam name="TParameters">The type of <see cref="Parameters.BaseParameters"/> to construct for the API call.</typeparam>
+        /// <typeparam name="TParameters">The type of <see cref="Parameters.BaseParameters{TEntries}"/> to construct for the API call.</typeparam>
         /// <returns>A TParameters-type set of parameters to use for the subsequent API call.</returns>
         /// <exception cref="EndOfPaginationError">Thrown if there are no more items to retrieve for the paginated collection.</exception>
         // This method is abstract and must be implemented for each collection.

--- a/EasyPost/_base/EasyPostClient.cs
+++ b/EasyPost/_base/EasyPostClient.cs
@@ -119,7 +119,7 @@ namespace EasyPost._base
         /// <param name="rootElement">Optional root element for the resultant JSON to begin deserialization at.</param>
         /// <typeparam name="T">Type of object to deserialize response data into. Must be subclass of <see cref="EasyPostObject"/>.</typeparam>
         /// <returns>An instance of a T-type object.</returns>
-        internal async Task<T> RequestAsync<T>(Method method, string endpoint, ApiVersion apiVersion, CancellationToken cancellationToken, Dictionary<string, object>? parameters = null, string? rootElement = null)
+        public async Task<T> RequestAsync<T>(Method method, string endpoint, ApiVersion apiVersion, CancellationToken cancellationToken, Dictionary<string, object>? parameters = null, string? rootElement = null)
             where T : class
         {
             // Build the request
@@ -170,7 +170,7 @@ namespace EasyPost._base
         /// <param name="parameters">Optional parameters to use for the request.</param>
         /// <returns><c>true</c> if the request was successful, <c>false</c> otherwise.</returns>
         // ReSharper disable once UnusedMethodReturnValue.Global
-        internal async Task<bool> RequestAsync(Method method, string endpoint, ApiVersion apiVersion, CancellationToken cancellationToken, Dictionary<string, object>? parameters = null)
+        public async Task<bool> RequestAsync(Method method, string endpoint, ApiVersion apiVersion, CancellationToken cancellationToken, Dictionary<string, object>? parameters = null)
         {
             // Build the request
             Dictionary<string, string> headers = _configuration.GetHeaders(apiVersion);


### PR DESCRIPTION
# Description

We went a bit overboard during recent redesigns and refactors in terms of locking down our methods to internal-only, out of concern of preventing our end-users from accidentally shooting themselves in the foot.

However, bit by bit we've had to roll back changes to these for one reason or another. This PR opens up the three final remaining internal-only methods, allowing end-users to modify them or override them as they need in their own applications. This does NOT pose a vulnerability to our system.

# Testing

- N/A

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
