### PR TITLE
[fix] Add `Options` parameter for beta rate retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - This parameter is no longer supported by the EasyPost API
 - Remove `CarbonOffset` model
 - Remove `CreateAndBuy` method in `Batch` service due to API deprecation
+- Add `Options` parameter for beta rates retrieval parameter set
 
 ## v5.8.0 (2023-10-11)
 

--- a/EasyPost/Parameters/Beta/Rate/Retrieve.cs
+++ b/EasyPost/Parameters/Beta/Rate/Retrieve.cs
@@ -25,6 +25,12 @@ namespace EasyPost.Parameters.Beta.Rate
         public IAddressParameter? FromAddress { get; set; }
 
         /// <summary>
+        ///     Additional <see cref="Models.API.Options"/> to use to retrieve <see cref="Models.API.Beta.StatelessRate"/>s.
+        /// </summary>
+        [TopLevelRequestParameter(Necessity.Optional, "shipment", "options")]
+        public Models.API.Options? Options { get; set; }
+
+        /// <summary>
         ///     Reference name to use to retrieve <see cref="Models.API.Beta.StatelessRate"/>s.
         /// </summary>
         [TopLevelRequestParameter(Necessity.Optional, "shipment", "reference")]


### PR DESCRIPTION
# Description

Users need to be able to define options when retrieving beta rates, same as for creating a shipment.

# Testing

- N/A

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
