### PR TITLE
[chore] Update create_verify unit test with better invalid address

### DIFF
--- a/EasyPost.Tests/Fixture.cs
+++ b/EasyPost.Tests/Fixture.cs
@@ -73,8 +73,6 @@ namespace EasyPost.Tests._Utilities
 
         internal static Dictionary<string, object> FullShipment => GetFixtureStructure().Shipments.Full;
 
-        internal static Dictionary<string, object> IncorrectAddress => GetFixtureStructure().Addresses.IncorrectAddress;
-
         internal static Dictionary<string, object> OneCallBuyShipment => new()
         {
             { "to_address", CaAddress1 },

--- a/EasyPost.Tests/Fixture.cs
+++ b/EasyPost.Tests/Fixture.cs
@@ -73,6 +73,8 @@ namespace EasyPost.Tests._Utilities
 
         internal static Dictionary<string, object> FullShipment => GetFixtureStructure().Shipments.Full;
 
+        internal static Dictionary<string, object> IncorrectAddress => GetFixtureStructure().Addresses.IncorrectAddress;
+
         internal static Dictionary<string, object> OneCallBuyShipment => new()
         {
             { "to_address", CaAddress1 },

--- a/EasyPost.Tests/ServicesTests/AddressServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/AddressServiceTest.cs
@@ -5,6 +5,7 @@ using EasyPost.Models.API;
 using EasyPost.Tests._Utilities;
 using EasyPost.Tests._Utilities.Attributes;
 using EasyPost.Utilities.Internal.Attributes;
+using EasyPost.Utilities.Internal.Extensions;
 using Xunit;
 
 namespace EasyPost.Tests.ServicesTests
@@ -40,15 +41,25 @@ namespace EasyPost.Tests.ServicesTests
         {
             UseVCR("create_verify");
 
-            Dictionary<string, object> addressData = Fixtures.IncorrectAddress;
-            // internally, we're just checking for the presence of "verify" in the dictionary, so the value doesn't matter
-            addressData.Add("verify", true);
+            Dictionary<string, object> addressData = Fixtures.CaAddress1;
+            addressData["street1"] = "jfskfhasli"; // Just some random string to make the address invalid
 
+            // Creating normally (without specifying "verify") will make the address, perform no verifications
             Address address = await Client.Address.Create(addressData);
 
             Assert.IsType<Address>(address);
-            Assert.StartsWith("adr_", address.Id);
-            Assert.Equal("417 MONTGOMERY ST FL 5", address.Street1);
+            Assert.Null(address.Verifications.Delivery);
+            Assert.Null(address.Verifications.Zip4);
+
+            // Creating with verify would make the address and perform verifications
+            // internally, we're just checking for the presence of "verify" in the dictionary, so the value doesn't matter
+            addressData.Add("verify", true);
+
+            address = await Client.Address.Create(addressData);
+
+            Assert.IsType<Address>(address);
+            Assert.NotNull(address.Verifications.Delivery);
+            Assert.NotNull(address.Verifications.Zip4);
         }
 
         [Fact]
@@ -58,15 +69,25 @@ namespace EasyPost.Tests.ServicesTests
         {
             UseVCR("create_verify_array");
 
-            Dictionary<string, object> addressData = Fixtures.IncorrectAddress;
-            // internally, we're just checking for the presence of "verify" in the dictionary, so the value doesn't matter
-            addressData.Add("verify", new List<bool> { true });
+            Dictionary<string, object> addressData = Fixtures.CaAddress1;
+            addressData["street1"] = "jfskfhasli"; // Just some random string to make the address invalid
 
+            // Creating normally (without specifying "verify") will make the address, perform no verifications
             Address address = await Client.Address.Create(addressData);
 
             Assert.IsType<Address>(address);
-            Assert.StartsWith("adr_", address.Id);
-            Assert.Equal("417 MONTGOMERY ST FL 5", address.Street1);
+            Assert.Null(address.Verifications.Delivery);
+            Assert.Null(address.Verifications.Zip4);
+
+            // Creating with verify would make the address and perform verifications
+            // internally, we're just checking for the presence of "verify" in the dictionary, so the value doesn't matter
+            addressData.Add("verify", new List<bool> { true });
+
+            address = await Client.Address.Create(addressData);
+
+            Assert.IsType<Address>(address);
+            Assert.NotNull(address.Verifications.Delivery);
+            Assert.NotNull(address.Verifications.Zip4);
         }
 
         [Fact]

--- a/EasyPost.Tests/ServicesTests/AddressServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/AddressServiceTest.cs
@@ -41,8 +41,7 @@ namespace EasyPost.Tests.ServicesTests
         {
             UseVCR("create_verify");
 
-            Dictionary<string, object> addressData = Fixtures.CaAddress1;
-            addressData["street1"] = "jfskfhasli"; // Just some random string to make the address invalid
+            Dictionary<string, object> addressData = Fixtures.IncorrectAddress;
 
             // Creating normally (without specifying "verify") will make the address, perform no verifications
             Address address = await Client.Address.Create(addressData);
@@ -69,8 +68,7 @@ namespace EasyPost.Tests.ServicesTests
         {
             UseVCR("create_verify_array");
 
-            Dictionary<string, object> addressData = Fixtures.CaAddress1;
-            addressData["street1"] = "jfskfhasli"; // Just some random string to make the address invalid
+            Dictionary<string, object> addressData = Fixtures.IncorrectAddress;
 
             // Creating normally (without specifying "verify") will make the address, perform no verifications
             Address address = await Client.Address.Create(addressData);

--- a/EasyPost.Tests/ServicesTests/WithParameters/AddressServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/WithParameters/AddressServiceTest.cs
@@ -43,16 +43,25 @@ namespace EasyPost.Tests.ServicesTests.WithParameters
         {
             UseVCR("create_verify");
 
-            Dictionary<string, object> fixture = Fixtures.IncorrectAddress;
-            fixture["verify"] = true;
-
+            Dictionary<string, object> fixture = Fixtures.CaAddress1;
             Parameters.Address.Create parameters = Fixtures.Parameters.Addresses.Create(fixture);
+            parameters.Street1 = "jfskfhasli"; // Just some random string to make the address invalid
 
+            // Creating normally (without specifying "verify") will make the address, perform no verifications
             Address address = await Client.Address.Create(parameters);
 
             Assert.IsType<Address>(address);
-            Assert.StartsWith("adr_", address.Id);
-            Assert.Equal("417 MONTGOMERY ST FL 5", address.Street1);
+            Assert.Null(address.Verifications.Delivery);
+            Assert.Null(address.Verifications.Zip4);
+
+            // Creating with verify would make the address and perform verifications
+            parameters.Verify = true;
+
+            address = await Client.Address.Create(parameters);
+
+            Assert.IsType<Address>(address);
+            Assert.NotNull(address.Verifications.Delivery);
+            Assert.NotNull(address.Verifications.Zip4);
         }
 
         [Fact]

--- a/EasyPost.Tests/ServicesTests/WithParameters/AddressServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/WithParameters/AddressServiceTest.cs
@@ -43,9 +43,8 @@ namespace EasyPost.Tests.ServicesTests.WithParameters
         {
             UseVCR("create_verify");
 
-            Dictionary<string, object> fixture = Fixtures.CaAddress1;
+            Dictionary<string, object> fixture = Fixtures.IncorrectAddress;
             Parameters.Address.Create parameters = Fixtures.Parameters.Addresses.Create(fixture);
-            parameters.Street1 = "jfskfhasli"; // Just some random string to make the address invalid
 
             // Creating normally (without specifying "verify") will make the address, perform no verifications
             Address address = await Client.Address.Create(parameters);

--- a/EasyPost.Tests/cassettes/net/address_service/create_verify.json
+++ b/EasyPost.Tests/cassettes/net/address_service/create_verify.json
@@ -1,13 +1,13 @@
 [
   {
-    "Duration": 566,
-    "RecordedAt": "2024-01-05T12:27:37.926982-07:00",
+    "Duration": 697,
+    "RecordedAt": "2024-01-05T15:02:36.646443-07:00",
     "Request": {
-      "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"}}",
+      "Body": "{\"address\":{\"company\":\"EasyPost\",\"street1\":\"000 unknown street\",\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "190"
+        "Content-Length": "175"
       },
       "Method": "POST",
       "RequestHeaders": {
@@ -17,12 +17,12 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_7c3dc1a6ac0011eeb129ac1f6bc53342\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:37-07:00\",\"updated_at\":\"2024-01-05T12:27:37-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}",
+      "Body": "{\"id\":\"adr_22a610e9ac1611ee83deac1f6bc539ae\",\"object\":\"Address\",\"created_at\":\"2024-01-05T15:02:36-07:00\",\"updated_at\":\"2024-01-05T15:02:36-07:00\",\"name\":null,\"company\":\"EasyPost\",\"street1\":\"000 unknown street\",\"street2\":null,\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "456"
+        "Content-Length": "453"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -32,15 +32,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "dc2c57f265985829f44f7f6d000eeef5",
+        "x-ep-request-uuid": "f29a8d0265987c7cf451b51100285169",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_7c3dc1a6ac0011eeb129ac1f6bc53342",
-        "x-runtime": "0.038656",
-        "x-node": "bigweb35nuq",
+        "Location": "/api/v2/addresses/adr_22a610e9ac1611ee83deac1f6bc539ae",
+        "x-runtime": "0.033697",
+        "x-node": "bigweb36nuq",
         "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb2nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
+        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {
@@ -50,14 +50,14 @@
     }
   },
   {
-    "Duration": 98,
-    "RecordedAt": "2024-01-05T12:27:38.069227-07:00",
+    "Duration": 92,
+    "RecordedAt": "2024-01-05T15:02:36.791373-07:00",
     "Request": {
-      "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify\":true}",
+      "Body": "{\"address\":{\"company\":\"EasyPost\",\"street1\":\"000 unknown street\",\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify\":true}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "204"
+        "Content-Length": "189"
       },
       "Method": "POST",
       "RequestHeaders": {
@@ -67,12 +67,12 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_7c64cb0eac0011ee912aac1f6bc539ae\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:38-07:00\",\"updated_at\":\"2024-01-05T12:27:38-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":{}}}}",
+      "Body": "{\"id\":\"adr_22d2503aac1611ee83f5ac1f6bc539ae\",\"object\":\"Address\",\"created_at\":\"2024-01-05T15:02:36-07:00\",\"updated_at\":\"2024-01-05T15:02:36-07:00\",\"name\":null,\"company\":\"EasyPost\",\"street1\":\"000 unknown street\",\"street2\":null,\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null}],\"details\":{}}}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "965"
+        "Content-Length": "750"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -82,15 +82,16 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "dc2c57f26598582af44f7f6d000eef2a",
+        "x-ep-request-uuid": "f29a8d0265987c7cf451b5110028519e",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_7c64cb0eac0011ee912aac1f6bc539ae",
-        "x-runtime": "0.054844",
-        "x-node": "bigweb34nuq",
+        "Location": "/api/v2/addresses/adr_22d2503aac1611ee83f5ac1f6bc539ae",
+        "x-runtime": "0.054438",
+        "x-node": "bigweb32nuq",
         "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb2nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
+        "x-canary": "direct",
+        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/net/address_service/create_verify.json
+++ b/EasyPost.Tests/cassettes/net/address_service/create_verify.json
@@ -1,13 +1,13 @@
 [
   {
-    "Duration": 290,
-    "RecordedAt": "2023-04-25T21:17:06.259204-06:00",
+    "Duration": 566,
+    "RecordedAt": "2024-01-05T12:27:37.926982-07:00",
     "Request": {
-      "Body": "{\"address\":{\"company\":\"EasyPost\",\"street1\":\"417 montgomery street\",\"street2\":\"FL 5\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify\":true}",
+      "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "212"
+        "Content-Length": "190"
       },
       "Method": "POST",
       "RequestHeaders": {
@@ -17,12 +17,12 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_d29a3e5ce3e011eda164ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2023-04-25T21:17:06-06:00\",\"updated_at\":\"2023-04-25T21:17:06-06:00\",\"name\":null,\"company\":\"EASYPOST\",\"street1\":\"417 MONTGOMERY ST FL 5\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94104-1129\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[{\"code\":\"E.SECONDARY_INFORMATION.INVALID\",\"field\":\"street2\",\"message\":\"Invalid secondary information(Apt/Suite#)\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[{\"code\":\"E.SECONDARY_INFORMATION.INVALID\",\"field\":\"street2\",\"message\":\"Invalid secondary information(Apt/Suite#)\",\"suggestion\":null}],\"details\":{\"latitude\":37.79342,\"longitude\":-122.40288,\"time_zone\":\"America/Los_Angeles\"}}}}",
+      "Body": "{\"id\":\"adr_7c3dc1a6ac0011eeb129ac1f6bc53342\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:37-07:00\",\"updated_at\":\"2024-01-05T12:27:37-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "907"
+        "Content-Length": "456"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -32,16 +32,65 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "d677fdbb644897b2e18646dd0008c9f6",
+        "x-ep-request-uuid": "dc2c57f265985829f44f7f6d000eeef5",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_d29a3e5ce3e011eda164ac1f6bc72124",
-        "ETag": "W/\"6fbca79dbc176d03bf9036475c4686d1\"",
-        "x-runtime": "0.047659",
-        "x-node": "bigweb4nuq",
-        "x-version-label": "easypost-202304252326-79950b6035-master",
+        "Location": "/api/v2/addresses/adr_7c3dc1a6ac0011eeb129ac1f6bc53342",
+        "x-runtime": "0.038656",
+        "x-node": "bigweb35nuq",
+        "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq a29e4ad05c,extlb2nuq a29e4ad05c",
+        "x-proxied": "intlb2nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "Status": {
+        "Code": 201,
+        "Message": "Created"
+      }
+    }
+  },
+  {
+    "Duration": 98,
+    "RecordedAt": "2024-01-05T12:27:38.069227-07:00",
+    "Request": {
+      "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify\":true}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "204"
+      },
+      "Method": "POST",
+      "RequestHeaders": {
+        "Authorization": "<REDACTED>",
+        "User-Agent": "<REDACTED>"
+      },
+      "Uri": "https://api.easypost.com/v2/addresses"
+    },
+    "Response": {
+      "Body": "{\"id\":\"adr_7c64cb0eac0011ee912aac1f6bc539ae\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:38-07:00\",\"updated_at\":\"2024-01-05T12:27:38-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":{}}}}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "965"
+      },
+      "HttpVersion": "1.1",
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "dc2c57f26598582af44f7f6d000eef2a",
+        "Cache-Control": "no-store, no-cache, private",
+        "Pragma": "no-cache",
+        "Location": "/api/v2/addresses/adr_7c64cb0eac0011ee912aac1f6bc539ae",
+        "x-runtime": "0.054844",
+        "x-node": "bigweb34nuq",
+        "x-version-label": "easypost-202401051829-4cf193bd35-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb2nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/net/address_service/create_verify_array.json
+++ b/EasyPost.Tests/cassettes/net/address_service/create_verify_array.json
@@ -1,13 +1,13 @@
 [
   {
-    "Duration": 415,
-    "RecordedAt": "2023-04-25T21:17:07.078099-06:00",
+    "Duration": 239,
+    "RecordedAt": "2024-01-05T12:27:38.352714-07:00",
     "Request": {
-      "Body": "{\"address\":{\"company\":\"EasyPost\",\"street1\":\"417 montgomery street\",\"street2\":\"FL 5\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify\":true}",
+      "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "212"
+        "Content-Length": "190"
       },
       "Method": "POST",
       "RequestHeaders": {
@@ -17,12 +17,12 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_d3107b15e3e011ed9ba3ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-04-25T21:17:07-06:00\",\"updated_at\":\"2023-04-25T21:17:07-06:00\",\"name\":null,\"company\":\"EASYPOST\",\"street1\":\"417 MONTGOMERY ST FL 5\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94104-1129\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[{\"code\":\"E.SECONDARY_INFORMATION.INVALID\",\"field\":\"street2\",\"message\":\"Invalid secondary information(Apt/Suite#)\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[{\"code\":\"E.SECONDARY_INFORMATION.INVALID\",\"field\":\"street2\",\"message\":\"Invalid secondary information(Apt/Suite#)\",\"suggestion\":null}],\"details\":{\"latitude\":37.79342,\"longitude\":-122.40288,\"time_zone\":\"America/Los_Angeles\"}}}}",
+      "Body": "{\"id\":\"adr_7c90acefac0011eeb16aac1f6bc53342\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:38-07:00\",\"updated_at\":\"2024-01-05T12:27:38-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "907"
+        "Content-Length": "456"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -32,16 +32,65 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "d4af614c644897b3f752256b0009464f",
+        "x-ep-request-uuid": "dc2c57f36598582af42c72e7000eef67",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_d3107b15e3e011ed9ba3ac1f6bc7b362",
-        "ETag": "W/\"0699491bfb2da6bf9f09538b9a445df6\"",
-        "x-runtime": "0.052085",
-        "x-node": "bigweb1nuq",
-        "x-version-label": "easypost-202304252326-79950b6035-master",
+        "Location": "/api/v2/addresses/adr_7c90acefac0011eeb16aac1f6bc53342",
+        "x-runtime": "0.031499",
+        "x-node": "bigweb36nuq",
+        "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq a29e4ad05c,intlb1wdc a29e4ad05c,extlb4wdc a29e4ad05c",
+        "x-proxied": "intlb2nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "Status": {
+        "Code": 201,
+        "Message": "Created"
+      }
+    }
+  },
+  {
+    "Duration": 88,
+    "RecordedAt": "2024-01-05T12:27:38.466136-07:00",
+    "Request": {
+      "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify\":true}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "204"
+      },
+      "Method": "POST",
+      "RequestHeaders": {
+        "Authorization": "<REDACTED>",
+        "User-Agent": "<REDACTED>"
+      },
+      "Uri": "https://api.easypost.com/v2/addresses"
+    },
+    "Response": {
+      "Body": "{\"id\":\"adr_7ca08d96ac0011ee9146ac1f6bc539ae\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:38-07:00\",\"updated_at\":\"2024-01-05T12:27:38-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":{}}}}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "965"
+      },
+      "HttpVersion": "1.1",
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "dc2c57f36598582af42c72e7000eef74",
+        "Cache-Control": "no-store, no-cache, private",
+        "Pragma": "no-cache",
+        "Location": "/api/v2/addresses/adr_7ca08d96ac0011ee9146ac1f6bc539ae",
+        "x-runtime": "0.048819",
+        "x-node": "bigweb39nuq",
+        "x-version-label": "easypost-202401051829-4cf193bd35-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb2nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/net/address_service/create_verify_array.json
+++ b/EasyPost.Tests/cassettes/net/address_service/create_verify_array.json
@@ -1,13 +1,13 @@
 [
   {
-    "Duration": 239,
-    "RecordedAt": "2024-01-05T12:27:38.352714-07:00",
+    "Duration": 204,
+    "RecordedAt": "2024-01-05T15:02:37.054535-07:00",
     "Request": {
-      "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"}}",
+      "Body": "{\"address\":{\"company\":\"EasyPost\",\"street1\":\"000 unknown street\",\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "190"
+        "Content-Length": "175"
       },
       "Method": "POST",
       "RequestHeaders": {
@@ -17,12 +17,12 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_7c90acefac0011eeb16aac1f6bc53342\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:38-07:00\",\"updated_at\":\"2024-01-05T12:27:38-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}",
+      "Body": "{\"id\":\"adr_22faf2fbac1611eead093cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T15:02:37-07:00\",\"updated_at\":\"2024-01-05T15:02:37-07:00\",\"name\":null,\"company\":\"EasyPost\",\"street1\":\"000 unknown street\",\"street2\":null,\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "456"
+        "Content-Length": "453"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -32,15 +32,16 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "dc2c57f36598582af42c72e7000eef67",
+        "x-ep-request-uuid": "f29a8cfe65987c7df3f5af0d002851cf",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_7c90acefac0011eeb16aac1f6bc53342",
-        "x-runtime": "0.031499",
-        "x-node": "bigweb36nuq",
+        "Location": "/api/v2/addresses/adr_22faf2fbac1611eead093cecef1b359e",
+        "x-runtime": "0.034539",
+        "x-node": "bigweb32nuq",
         "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb2nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
+        "x-canary": "direct",
+        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {
@@ -50,14 +51,14 @@
     }
   },
   {
-    "Duration": 88,
-    "RecordedAt": "2024-01-05T12:27:38.466136-07:00",
+    "Duration": 87,
+    "RecordedAt": "2024-01-05T15:02:37.165476-07:00",
     "Request": {
-      "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify\":true}",
+      "Body": "{\"address\":{\"company\":\"EasyPost\",\"street1\":\"000 unknown street\",\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify\":true}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "204"
+        "Content-Length": "189"
       },
       "Method": "POST",
       "RequestHeaders": {
@@ -67,12 +68,12 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_7ca08d96ac0011ee9146ac1f6bc539ae\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:38-07:00\",\"updated_at\":\"2024-01-05T12:27:38-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":{}}}}",
+      "Body": "{\"id\":\"adr_230c61bbac1611eea500ac1f6bc539aa\",\"object\":\"Address\",\"created_at\":\"2024-01-05T15:02:37-07:00\",\"updated_at\":\"2024-01-05T15:02:37-07:00\",\"name\":null,\"company\":\"EasyPost\",\"street1\":\"000 unknown street\",\"street2\":null,\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null}],\"details\":{}}}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "965"
+        "Content-Length": "750"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -82,15 +83,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "dc2c57f36598582af42c72e7000eef74",
+        "x-ep-request-uuid": "f29a8cfe65987c7df3f5af0d002851e4",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_7ca08d96ac0011ee9146ac1f6bc539ae",
-        "x-runtime": "0.048819",
-        "x-node": "bigweb39nuq",
+        "Location": "/api/v2/addresses/adr_230c61bbac1611eea500ac1f6bc539aa",
+        "x-runtime": "0.049542",
+        "x-node": "bigweb31nuq",
         "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb2nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
+        "x-proxied": "intlb2nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/net/address_service/create_verify_strict.json
+++ b/EasyPost.Tests/cassettes/net/address_service/create_verify_strict.json
@@ -1,7 +1,7 @@
 [
   {
-    "Duration": 240,
-    "RecordedAt": "2024-01-05T12:27:38.764342-07:00",
+    "Duration": 246,
+    "RecordedAt": "2024-01-05T15:02:37.467416-07:00",
     "Request": {
       "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify_strict\":true}",
       "BodyContentType": "Json",
@@ -17,7 +17,7 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_7ccf2b45ac0011eeb187ac1f6bc53342\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:38-07:00\",\"updated_at\":\"2024-01-05T12:27:38-07:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
+      "Body": "{\"id\":\"adr_233a8a9bac1611ee8435ac1f6bc539ae\",\"object\":\"Address\",\"created_at\":\"2024-01-05T15:02:37-07:00\",\"updated_at\":\"2024-01-05T15:02:37-07:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
@@ -32,15 +32,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "f29a8d046598582af43056f8000dbbf4",
+        "x-ep-request-uuid": "dc2c57f165987c7df3f7dba7002bf940",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_7ccf2b45ac0011eeb187ac1f6bc53342",
-        "x-runtime": "0.059030",
-        "x-node": "bigweb39nuq",
+        "Location": "/api/v2/addresses/adr_233a8a9bac1611ee8435ac1f6bc539ae",
+        "x-runtime": "0.056362",
+        "x-node": "bigweb35nuq",
         "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
+        "x-proxied": "intlb2nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/net/address_service/create_verify_strict.json
+++ b/EasyPost.Tests/cassettes/net/address_service/create_verify_strict.json
@@ -1,7 +1,7 @@
 [
   {
-    "Duration": 235,
-    "RecordedAt": "2023-04-25T21:17:09.744778-06:00",
+    "Duration": 240,
+    "RecordedAt": "2024-01-05T12:27:38.764342-07:00",
     "Request": {
       "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify_strict\":true}",
       "BodyContentType": "Json",
@@ -17,7 +17,7 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_d4ade89be3e011eda3ceac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-04-25T21:17:09-06:00\",\"updated_at\":\"2023-04-25T21:17:09-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
+      "Body": "{\"id\":\"adr_7ccf2b45ac0011eeb187ac1f6bc53342\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:38-07:00\",\"updated_at\":\"2024-01-05T12:27:38-07:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
@@ -32,16 +32,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "72dbe703644897b5e186cdd4000b1fd1",
+        "x-ep-request-uuid": "f29a8d046598582af43056f8000dbbf4",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_d4ade89be3e011eda3ceac1f6bc7b362",
-        "ETag": "W/\"dbc15b50d6eead966c89e21996ed5088\"",
-        "x-runtime": "0.050198",
-        "x-node": "bigweb4nuq",
-        "x-version-label": "easypost-202304252326-79950b6035-master",
+        "Location": "/api/v2/addresses/adr_7ccf2b45ac0011eeb187ac1f6bc53342",
+        "x-runtime": "0.059030",
+        "x-node": "bigweb39nuq",
+        "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq a29e4ad05c,extlb1nuq a29e4ad05c",
+        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/net/address_service/create_verify_strict_array.json
+++ b/EasyPost.Tests/cassettes/net/address_service/create_verify_strict_array.json
@@ -1,7 +1,7 @@
 [
   {
-    "Duration": 222,
-    "RecordedAt": "2023-04-25T21:17:09.977339-06:00",
+    "Duration": 277,
+    "RecordedAt": "2024-01-05T12:27:39.064085-07:00",
     "Request": {
       "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify_strict\":true}",
       "BodyContentType": "Json",
@@ -17,7 +17,7 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_d4d0e5a8e3e011eda47bac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2023-04-25T21:17:10-06:00\",\"updated_at\":\"2023-04-25T21:17:10-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
+      "Body": "{\"id\":\"adr_7cf899d1ac0011ee9179ac1f6bc539ae\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:39-07:00\",\"updated_at\":\"2024-01-05T12:27:39-07:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
@@ -32,16 +32,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "72dbe701644897b6e1bd2947000b1fdf",
+        "x-ep-request-uuid": "f29a8cfe6598582bf0220551000dbc22",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_d4d0e5a8e3e011eda47bac1f6bc7b362",
-        "ETag": "W/\"c3c6810bc5ce6f5ecfdc057fce0d7651\"",
-        "x-runtime": "0.059701",
-        "x-node": "bigweb11nuq",
-        "x-version-label": "easypost-202304252326-79950b6035-master",
+        "Location": "/api/v2/addresses/adr_7cf899d1ac0011ee9179ac1f6bc539ae",
+        "x-runtime": "0.079807",
+        "x-node": "bigweb35nuq",
+        "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq a29e4ad05c,extlb1nuq a29e4ad05c",
+        "x-proxied": "intlb2nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/net/address_service/create_verify_strict_array.json
+++ b/EasyPost.Tests/cassettes/net/address_service/create_verify_strict_array.json
@@ -1,7 +1,7 @@
 [
   {
-    "Duration": 277,
-    "RecordedAt": "2024-01-05T12:27:39.064085-07:00",
+    "Duration": 230,
+    "RecordedAt": "2024-01-05T15:02:37.718548-07:00",
     "Request": {
       "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify_strict\":true}",
       "BodyContentType": "Json",
@@ -17,7 +17,7 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_7cf899d1ac0011ee9179ac1f6bc539ae\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:39-07:00\",\"updated_at\":\"2024-01-05T12:27:39-07:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
+      "Body": "{\"id\":\"adr_235fd49bac1611eead4a3cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T15:02:37-07:00\",\"updated_at\":\"2024-01-05T15:02:37-07:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
@@ -32,15 +32,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "f29a8cfe6598582bf0220551000dbc22",
+        "x-ep-request-uuid": "dc2c57ef65987c7df3f6330a002bf987",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_7cf899d1ac0011ee9179ac1f6bc539ae",
-        "x-runtime": "0.079807",
-        "x-node": "bigweb35nuq",
+        "Location": "/api/v2/addresses/adr_235fd49bac1611eead4a3cecef1b359e",
+        "x-runtime": "0.058741",
+        "x-node": "bigweb31nuq",
         "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb2nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
+        "x-proxied": "intlb2nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/net/address_service_with_parameters/create_verify.json
+++ b/EasyPost.Tests/cassettes/net/address_service_with_parameters/create_verify.json
@@ -1,13 +1,13 @@
 [
   {
-    "Duration": 238,
-    "RecordedAt": "2024-01-05T12:27:38.121117-07:00",
+    "Duration": 689,
+    "RecordedAt": "2024-01-05T15:02:36.646449-07:00",
     "Request": {
-      "Body": "{\"address\":{\"city\":\"San Francisco\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"name\":\"Jack Sparrow\",\"phone\":\"<REDACTED>\",\"state\":\"CA\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"zip\":\"94107\"}}",
+      "Body": "{\"address\":{\"city\":\"Not A City\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\",\"state\":\"ZZ\",\"street1\":\"000 unknown street\",\"zip\":\"00001\"}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "190"
+        "Content-Length": "154"
       },
       "Method": "POST",
       "RequestHeaders": {
@@ -17,12 +17,12 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_7c6c13bfac0011eeb5243cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:38-07:00\",\"updated_at\":\"2024-01-05T12:27:38-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}",
+      "Body": "{\"id\":\"adr_22a6ae7eac1611eeace33cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T15:02:36-07:00\",\"updated_at\":\"2024-01-05T15:02:36-07:00\",\"name\":null,\"company\":null,\"street1\":\"000 unknown street\",\"street2\":null,\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "456"
+        "Content-Length": "447"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -32,16 +32,16 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "dc2c57f36598582af3f7dc33000eef39",
+        "x-ep-request-uuid": "f29a8d0165987c7cf40c113400285168",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_7c6c13bfac0011eeb5243cecef1b359e",
-        "x-runtime": "0.044841",
-        "x-node": "bigweb43nuq",
+        "Location": "/api/v2/addresses/adr_22a6ae7eac1611eeace33cecef1b359e",
+        "x-runtime": "0.039327",
+        "x-node": "bigweb32nuq",
         "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
         "x-canary": "direct",
-        "x-proxied": "intlb1nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
+        "x-proxied": "intlb2nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {
@@ -51,14 +51,14 @@
     }
   },
   {
-    "Duration": 94,
-    "RecordedAt": "2024-01-05T12:27:38.232125-07:00",
+    "Duration": 87,
+    "RecordedAt": "2024-01-05T15:02:36.7972-07:00",
     "Request": {
-      "Body": "{\"address\":{\"city\":\"San Francisco\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"name\":\"Jack Sparrow\",\"phone\":\"<REDACTED>\",\"state\":\"CA\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"zip\":\"94107\"},\"verify\":true}",
+      "Body": "{\"address\":{\"city\":\"Not A City\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\",\"state\":\"ZZ\",\"street1\":\"000 unknown street\",\"zip\":\"00001\"},\"verify\":true}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "204"
+        "Content-Length": "168"
       },
       "Method": "POST",
       "RequestHeaders": {
@@ -68,12 +68,12 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_7c7d2eddac0011eeb5303cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:38-07:00\",\"updated_at\":\"2024-01-05T12:27:38-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":{}}}}",
+      "Body": "{\"id\":\"adr_22d3ad7eac1611eeacff3cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T15:02:36-07:00\",\"updated_at\":\"2024-01-05T15:02:36-07:00\",\"name\":null,\"company\":null,\"street1\":\"000 unknown street\",\"street2\":null,\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null}],\"details\":{}}}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "965"
+        "Content-Length": "744"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -83,15 +83,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "dc2c57f36598582af3f7dc33000eef52",
+        "x-ep-request-uuid": "f29a8d0165987c7cf40c1134002851a2",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_7c7d2eddac0011eeb5303cecef1b359e",
-        "x-runtime": "0.053683",
-        "x-node": "bigweb35nuq",
+        "Location": "/api/v2/addresses/adr_22d3ad7eac1611eeacff3cecef1b359e",
+        "x-runtime": "0.049349",
+        "x-node": "bigweb42nuq",
         "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
+        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/net/address_service_with_parameters/create_verify.json
+++ b/EasyPost.Tests/cassettes/net/address_service_with_parameters/create_verify.json
@@ -1,13 +1,13 @@
 [
   {
-    "Duration": 429,
-    "RecordedAt": "2023-04-25T21:17:06.833362-06:00",
+    "Duration": 238,
+    "RecordedAt": "2024-01-05T12:27:38.121117-07:00",
     "Request": {
-      "Body": "{\"address\":{\"city\":\"San Francisco\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\",\"state\":\"CA\",\"street1\":\"417 montgomery street\",\"street2\":\"FL 5\",\"zip\":\"94104\"},\"verify\":true}",
+      "Body": "{\"address\":{\"city\":\"San Francisco\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"name\":\"Jack Sparrow\",\"phone\":\"<REDACTED>\",\"state\":\"CA\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"zip\":\"94107\"}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "191"
+        "Content-Length": "190"
       },
       "Method": "POST",
       "RequestHeaders": {
@@ -17,12 +17,12 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_d2ec05ace3e011ed92c4ac1f6bc7bdc6\",\"object\":\"Address\",\"created_at\":\"2023-04-25T21:17:06-06:00\",\"updated_at\":\"2023-04-25T21:17:06-06:00\",\"name\":null,\"company\":null,\"street1\":\"417 MONTGOMERY ST FL 5\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94104-1129\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[{\"code\":\"E.SECONDARY_INFORMATION.INVALID\",\"field\":\"street2\",\"message\":\"Invalid secondary information(Apt/Suite#)\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[{\"code\":\"E.SECONDARY_INFORMATION.INVALID\",\"field\":\"street2\",\"message\":\"Invalid secondary information(Apt/Suite#)\",\"suggestion\":null}],\"details\":{\"latitude\":37.79342,\"longitude\":-122.40288,\"time_zone\":\"America/Los_Angeles\"}}}}",
+      "Body": "{\"id\":\"adr_7c6c13bfac0011eeb5243cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:38-07:00\",\"updated_at\":\"2024-01-05T12:27:38-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "901"
+        "Content-Length": "456"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -32,16 +32,66 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "d4af614b644897b2f753e87b0009463e",
+        "x-ep-request-uuid": "dc2c57f36598582af3f7dc33000eef39",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_d2ec05ace3e011ed92c4ac1f6bc7bdc6",
-        "ETag": "W/\"0e7da312eae0f9887b86e0aac59ce2e7\"",
-        "x-runtime": "0.047057",
-        "x-node": "bigweb6nuq",
-        "x-version-label": "easypost-202304252326-79950b6035-master",
+        "Location": "/api/v2/addresses/adr_7c6c13bfac0011eeb5243cecef1b359e",
+        "x-runtime": "0.044841",
+        "x-node": "bigweb43nuq",
+        "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq a29e4ad05c,intlb2wdc a29e4ad05c,extlb4wdc a29e4ad05c",
+        "x-canary": "direct",
+        "x-proxied": "intlb1nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "Status": {
+        "Code": 201,
+        "Message": "Created"
+      }
+    }
+  },
+  {
+    "Duration": 94,
+    "RecordedAt": "2024-01-05T12:27:38.232125-07:00",
+    "Request": {
+      "Body": "{\"address\":{\"city\":\"San Francisco\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"name\":\"Jack Sparrow\",\"phone\":\"<REDACTED>\",\"state\":\"CA\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"zip\":\"94107\"},\"verify\":true}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "204"
+      },
+      "Method": "POST",
+      "RequestHeaders": {
+        "Authorization": "<REDACTED>",
+        "User-Agent": "<REDACTED>"
+      },
+      "Uri": "https://api.easypost.com/v2/addresses"
+    },
+    "Response": {
+      "Body": "{\"id\":\"adr_7c7d2eddac0011eeb5303cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:38-07:00\",\"updated_at\":\"2024-01-05T12:27:38-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":{}}}}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "965"
+      },
+      "HttpVersion": "1.1",
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-XSS-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "dc2c57f36598582af3f7dc33000eef52",
+        "Cache-Control": "no-store, no-cache, private",
+        "Pragma": "no-cache",
+        "Location": "/api/v2/addresses/adr_7c7d2eddac0011eeb5303cecef1b359e",
+        "x-runtime": "0.053683",
+        "x-node": "bigweb35nuq",
+        "x-version-label": "easypost-202401051829-4cf193bd35-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb1nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/net/address_service_with_parameters/create_verify_strict.json
+++ b/EasyPost.Tests/cassettes/net/address_service_with_parameters/create_verify_strict.json
@@ -1,7 +1,7 @@
 [
   {
-    "Duration": 419,
-    "RecordedAt": "2023-04-25T21:17:07.264891-06:00",
+    "Duration": 227,
+    "RecordedAt": "2024-01-05T12:27:38.516833-07:00",
     "Request": {
       "Body": "{\"address\":{\"city\":\"San Francisco\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"name\":\"Jack Sparrow\",\"phone\":\"<REDACTED>\",\"state\":\"CA\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"zip\":\"94107\"},\"verify_strict\":true}",
       "BodyContentType": "Json",
@@ -17,7 +17,7 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_d32d9571e3e011eda469ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2023-04-25T21:17:07-06:00\",\"updated_at\":\"2023-04-25T21:17:07-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
+      "Body": "{\"id\":\"adr_7ca8fad6ac0011eeb5443cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:38-07:00\",\"updated_at\":\"2024-01-05T12:27:38-07:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
@@ -32,16 +32,16 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "d4af6151644897b3f752c6060009465f",
+        "x-ep-request-uuid": "dc2c57f26598582af41930dd000eef81",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_d32d9571e3e011eda469ac1f6bc72124",
-        "ETag": "W/\"f2d88da17e190ce983fd63bbe0d649b6\"",
-        "x-runtime": "0.057984",
-        "x-node": "bigweb2nuq",
-        "x-version-label": "easypost-202304252326-79950b6035-master",
+        "Location": "/api/v2/addresses/adr_7ca8fad6ac0011eeb5443cecef1b359e",
+        "x-runtime": "0.055343",
+        "x-node": "bigweb32nuq",
+        "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb2nuq a29e4ad05c,intlb1wdc a29e4ad05c,extlb4wdc a29e4ad05c",
+        "x-canary": "direct",
+        "x-proxied": "intlb2nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/net/address_service_with_parameters/create_verify_strict.json
+++ b/EasyPost.Tests/cassettes/net/address_service_with_parameters/create_verify_strict.json
@@ -1,7 +1,7 @@
 [
   {
-    "Duration": 227,
-    "RecordedAt": "2024-01-05T12:27:38.516833-07:00",
+    "Duration": 399,
+    "RecordedAt": "2024-01-05T15:02:37.251437-07:00",
     "Request": {
       "Body": "{\"address\":{\"city\":\"San Francisco\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"name\":\"Jack Sparrow\",\"phone\":\"<REDACTED>\",\"state\":\"CA\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"zip\":\"94107\"},\"verify_strict\":true}",
       "BodyContentType": "Json",
@@ -17,7 +17,7 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_7ca8fad6ac0011eeb5443cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:38-07:00\",\"updated_at\":\"2024-01-05T12:27:38-07:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
+      "Body": "{\"id\":\"adr_23196734ac1611eea507ac1f6bc539aa\",\"object\":\"Address\",\"created_at\":\"2024-01-05T15:02:37-07:00\",\"updated_at\":\"2024-01-05T15:02:37-07:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
@@ -32,16 +32,16 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "dc2c57f26598582af41930dd000eef81",
+        "x-ep-request-uuid": "f29a8cfe65987c7df409df05002851d5",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_7ca8fad6ac0011eeb5443cecef1b359e",
-        "x-runtime": "0.055343",
-        "x-node": "bigweb32nuq",
+        "Location": "/api/v2/addresses/adr_23196734ac1611eea507ac1f6bc539aa",
+        "x-runtime": "0.210026",
+        "x-node": "bigweb43nuq",
         "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
         "x-canary": "direct",
-        "x-proxied": "intlb2nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
+        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/netstandard/address_service/create_verify.json
+++ b/EasyPost.Tests/cassettes/netstandard/address_service/create_verify.json
@@ -1,30 +1,28 @@
 [
   {
-    "Duration": 658,
-    "RecordedAt": "2022-10-24T12:36:17.842733-06:00",
+    "Duration": 427,
+    "RecordedAt": "2024-01-05T12:27:51.477007-07:00",
     "Request": {
-      "Body": "{\"address\":{\"company\":\"EasyPost\",\"street1\":\"417 montgomery street\",\"street2\":\"FL 5\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify\":true}",
+      "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "212"
+        "Content-Length": "190"
       },
       "Method": "POST",
       "RequestHeaders": {
         "Authorization": "<REDACTED>",
-        "content_type": "application/json",
-        "Accept": "application/json,text/json,text/x-json,text/javascript,application/xml,text/xml",
         "User-Agent": "<REDACTED>"
       },
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_bf7c543753ca11ed9f41ac1f6b0a0d1e\",\"object\":\"Address\",\"created_at\":\"2022-10-24T12:36:17-06:00\",\"updated_at\":\"2022-10-24T12:36:17-06:00\",\"name\":null,\"company\":\"EASYPOST\",\"street1\":\"417 MONTGOMERY ST FL 5\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94104-1129\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[{\"code\":\"E.SECONDARY_INFORMATION.INVALID\",\"field\":\"street2\",\"message\":\"Invalid secondary information(Apt/Suite#)\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[{\"code\":\"E.SECONDARY_INFORMATION.INVALID\",\"field\":\"street2\",\"message\":\"Invalid secondary information(Apt/Suite#)\",\"suggestion\":null}],\"details\":{\"latitude\":37.79342,\"longitude\":-122.40288,\"time_zone\":\"America/Los_Angeles\"}}}}",
+      "Body": "{\"id\":\"adr_8454b4c2ac0011ee94f1ac1f6bc539ae\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:51-07:00\",\"updated_at\":\"2024-01-05T12:27:51-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "907"
+        "Content-Length": "456"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -34,16 +32,65 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "referrer-policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "bcc8f23d6356db21ecd673ce00229b1d",
+        "x-ep-request-uuid": "f29a8d0165985837f40b8c8e000dc428",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_bf7c543753ca11ed9f41ac1f6b0a0d1e",
-        "ETag": "W/\"62dec7fb62750f93f9a10752fd391446\"",
-        "x-runtime": "0.050538",
-        "x-node": "bigweb3nuq",
-        "x-version-label": "easypost-202210241803-ba94ab8034-master",
+        "Location": "/api/v2/addresses/adr_8454b4c2ac0011ee94f1ac1f6bc539ae",
+        "x-runtime": "0.040746",
+        "x-node": "bigweb39nuq",
+        "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq 29913d444b,extlb2nuq 29913d444b",
+        "x-proxied": "intlb2nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "Status": {
+        "Code": 201,
+        "Message": "Created"
+      }
+    }
+  },
+  {
+    "Duration": 96,
+    "RecordedAt": "2024-01-05T12:27:51.618988-07:00",
+    "Request": {
+      "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify\":true}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "204"
+      },
+      "Method": "POST",
+      "RequestHeaders": {
+        "Authorization": "<REDACTED>",
+        "User-Agent": "<REDACTED>"
+      },
+      "Uri": "https://api.easypost.com/v2/addresses"
+    },
+    "Response": {
+      "Body": "{\"id\":\"adr_8477c4c2ac0011eeb509ac1f6bc53342\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:51-07:00\",\"updated_at\":\"2024-01-05T12:27:51-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":{}}}}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "965"
+      },
+      "HttpVersion": "1.1",
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "referrer-policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "f29a8d0165985837f40b8c8e000dc450",
+        "Cache-Control": "no-store, no-cache, private",
+        "Pragma": "no-cache",
+        "Location": "/api/v2/addresses/adr_8477c4c2ac0011eeb509ac1f6bc53342",
+        "x-runtime": "0.051427",
+        "x-node": "bigweb42nuq",
+        "x-version-label": "easypost-202401051829-4cf193bd35-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/netstandard/address_service/create_verify.json
+++ b/EasyPost.Tests/cassettes/netstandard/address_service/create_verify.json
@@ -1,13 +1,13 @@
 [
   {
-    "Duration": 427,
-    "RecordedAt": "2024-01-05T12:27:51.477007-07:00",
+    "Duration": 841,
+    "RecordedAt": "2024-01-05T15:02:50.288369-07:00",
     "Request": {
-      "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"}}",
+      "Body": "{\"address\":{\"company\":\"EasyPost\",\"street1\":\"000 unknown street\",\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "190"
+        "Content-Length": "175"
       },
       "Method": "POST",
       "RequestHeaders": {
@@ -17,12 +17,12 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_8454b4c2ac0011ee94f1ac1f6bc539ae\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:51-07:00\",\"updated_at\":\"2024-01-05T12:27:51-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}",
+      "Body": "{\"id\":\"adr_2ad1240aac1611eea3acac1f6bc53342\",\"object\":\"Address\",\"created_at\":\"2024-01-05T15:02:50-07:00\",\"updated_at\":\"2024-01-05T15:02:50-07:00\",\"name\":null,\"company\":\"EasyPost\",\"street1\":\"000 unknown street\",\"street2\":null,\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "456"
+        "Content-Length": "453"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -32,15 +32,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "referrer-policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "f29a8d0165985837f40b8c8e000dc428",
+        "x-ep-request-uuid": "dc2c57ef65987c8af441d1d1002c04d3",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_8454b4c2ac0011ee94f1ac1f6bc539ae",
-        "x-runtime": "0.040746",
-        "x-node": "bigweb39nuq",
+        "Location": "/api/v2/addresses/adr_2ad1240aac1611eea3acac1f6bc53342",
+        "x-runtime": "0.035651",
+        "x-node": "bigweb38nuq",
         "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb2nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
+        "x-proxied": "intlb2nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {
@@ -50,14 +50,14 @@
     }
   },
   {
-    "Duration": 96,
-    "RecordedAt": "2024-01-05T12:27:51.618988-07:00",
+    "Duration": 86,
+    "RecordedAt": "2024-01-05T15:02:50.441604-07:00",
     "Request": {
-      "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify\":true}",
+      "Body": "{\"address\":{\"company\":\"EasyPost\",\"street1\":\"000 unknown street\",\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify\":true}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "204"
+        "Content-Length": "189"
       },
       "Method": "POST",
       "RequestHeaders": {
@@ -67,12 +67,12 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_8477c4c2ac0011eeb509ac1f6bc53342\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:51-07:00\",\"updated_at\":\"2024-01-05T12:27:51-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":{}}}}",
+      "Body": "{\"id\":\"adr_2af55f83ac1611eea9ceac1f6bc539aa\",\"object\":\"Address\",\"created_at\":\"2024-01-05T15:02:50-07:00\",\"updated_at\":\"2024-01-05T15:02:50-07:00\",\"name\":null,\"company\":\"EasyPost\",\"street1\":\"000 unknown street\",\"street2\":null,\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null}],\"details\":{}}}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "965"
+        "Content-Length": "750"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -82,15 +82,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "referrer-policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "f29a8d0165985837f40b8c8e000dc450",
+        "x-ep-request-uuid": "dc2c57ef65987c8af441d1d1002c050d",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_8477c4c2ac0011eeb509ac1f6bc53342",
-        "x-runtime": "0.051427",
-        "x-node": "bigweb42nuq",
+        "Location": "/api/v2/addresses/adr_2af55f83ac1611eea9ceac1f6bc539aa",
+        "x-runtime": "0.050029",
+        "x-node": "bigweb31nuq",
         "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
+        "x-proxied": "intlb1nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/netstandard/address_service/create_verify_array.json
+++ b/EasyPost.Tests/cassettes/netstandard/address_service/create_verify_array.json
@@ -1,30 +1,28 @@
 [
   {
-    "Duration": 250,
-    "RecordedAt": "2022-10-24T12:36:19.469426-06:00",
+    "Duration": 211,
+    "RecordedAt": "2024-01-05T12:27:51.87014-07:00",
     "Request": {
-      "Body": "{\"address\":{\"company\":\"EasyPost\",\"street1\":\"417 montgomery street\",\"street2\":\"FL 5\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94104\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify\":true}",
+      "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "212"
+        "Content-Length": "190"
       },
       "Method": "POST",
       "RequestHeaders": {
         "Authorization": "<REDACTED>",
-        "content_type": "application/json",
-        "Accept": "application/json,text/json,text/x-json,text/javascript,application/xml,text/xml",
         "User-Agent": "<REDACTED>"
       },
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_c0741ccc53ca11ed8cb3ac1f6bc7b362\",\"object\":\"Address\",\"created_at\":\"2022-10-24T12:36:19-06:00\",\"updated_at\":\"2022-10-24T12:36:19-06:00\",\"name\":null,\"company\":\"EASYPOST\",\"street1\":\"417 MONTGOMERY ST FL 5\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94104-1129\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[{\"code\":\"E.SECONDARY_INFORMATION.INVALID\",\"field\":\"street2\",\"message\":\"Invalid secondary information(Apt/Suite#)\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[{\"code\":\"E.SECONDARY_INFORMATION.INVALID\",\"field\":\"street2\",\"message\":\"Invalid secondary information(Apt/Suite#)\",\"suggestion\":null}],\"details\":{\"latitude\":37.79342,\"longitude\":-122.40288,\"time_zone\":\"America/Los_Angeles\"}}}}",
+      "Body": "{\"id\":\"adr_849f6a7fac0011eeb8f53cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:52-07:00\",\"updated_at\":\"2024-01-05T12:27:52-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "907"
+        "Content-Length": "456"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -34,16 +32,65 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "referrer-policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "d6c023f46356db23eca00be00021c804",
+        "x-ep-request-uuid": "f29a8d0265985837f41a62eb000dc48b",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_c0741ccc53ca11ed8cb3ac1f6bc7b362",
-        "ETag": "W/\"ca3943ae67eea6f4a5cc2ee71e1e7bd1\"",
-        "x-runtime": "0.147806",
-        "x-node": "bigweb8nuq",
-        "x-version-label": "easypost-202210241803-ba94ab8034-master",
+        "Location": "/api/v2/addresses/adr_849f6a7fac0011eeb8f53cecef1b359e",
+        "x-runtime": "0.032608",
+        "x-node": "bigweb34nuq",
+        "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq 29913d444b,extlb1nuq 29913d444b",
+        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "Status": {
+        "Code": 201,
+        "Message": "Created"
+      }
+    }
+  },
+  {
+    "Duration": 89,
+    "RecordedAt": "2024-01-05T12:27:51.978081-07:00",
+    "Request": {
+      "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify\":true}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "204"
+      },
+      "Method": "POST",
+      "RequestHeaders": {
+        "Authorization": "<REDACTED>",
+        "User-Agent": "<REDACTED>"
+      },
+      "Uri": "https://api.easypost.com/v2/addresses"
+    },
+    "Response": {
+      "Body": "{\"id\":\"adr_84aedb51ac0011eeb8fc3cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:52-07:00\",\"updated_at\":\"2024-01-05T12:27:52-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":{}}}}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "965"
+      },
+      "HttpVersion": "1.1",
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "referrer-policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "f29a8d0265985838f41a62eb000dc495",
+        "Cache-Control": "no-store, no-cache, private",
+        "Pragma": "no-cache",
+        "Location": "/api/v2/addresses/adr_84aedb51ac0011eeb8fc3cecef1b359e",
+        "x-runtime": "0.053811",
+        "x-node": "bigweb35nuq",
+        "x-version-label": "easypost-202401051829-4cf193bd35-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/netstandard/address_service/create_verify_array.json
+++ b/EasyPost.Tests/cassettes/netstandard/address_service/create_verify_array.json
@@ -1,13 +1,13 @@
 [
   {
-    "Duration": 211,
-    "RecordedAt": "2024-01-05T12:27:51.87014-07:00",
+    "Duration": 234,
+    "RecordedAt": "2024-01-05T15:02:50.730963-07:00",
     "Request": {
-      "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"}}",
+      "Body": "{\"address\":{\"company\":\"EasyPost\",\"street1\":\"000 unknown street\",\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "190"
+        "Content-Length": "175"
       },
       "Method": "POST",
       "RequestHeaders": {
@@ -17,12 +17,12 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_849f6a7fac0011eeb8f53cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:52-07:00\",\"updated_at\":\"2024-01-05T12:27:52-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}",
+      "Body": "{\"id\":\"adr_2b2265f0ac1611ee8903ac1f6bc539ae\",\"object\":\"Address\",\"created_at\":\"2024-01-05T15:02:50-07:00\",\"updated_at\":\"2024-01-05T15:02:50-07:00\",\"name\":null,\"company\":\"EasyPost\",\"street1\":\"000 unknown street\",\"street2\":null,\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "456"
+        "Content-Length": "453"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -32,15 +32,16 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "referrer-policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "f29a8d0265985837f41a62eb000dc48b",
+        "x-ep-request-uuid": "dc2c57ee65987c8af42f24f0002c0554",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_849f6a7fac0011eeb8f53cecef1b359e",
-        "x-runtime": "0.032608",
-        "x-node": "bigweb34nuq",
+        "Location": "/api/v2/addresses/adr_2b2265f0ac1611ee8903ac1f6bc539ae",
+        "x-runtime": "0.046857",
+        "x-node": "bigweb43nuq",
         "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
+        "x-canary": "direct",
+        "x-proxied": "intlb1nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {
@@ -50,14 +51,14 @@
     }
   },
   {
-    "Duration": 89,
-    "RecordedAt": "2024-01-05T12:27:51.978081-07:00",
+    "Duration": 88,
+    "RecordedAt": "2024-01-05T15:02:50.850197-07:00",
     "Request": {
-      "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify\":true}",
+      "Body": "{\"address\":{\"company\":\"EasyPost\",\"street1\":\"000 unknown street\",\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify\":true}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "204"
+        "Content-Length": "189"
       },
       "Method": "POST",
       "RequestHeaders": {
@@ -67,12 +68,12 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_84aedb51ac0011eeb8fc3cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:52-07:00\",\"updated_at\":\"2024-01-05T12:27:52-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":{}}}}",
+      "Body": "{\"id\":\"adr_2b343d24ac1611ee890dac1f6bc539ae\",\"object\":\"Address\",\"created_at\":\"2024-01-05T15:02:50-07:00\",\"updated_at\":\"2024-01-05T15:02:50-07:00\",\"name\":null,\"company\":\"EasyPost\",\"street1\":\"000 unknown street\",\"street2\":null,\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null}],\"details\":{}}}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "965"
+        "Content-Length": "750"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -82,15 +83,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "referrer-policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "f29a8d0265985838f41a62eb000dc495",
+        "x-ep-request-uuid": "dc2c57ee65987c8af42f24f0002c0567",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_84aedb51ac0011eeb8fc3cecef1b359e",
-        "x-runtime": "0.053811",
-        "x-node": "bigweb35nuq",
+        "Location": "/api/v2/addresses/adr_2b343d24ac1611ee890dac1f6bc539ae",
+        "x-runtime": "0.046097",
+        "x-node": "bigweb39nuq",
         "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
+        "x-proxied": "intlb1nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/netstandard/address_service/create_verify_strict.json
+++ b/EasyPost.Tests/cassettes/netstandard/address_service/create_verify_strict.json
@@ -1,7 +1,7 @@
 [
   {
-    "Duration": 398,
-    "RecordedAt": "2022-10-24T12:36:20.597859-06:00",
+    "Duration": 267,
+    "RecordedAt": "2024-01-05T12:27:52.308691-07:00",
     "Request": {
       "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify_strict\":true}",
       "BodyContentType": "Json",
@@ -12,14 +12,12 @@
       "Method": "POST",
       "RequestHeaders": {
         "Authorization": "<REDACTED>",
-        "content_type": "application/json",
-        "Accept": "application/json,text/json,text/x-json,text/javascript,application/xml,text/xml",
         "User-Agent": "<REDACTED>"
       },
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_c12059de53ca11ed962bac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-10-24T12:36:20-06:00\",\"updated_at\":\"2022-10-24T12:36:20-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
+      "Body": "{\"id\":\"adr_84e08c05ac0011eeb585ac1f6bc539aa\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:52-07:00\",\"updated_at\":\"2024-01-05T12:27:52-07:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
@@ -34,16 +32,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "referrer-policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "bcc8f23f6356db24f3c5ca8f00229c3f",
+        "x-ep-request-uuid": "f29a8d0465985838f4194a4a000dc4bd",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_c12059de53ca11ed962bac1f6bc72124",
-        "ETag": "W/\"96a6c7932a17faf79527a2d9f7c0ffad\"",
-        "x-runtime": "0.048461",
-        "x-node": "bigweb1nuq",
-        "x-version-label": "easypost-202210241803-ba94ab8034-master",
+        "Location": "/api/v2/addresses/adr_84e08c05ac0011eeb585ac1f6bc539aa",
+        "x-runtime": "0.086371",
+        "x-node": "bigweb41nuq",
+        "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq 29913d444b,extlb2nuq 29913d444b",
+        "x-proxied": "intlb2nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/netstandard/address_service/create_verify_strict.json
+++ b/EasyPost.Tests/cassettes/netstandard/address_service/create_verify_strict.json
@@ -1,7 +1,7 @@
 [
   {
-    "Duration": 267,
-    "RecordedAt": "2024-01-05T12:27:52.308691-07:00",
+    "Duration": 232,
+    "RecordedAt": "2024-01-05T15:02:51.149773-07:00",
     "Request": {
       "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify_strict\":true}",
       "BodyContentType": "Json",
@@ -17,7 +17,7 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_84e08c05ac0011eeb585ac1f6bc539aa\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:52-07:00\",\"updated_at\":\"2024-01-05T12:27:52-07:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
+      "Body": "{\"id\":\"adr_2b619cb1ac1611eeb21d3cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T15:02:51-07:00\",\"updated_at\":\"2024-01-05T15:02:51-07:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
@@ -32,15 +32,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "referrer-policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "f29a8d0465985838f4194a4a000dc4bd",
+        "x-ep-request-uuid": "dc2c57ed65987c8bf3f7c64a002c05a5",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_84e08c05ac0011eeb585ac1f6bc539aa",
-        "x-runtime": "0.086371",
-        "x-node": "bigweb41nuq",
+        "Location": "/api/v2/addresses/adr_2b619cb1ac1611eeb21d3cecef1b359e",
+        "x-runtime": "0.057250",
+        "x-node": "bigweb31nuq",
         "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb2nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
+        "x-proxied": "intlb2nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/netstandard/address_service/create_verify_strict_array.json
+++ b/EasyPost.Tests/cassettes/netstandard/address_service/create_verify_strict_array.json
@@ -1,7 +1,7 @@
 [
   {
-    "Duration": 398,
-    "RecordedAt": "2022-10-24T12:36:21.019116-06:00",
+    "Duration": 232,
+    "RecordedAt": "2024-01-05T12:27:52.564445-07:00",
     "Request": {
       "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify_strict\":true}",
       "BodyContentType": "Json",
@@ -12,14 +12,12 @@
       "Method": "POST",
       "RequestHeaders": {
         "Authorization": "<REDACTED>",
-        "content_type": "application/json",
-        "Accept": "application/json,text/json,text/x-json,text/javascript,application/xml,text/xml",
         "User-Agent": "<REDACTED>"
       },
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_c16067f153ca11ed9773ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2022-10-24T12:36:21-06:00\",\"updated_at\":\"2022-10-24T12:36:21-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
+      "Body": "{\"id\":\"adr_850878e3ac0011eeb544ac1f6bc53342\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:52-07:00\",\"updated_at\":\"2024-01-05T12:27:52-07:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
@@ -34,16 +32,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "referrer-policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "bcc8f23b6356db25ec90c2f000229c63",
+        "x-ep-request-uuid": "f29a8d0065985838f41d296b000dc4ea",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_c16067f153ca11ed9773ac1f6bc72124",
-        "ETag": "W/\"1637239027af2c4e245417121258ce24\"",
-        "x-runtime": "0.051989",
-        "x-node": "bigweb5nuq",
-        "x-version-label": "easypost-202210241803-ba94ab8034-master",
+        "Location": "/api/v2/addresses/adr_850878e3ac0011eeb544ac1f6bc53342",
+        "x-runtime": "0.052219",
+        "x-node": "bigweb38nuq",
+        "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq 29913d444b,extlb2nuq 29913d444b",
+        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/netstandard/address_service/create_verify_strict_array.json
+++ b/EasyPost.Tests/cassettes/netstandard/address_service/create_verify_strict_array.json
@@ -1,7 +1,7 @@
 [
   {
-    "Duration": 232,
-    "RecordedAt": "2024-01-05T12:27:52.564445-07:00",
+    "Duration": 357,
+    "RecordedAt": "2024-01-05T15:02:51.532291-07:00",
     "Request": {
       "Body": "{\"address\":{\"name\":\"Jack Sparrow\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\"},\"verify_strict\":true}",
       "BodyContentType": "Json",
@@ -17,7 +17,7 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_850878e3ac0011eeb544ac1f6bc53342\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:52-07:00\",\"updated_at\":\"2024-01-05T12:27:52-07:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
+      "Body": "{\"id\":\"adr_2b9bc40eac1611eea421ac1f6bc53342\",\"object\":\"Address\",\"created_at\":\"2024-01-05T15:02:51-07:00\",\"updated_at\":\"2024-01-05T15:02:51-07:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
@@ -32,15 +32,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "referrer-policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "f29a8d0065985838f41d296b000dc4ea",
+        "x-ep-request-uuid": "dc2c57f165987c8bf42f4254002c05ec",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_850878e3ac0011eeb544ac1f6bc53342",
-        "x-runtime": "0.052219",
-        "x-node": "bigweb38nuq",
+        "Location": "/api/v2/addresses/adr_2b9bc40eac1611eea421ac1f6bc53342",
+        "x-runtime": "0.168353",
+        "x-node": "bigweb41nuq",
         "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
+        "x-proxied": "intlb2nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/netstandard/address_service_with_parameters/create_verify.json
+++ b/EasyPost.Tests/cassettes/netstandard/address_service_with_parameters/create_verify.json
@@ -1,30 +1,28 @@
 [
   {
-    "Duration": 221,
-    "RecordedAt": "2023-03-15T16:18:04.339761-06:00",
+    "Duration": 811,
+    "RecordedAt": "2024-01-05T12:27:51.477017-07:00",
     "Request": {
-      "Body": "{\"address\":{\"city\":\"San Francisco\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\",\"state\":\"CA\",\"street1\":\"417 montgomery street\",\"street2\":\"FL 5\",\"zip\":\"94104\"},\"verify\":true}",
+      "Body": "{\"address\":{\"city\":\"San Francisco\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"name\":\"Jack Sparrow\",\"phone\":\"<REDACTED>\",\"state\":\"CA\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"zip\":\"94107\"}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "191"
+        "Content-Length": "190"
       },
       "Method": "POST",
       "RequestHeaders": {
         "Authorization": "<REDACTED>",
-        "content_type": "application/json",
-        "Accept": "application/json,text/json,text/x-json,text/javascript,application/xml,text/xml",
         "User-Agent": "<REDACTED>"
       },
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_41729ab0c37f11ed82caac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2023-03-15T16:18:04-06:00\",\"updated_at\":\"2023-03-15T16:18:04-06:00\",\"name\":null,\"company\":null,\"street1\":\"417 MONTGOMERY ST FL 5\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94104-1129\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":false,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[{\"code\":\"E.SECONDARY_INFORMATION.INVALID\",\"field\":\"street2\",\"message\":\"Invalid secondary information(Apt/Suite#)\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[{\"code\":\"E.SECONDARY_INFORMATION.INVALID\",\"field\":\"street2\",\"message\":\"Invalid secondary information(Apt/Suite#)\",\"suggestion\":null}],\"details\":{\"latitude\":37.79342,\"longitude\":-122.40288,\"time_zone\":\"America/Los_Angeles\"}}}}",
+      "Body": "{\"id\":\"adr_8460e86cac0011eeb8d23cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:51-07:00\",\"updated_at\":\"2024-01-05T12:27:51-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "901"
+        "Content-Length": "456"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -34,16 +32,65 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "referrer-policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "287eb8e56412441ce675ab09002c3704",
+        "x-ep-request-uuid": "f29a8d0065985837f42b4d7f000dc437",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_41729ab0c37f11ed82caac1f6bc72124",
-        "ETag": "W/\"0691da589802f72bc79a25491168196b\"",
-        "x-runtime": "0.048627",
-        "x-node": "bigweb1nuq",
-        "x-version-label": "easypost-202303142258-f5b873fcbd-master",
+        "Location": "/api/v2/addresses/adr_8460e86cac0011eeb8d23cecef1b359e",
+        "x-runtime": "0.038244",
+        "x-node": "bigweb35nuq",
+        "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb2nuq a40ea751fd,extlb1nuq a40ea751fd",
+        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
+        "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
+      },
+      "Status": {
+        "Code": 201,
+        "Message": "Created"
+      }
+    }
+  },
+  {
+    "Duration": 93,
+    "RecordedAt": "2024-01-05T12:27:51.631467-07:00",
+    "Request": {
+      "Body": "{\"address\":{\"city\":\"San Francisco\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"name\":\"Jack Sparrow\",\"phone\":\"<REDACTED>\",\"state\":\"CA\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"zip\":\"94107\"},\"verify\":true}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "204"
+      },
+      "Method": "POST",
+      "RequestHeaders": {
+        "Authorization": "<REDACTED>",
+        "User-Agent": "<REDACTED>"
+      },
+      "Uri": "https://api.easypost.com/v2/addresses"
+    },
+    "Response": {
+      "Body": "{\"id\":\"adr_847a1a6eac0011eeb8e03cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:51-07:00\",\"updated_at\":\"2024-01-05T12:27:51-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":{}}}}",
+      "BodyContentType": "Json",
+      "ContentHeaders": {
+        "Expires": "0",
+        "Content-Type": "application/json; charset=utf-8",
+        "Content-Length": "965"
+      },
+      "HttpVersion": "1.1",
+      "ResponseHeaders": {
+        "X-Frame-Options": "SAMEORIGIN",
+        "x-xss-protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "x-download-options": "noopen",
+        "x-permitted-cross-domain-policies": "none",
+        "referrer-policy": "strict-origin-when-cross-origin",
+        "x-ep-request-uuid": "f29a8d0065985837f42b4d7f000dc452",
+        "Cache-Control": "no-store, no-cache, private",
+        "Pragma": "no-cache",
+        "Location": "/api/v2/addresses/adr_847a1a6eac0011eeb8e03cecef1b359e",
+        "x-runtime": "0.054949",
+        "x-node": "bigweb33nuq",
+        "x-version-label": "easypost-202401051829-4cf193bd35-master",
+        "x-backend": "easypost",
+        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/netstandard/address_service_with_parameters/create_verify.json
+++ b/EasyPost.Tests/cassettes/netstandard/address_service_with_parameters/create_verify.json
@@ -1,13 +1,13 @@
 [
   {
-    "Duration": 811,
-    "RecordedAt": "2024-01-05T12:27:51.477017-07:00",
+    "Duration": 284,
+    "RecordedAt": "2024-01-05T15:02:50.288354-07:00",
     "Request": {
-      "Body": "{\"address\":{\"city\":\"San Francisco\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"name\":\"Jack Sparrow\",\"phone\":\"<REDACTED>\",\"state\":\"CA\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"zip\":\"94107\"}}",
+      "Body": "{\"address\":{\"city\":\"Not A City\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\",\"state\":\"ZZ\",\"street1\":\"000 unknown street\",\"zip\":\"00001\"}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "190"
+        "Content-Length": "154"
       },
       "Method": "POST",
       "RequestHeaders": {
@@ -17,12 +17,12 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_8460e86cac0011eeb8d23cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:51-07:00\",\"updated_at\":\"2024-01-05T12:27:51-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}",
+      "Body": "{\"id\":\"adr_2ad14e91ac1611eea9c3ac1f6bc539aa\",\"object\":\"Address\",\"created_at\":\"2024-01-05T15:02:50-07:00\",\"updated_at\":\"2024-01-05T15:02:50-07:00\",\"name\":null,\"company\":null,\"street1\":\"000 unknown street\",\"street2\":null,\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "456"
+        "Content-Length": "447"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -32,15 +32,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "referrer-policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "f29a8d0065985837f42b4d7f000dc437",
+        "x-ep-request-uuid": "dc2c57f165987c8af4513e34002c04d4",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_8460e86cac0011eeb8d23cecef1b359e",
-        "x-runtime": "0.038244",
-        "x-node": "bigweb35nuq",
+        "Location": "/api/v2/addresses/adr_2ad14e91ac1611eea9c3ac1f6bc539aa",
+        "x-runtime": "0.034369",
+        "x-node": "bigweb36nuq",
         "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
+        "x-proxied": "intlb1nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {
@@ -51,13 +51,13 @@
   },
   {
     "Duration": 93,
-    "RecordedAt": "2024-01-05T12:27:51.631467-07:00",
+    "RecordedAt": "2024-01-05T15:02:50.426533-07:00",
     "Request": {
-      "Body": "{\"address\":{\"city\":\"San Francisco\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"name\":\"Jack Sparrow\",\"phone\":\"<REDACTED>\",\"state\":\"CA\",\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"zip\":\"94107\"},\"verify\":true}",
+      "Body": "{\"address\":{\"city\":\"Not A City\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"phone\":\"<REDACTED>\",\"state\":\"ZZ\",\"street1\":\"000 unknown street\",\"zip\":\"00001\"},\"verify\":true}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "204"
+        "Content-Length": "168"
       },
       "Method": "POST",
       "RequestHeaders": {
@@ -67,12 +67,12 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_847a1a6eac0011eeb8e03cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:51-07:00\",\"updated_at\":\"2024-01-05T12:27:51-07:00\",\"name\":\"Jack Sparrow\",\"company\":null,\"street1\":\"jfskfhasli\",\"street2\":\"Apt 20\",\"city\":\"San Francisco\",\"state\":\"CA\",\"zip\":\"94107\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null},{\"code\":\"E.HOUSE_NUMBER.MISSING\",\"field\":\"street1\",\"message\":\"House number is missing\",\"suggestion\":null}],\"details\":{}}}}",
+      "Body": "{\"id\":\"adr_2af3f455ac1611eea9caac1f6bc539aa\",\"object\":\"Address\",\"created_at\":\"2024-01-05T15:02:50-07:00\",\"updated_at\":\"2024-01-05T15:02:50-07:00\",\"name\":null,\"company\":null,\"street1\":\"000 unknown street\",\"street2\":null,\"city\":\"Not A City\",\"state\":\"ZZ\",\"zip\":\"00001\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":null,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null}],\"details\":null},\"delivery\":{\"success\":false,\"errors\":[{\"code\":\"E.ADDRESS.NOT_FOUND\",\"field\":\"address\",\"message\":\"Address not found\",\"suggestion\":null}],\"details\":{}}}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
         "Content-Type": "application/json; charset=utf-8",
-        "Content-Length": "965"
+        "Content-Length": "744"
       },
       "HttpVersion": "1.1",
       "ResponseHeaders": {
@@ -82,15 +82,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "referrer-policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "f29a8d0065985837f42b4d7f000dc452",
+        "x-ep-request-uuid": "dc2c57f165987c8af4513e34002c0508",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_847a1a6eac0011eeb8e03cecef1b359e",
-        "x-runtime": "0.054949",
-        "x-node": "bigweb33nuq",
+        "Location": "/api/v2/addresses/adr_2af3f455ac1611eea9caac1f6bc539aa",
+        "x-runtime": "0.047134",
+        "x-node": "bigweb31nuq",
         "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
+        "x-proxied": "intlb2nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/netstandard/address_service_with_parameters/create_verify_strict.json
+++ b/EasyPost.Tests/cassettes/netstandard/address_service_with_parameters/create_verify_strict.json
@@ -1,7 +1,7 @@
 [
   {
-    "Duration": 255,
-    "RecordedAt": "2024-01-05T12:27:51.948852-07:00",
+    "Duration": 251,
+    "RecordedAt": "2024-01-05T15:02:50.728943-07:00",
     "Request": {
       "Body": "{\"address\":{\"city\":\"San Francisco\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"name\":\"Jack Sparrow\",\"phone\":\"<REDACTED>\",\"state\":\"CA\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"zip\":\"94107\"},\"verify_strict\":true}",
       "BodyContentType": "Json",
@@ -17,7 +17,7 @@
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_84aafe0dac0011eeb8fa3cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:52-07:00\",\"updated_at\":\"2024-01-05T12:27:52-07:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
+      "Body": "{\"id\":\"adr_2b20c69bac1611ee8901ac1f6bc539ae\",\"object\":\"Address\",\"created_at\":\"2024-01-05T15:02:50-07:00\",\"updated_at\":\"2024-01-05T15:02:50-07:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
@@ -32,15 +32,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "referrer-policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "f29a8cfd65985838f0210701000dc48f",
+        "x-ep-request-uuid": "dc2c57f465987c8af022127f002c054b",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_84aafe0dac0011eeb8fa3cecef1b359e",
-        "x-runtime": "0.071940",
+        "Location": "/api/v2/addresses/adr_2b20c69bac1611ee8901ac1f6bc539ae",
+        "x-runtime": "0.073075",
         "x-node": "bigweb38nuq",
         "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
+        "x-proxied": "intlb2nuq ab82b2e6e9,extlb1nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/netstandard/address_service_with_parameters/create_verify_strict.json
+++ b/EasyPost.Tests/cassettes/netstandard/address_service_with_parameters/create_verify_strict.json
@@ -1,7 +1,7 @@
 [
   {
-    "Duration": 217,
-    "RecordedAt": "2023-03-15T16:18:04.579083-06:00",
+    "Duration": 255,
+    "RecordedAt": "2024-01-05T12:27:51.948852-07:00",
     "Request": {
       "Body": "{\"address\":{\"city\":\"San Francisco\",\"country\":\"US\",\"email\":\"<REDACTED>\",\"name\":\"Jack Sparrow\",\"phone\":\"<REDACTED>\",\"state\":\"CA\",\"street1\":\"388 Townsend St\",\"street2\":\"Apt 20\",\"zip\":\"94107\"},\"verify_strict\":true}",
       "BodyContentType": "Json",
@@ -12,14 +12,12 @@
       "Method": "POST",
       "RequestHeaders": {
         "Authorization": "<REDACTED>",
-        "content_type": "application/json",
-        "Accept": "application/json,text/json,text/x-json,text/javascript,application/xml,text/xml",
         "User-Agent": "<REDACTED>"
       },
       "Uri": "https://api.easypost.com/v2/addresses"
     },
     "Response": {
-      "Body": "{\"id\":\"adr_41969e94c37f11ed82d4ac1f6bc72124\",\"object\":\"Address\",\"created_at\":\"2023-03-15T16:18:04-06:00\",\"updated_at\":\"2023-03-15T16:18:04-06:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
+      "Body": "{\"id\":\"adr_84aafe0dac0011eeb8fa3cecef1b359e\",\"object\":\"Address\",\"created_at\":\"2024-01-05T12:27:52-07:00\",\"updated_at\":\"2024-01-05T12:27:52-07:00\",\"name\":\"JACK SPARROW\",\"company\":null,\"street1\":\"388 TOWNSEND ST APT 20\",\"street2\":\"\",\"city\":\"SAN FRANCISCO\",\"state\":\"CA\",\"zip\":\"94107-1670\",\"country\":\"US\",\"phone\":\"<REDACTED>\",\"email\":\"<REDACTED>\",\"mode\":\"test\",\"carrier_facility\":null,\"residential\":true,\"federal_tax_id\":null,\"state_tax_id\":null,\"verifications\":{\"zip4\":{\"success\":true,\"errors\":[],\"details\":null},\"delivery\":{\"success\":true,\"errors\":[],\"details\":{\"latitude\":37.77551,\"longitude\":-122.39697,\"time_zone\":\"America/Los_Angeles\"}}}}",
       "BodyContentType": "Json",
       "ContentHeaders": {
         "Expires": "0",
@@ -34,16 +32,15 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "referrer-policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "287eb8e86412441ce689f512002c3710",
+        "x-ep-request-uuid": "f29a8cfd65985838f0210701000dc48f",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "Location": "/api/v2/addresses/adr_41969e94c37f11ed82d4ac1f6bc72124",
-        "ETag": "W/\"18a02324fcf913011046ee86f61e8b8b\"",
-        "x-runtime": "0.054361",
-        "x-node": "bigweb9nuq",
-        "x-version-label": "easypost-202303142258-f5b873fcbd-master",
+        "Location": "/api/v2/addresses/adr_84aafe0dac0011eeb8fa3cecef1b359e",
+        "x-runtime": "0.071940",
+        "x-node": "bigweb38nuq",
+        "x-version-label": "easypost-202401051829-4cf193bd35-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb1nuq a40ea751fd,extlb1nuq a40ea751fd",
+        "x-proxied": "intlb1nuq ab82b2e6e9,extlb2nuq 003ad9bca0",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {


### PR DESCRIPTION
# Description

The unit test for testing the "verify" parameter on address creation was broken due to recent updates to downstream shipper systems that no longer considered the "incorrect" address we were sending to be incorrect.

To avoid having to find another "incorrect" address combination to trigger the original assertions, the unit test has been rewritten to send a guaranteed-incorrect address to the API, showcasing the difference in responses (the presence of delivery and/or zip4 verifications) based on whether the "verify" parameter was included.

This shifts the unit test away from having to account for server-side or downstream errors, and instead more closely tests what we're actually trying to test, that the "verify" parameter is being sent or not sent to the API, and that "verifications" are being deserialized properly from the response. 

# Testing

- Unit tests updated
- Cassettes re-recorded as needed

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
