### PR TITLE
[chore] Make base EasyPostService extendable outside module

### DIFF
--- a/EasyPost/_base/EasyPostService.cs
+++ b/EasyPost/_base/EasyPostService.cs
@@ -21,7 +21,7 @@ namespace EasyPost._base
         ///     Initializes a new instance of the <see cref="EasyPostService"/> class.
         /// </summary>
         /// <param name="client">The <see cref="EasyPostClient"/> to use when this service makes API requests.</param>
-        internal EasyPostService(EasyPostClient client)
+        protected EasyPostService(EasyPostClient client)
         {
             Client = client;
         }


### PR DESCRIPTION
# Description

The `EasyPostService` base class used for all services (e.g. `UserService`) was marked internal, meaning it could not be constructed or extended outside of the EasyPost module. This PR instead sets it to `protected`, meaning it can still not be constructed directly, but can be inherited. This can be helpful for end-users trying to make extensions or custom implementations of the services, allowing them to use the base service rather than having to re-implement all client HTTP functionality themselves.

# Testing

- All unit tests pass
- Change does not affect compilation, run-time or linting

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
