### PR TITLE
[feat] Add ability to construct Options object from dictionary

### DIFF
--- a/EasyPost.Tests/ModelsTests/OptionsTests.cs
+++ b/EasyPost.Tests/ModelsTests/OptionsTests.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
 using EasyPost.Models.API;
 using EasyPost.Tests._Utilities;
 using EasyPost.Tests._Utilities.Attributes;
+using EasyPost.Utilities.Internal;
 using Xunit;
 
 namespace EasyPost.Tests.ModelsTests;
@@ -36,5 +38,20 @@ public class OptionsTests : UnitTest
         // check that the unsupported option is present
         Assert.True(dictionary.ContainsKey(unsupportedOption));
         Assert.Equal(unsupportedValue, dictionary[unsupportedOption]);
+    }
+
+    [Fact]
+    [Testing.Properties]
+    public void TestOptionsFromDictionary()
+    {
+        var dictionary = new Dictionary<string, object>
+        {
+            { "alcohol", true },
+        };
+
+        var options = Options.FromDictionary(dictionary);
+
+        // Data should be deserialized correctly and values set accordingly
+        Assert.True(options.Alcohol);
     }
 }

--- a/EasyPost/Exceptions/General/MissingPropertyError.cs
+++ b/EasyPost/Exceptions/General/MissingPropertyError.cs
@@ -13,8 +13,11 @@ namespace EasyPost.Exceptions.General
         /// <param name="obj">Object missing the property.</param>
         /// <param name="propertyName">Name of the missing property.</param>
 #pragma warning disable CA2241
+#pragma warning disable IDE0300
         internal MissingPropertyError(object obj, object propertyName)
+            // ReSharper disable once UseCollectionExpression
             : base(string.Format(CultureInfo.InvariantCulture, Constants.ErrorMessages.MissingProperty, new[] { obj.GetType().Name, propertyName }))
+#pragma warning restore IDE0300
 #pragma warning restore CA2241
         {
         }

--- a/EasyPost/Models/API/Options.cs
+++ b/EasyPost/Models/API/Options.cs
@@ -995,6 +995,7 @@ namespace EasyPost.Models.API
         /// <param name="value">Value of the option to add.</param>
         public void AddAdditionalOption(string key, object value) => _additionalOptions.Add(key, value);
 
+        /// <inheritdoc />
         public override Dictionary<string, object> AsDictionary()
         {
             Dictionary<string, object> data = base.AsDictionary();
@@ -1003,6 +1004,19 @@ namespace EasyPost.Models.API
             data = data.MergeIn(_additionalOptions);
 
             return data;
+        }
+
+        /// <summary>
+        ///     Create an <see cref="Options"/> object from a dictionary.
+        ///     WARNING: This method involves serializing and deserializing the data, which can be slow. Use sparingly.
+        /// </summary>
+        /// <param name="data">A <see cref="Dictionary{TKey,TValue}"/> of key-value pairs of options.</param>
+        /// <returns>An <see cref="Options"/> object.</returns>
+        public static Options? FromDictionary(Dictionary<string, object> data)
+        {
+            // Take the incoming dictionary, convert to JSON, then deserialize into an Options object
+            string jsonData = JsonConvert.SerializeObject(data);
+            return JsonConvert.DeserializeObject<Options>(jsonData);
         }
     }
 }


### PR DESCRIPTION
# Description

The `Options` object has always been in a weird middle-ground since we introduced parameter objects over a year ago, mainly because it it one of the few object classes in the library that is used in both requests (parameter sets) and responses (property of a `Shipment` model). Because the object is so large, with several dozen different "properties" (options), we've chosen not to duplicate it into request-specific and response-specific classes, but simply use the existing `Options` class, designed primarily for response JSON serialization, also for request JSON deserialization in parameter sets.

That has made the `Options` class difficult to transition to the parameter set construction paradigm we've established, especially because of how many properties it has that can be set.

This PR offers a "shortcut" to allow end-users to use a dictionary (for those still using the legacy dictionary method instead of parameter sets) to generate an `Options` object via a behind-the-scenes deserialization-serialization process. As with all our legacy dictionary-based functionality, this method relies on the end-user to properly construct a dictionary with the valid schema and key-value pairs (any invalid key-value pairs are inherently ignored and therefore won't produce the anticipated `Options` object upon de/serialization).

This is potentially the start of a larger effort to offer `FromDictionary` methods for all the Parameter classes to better facility (and validate) those still using the legacy dictionary workflow. For now, the `Options` object, due to its double-duty usage and its size and complexity, is the perfect initial candidate for this concept.

# Testing

- Added unit test to confirm new `FromDictionary` method works as expected

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
