### PR TITLE
[chore] Display object type, ID when converting object to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Next Release
 
-- Fix payment method funding and deletion failures due to undetermined payment method type
 - Add Refund function in insurance service for requesting a refund for standalone insurance.
+- Fix payment method funding and deletion failures due to undetermined payment method type
+- Fix `ToString` method for `EasyPostObject`- and `EphemeralEasyPostObject`-based objects to return object type and
+  optional ID
 
 ## v6.2.1 (2024-03-18)
 

--- a/EasyPost.Tests/baseTests/EasyPostObjectTests.cs
+++ b/EasyPost.Tests/baseTests/EasyPostObjectTests.cs
@@ -80,5 +80,24 @@ namespace EasyPost.Tests.baseTests
             Assert.False(apiKey == null);
             Assert.False(null == apiKey);
         }
+
+        [Fact]
+        [Testing.Function]
+        public void TestToString()
+        {
+            const string @object = "the_object_type";
+            const string id = "the_objet_id";
+
+            Address address = new()
+            {
+                Id = id,
+                Object = @object
+            };
+
+            const string expected = $"{@object} {id}";
+            string actual = address.ToString();
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/EasyPost/_base/EasyPostObject.cs
+++ b/EasyPost/_base/EasyPostObject.cs
@@ -46,6 +46,9 @@ namespace EasyPost._base
         public virtual Dictionary<string, object> AsDictionary() => JsonConvert.DeserializeObject<Dictionary<string, object>>(AsJson())!;
 
         /// <inheritdoc />
+        public override string ToString() => $"{Object!} {Id!}";
+
+        /// <inheritdoc />
         public override bool Equals(object? obj) => GetType() == obj?.GetType() && GetHashCode() == ((EasyPostObject)obj).GetHashCode();
 
         /// <inheritdoc />

--- a/EasyPost/_base/EphemeralEasyPostObject.cs
+++ b/EasyPost/_base/EphemeralEasyPostObject.cs
@@ -27,6 +27,9 @@ namespace EasyPost._base
         #endregion
 
         /// <inheritdoc />
+        public override string ToString() => Object!;
+
+        /// <inheritdoc />
         public override bool Equals(object? obj) => GetType() == obj?.GetType() && GetHashCode() == ((EphemeralEasyPostObject)obj).GetHashCode();
 
         /// <inheritdoc />


### PR DESCRIPTION
# Description

- Override `ToString` for EasyPost objects to display object type and optional ID

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
