### PR TITLE
[fix] Invalid `CarrierFields` structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release
 
+- Fix `CarrierFields` serialization bug causing carrier account operations to fail
 - Fix accessibility for `CreateFedExSmartPost` parameter set
 
 ## v6.3.0 (2024-04-10)

--- a/EasyPost.Integration/Basics.cs
+++ b/EasyPost.Integration/Basics.cs
@@ -25,7 +25,7 @@ public class Basics
         var carrier = new Carrier();
         var carrierAccount = new CarrierAccount();
         var carrierDetail = new CarrierDetail();
-        var credentialsField = new CredentialsField();
+        var carrierField = new CarrierField();
         var carrierFields = new CarrierFields();
         var carrierMetadata = new CarrierMetadata();
         var carrierType = new CarrierType();

--- a/EasyPost.Integration/Basics.cs
+++ b/EasyPost.Integration/Basics.cs
@@ -25,7 +25,7 @@ public class Basics
         var carrier = new Carrier();
         var carrierAccount = new CarrierAccount();
         var carrierDetail = new CarrierDetail();
-        var carrierField = new CarrierField();
+        var credentialsField = new CredentialsField();
         var carrierFields = new CarrierFields();
         var carrierMetadata = new CarrierMetadata();
         var carrierType = new CarrierType();

--- a/EasyPost.Tests/ServicesTests/CarrierAccountServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/CarrierAccountServiceTest.cs
@@ -149,9 +149,11 @@ namespace EasyPost.Tests.ServicesTests
         /// <summary>
         ///     Test that the CarrierAccount fields are correctly deserialized from the API response.
         ///     None of the demo carrier accounts used in the above tests have credentials or test credentials fields, so we need to use some mock data.
+        ///
+        ///     NOTE: CarrierField/CarrierFields are only used in the CarrierAccount model, which is only ever deserialized from an API response. We do not need to test serialization.
         /// </summary>
         [Fact]
-        [Testing.Function]
+        [Testing.EdgeCase]
         public async Task TestCarrierFieldsJsonDeserialization()
         {
             UseMockClient(new List<TestUtils.MockRequest>

--- a/EasyPost.Tests/ServicesTests/CarrierAccountServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/CarrierAccountServiceTest.cs
@@ -172,7 +172,7 @@ namespace EasyPost.Tests.ServicesTests
             Assert.NotNull(carrierAccount.Fields.Credentials);
             Assert.NotNull(carrierAccount.Fields.Credentials["account_number"]);
 
-            CredentialsField accountNumberField = carrierAccount.Fields.Credentials["account_number"];
+            CarrierField accountNumberField = carrierAccount.Fields.Credentials["account_number"];
             Assert.Equal("visible", accountNumberField.Visibility);
             Assert.Equal("DHL Account Number", accountNumberField.Label);
             Assert.Equal("123456", accountNumberField.Value);

--- a/EasyPost/Models/API/CarrierAccount.cs
+++ b/EasyPost/Models/API/CarrierAccount.cs
@@ -44,6 +44,12 @@ namespace EasyPost.Models.API
         public CarrierFields? Fields { get; set; }
 
         /// <summary>
+        ///     The logo for the associated carrier.
+        /// </summary>
+        [JsonProperty("logo")]
+        public string? Logo { get; set; }
+
+        /// <summary>
         ///     The name used when displaying a readable value for the type of the carrier account.
         /// </summary>
         [JsonProperty("readable")]
@@ -69,7 +75,6 @@ namespace EasyPost.Models.API
         public string? Type { get; set; }
 
         #endregion
-
     }
 }
 #pragma warning disable CA1724 // Naming conflicts with Parameters.CarrierAccount

--- a/EasyPost/Models/API/CarrierFields.cs
+++ b/EasyPost/Models/API/CarrierFields.cs
@@ -15,7 +15,7 @@ namespace EasyPost.Models.API
         ///     The credentials used in the production environment.
         /// </summary>
         [JsonProperty("credentials")]
-        public Dictionary<string, CredentialsField>? Credentials { get; set; }
+        public Dictionary<string, CarrierField>? Credentials { get; set; }
 
         /// <summary>
         ///     The credentials used in the test environment.
@@ -24,7 +24,7 @@ namespace EasyPost.Models.API
 #pragma warning disable SA1515
         // ReSharper disable once InconsistentNaming
 #pragma warning restore SA1515
-        public Dictionary<string, CredentialsField>? TestCredentials { get; set; }
+        public Dictionary<string, CarrierField>? TestCredentials { get; set; }
 
         /// <summary>
         ///     For USPS, this designates that no credentials are required.
@@ -44,7 +44,7 @@ namespace EasyPost.Models.API
     /// <summary>
     ///     Class representing a single EasyPost <see cref="CarrierAccount"/>'s credentials entry details.
     /// </summary>
-    public class CredentialsField : EasyPostObject
+    public class CarrierField : EasyPostObject
     {
         #region JSON Properties
 

--- a/EasyPost/Models/API/CarrierFields.cs
+++ b/EasyPost/Models/API/CarrierFields.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using EasyPost._base;
 using Newtonsoft.Json;
 
@@ -14,7 +15,7 @@ namespace EasyPost.Models.API
         ///     The credentials used in the production environment.
         /// </summary>
         [JsonProperty("credentials")]
-        public CarrierField? Credentials { get; set; }
+        public Dictionary<string, CredentialsField>? Credentials { get; set; }
 
         /// <summary>
         ///     The credentials used in the test environment.
@@ -23,7 +24,7 @@ namespace EasyPost.Models.API
 #pragma warning disable SA1515
         // ReSharper disable once InconsistentNaming
 #pragma warning restore SA1515
-        public CarrierField? TestCredentials { get; set; }
+        public Dictionary<string, CredentialsField>? TestCredentials { get; set; }
 
         /// <summary>
         ///     For USPS, this designates that no credentials are required.
@@ -43,15 +44,9 @@ namespace EasyPost.Models.API
     /// <summary>
     ///     Class representing a single EasyPost <see cref="CarrierAccount"/>'s credentials entry details.
     /// </summary>
-    public class CarrierField : EasyPostObject
+    public class CredentialsField : EasyPostObject
     {
         #region JSON Properties
-
-        /// <summary>
-        ///     The key of the field.
-        /// </summary>
-        [JsonProperty("key")]
-        public string? Key { get; set; }
 
         /// <summary>
         ///     The visibility value is used to control form field types.


### PR DESCRIPTION
# Description

This library was failing to deserialize a `CarrierAccount` from the API due to a failed deserialization of `CarrierFields`.

The previous assumption was that the API is returning "fields" in the JSON data for a `CarrierAccount` like so:

```json
{
  "id": "ca_123",
  "object": "CarrierAccount",
  ...
  "fields": {
    "credentials": [
      {
        "key": "account_number",
        "visibility": "visible",
        "label": "DHL Account Number",
        "value": "123456"
      },
      {
        "key": "country",
        "visibility": "visible",
        "label": "Account Country Code (2 Letter)",
        "value": "US"
      }
    ]
  }
}
```

When in fact, the API is returning "fields" like so:

```json
{
  "id": "ca_123",
  "object": "CarrierAccount",
  ...
  "fields": {
    "credentials": {
      "account_number": {
        "visibility": "visible",
        "label": "DHL Account Number",
        "value": "123456"
      },
      "country": {
        "visibility": "visible",
        "label": "Account Country Code (2 Letter)",
        "value": "US"
      }
    }
  }
}
```

Specifically, the "credentials" key under "fields" is not a list of dictionaries, but a dictionary of dictionaries, with the type of each credential field being the key in the key-value pair.

This PR updates the `CarrierFields` object structure to match the JSON schema.

Because the key for each type of credential field can by dynamic, users will have to access each credential field via a dictionary index:

```csharp
string countryLabel = myCarrierAccount.Fields.Credentials["country"].Label
```

This PR also adds the missing "logo" property for a `CarrierAccount`.

# Testing

- Add unit test to confirm deserialization works as expected
  - The carrier accounts used in our existing unit tests do not have fields returned by the API, so the serialization issue was not previously caught.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
