### PR TITLE
[fix] Add missing parameters for creating orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Add missing parameters for `Order.Create` parameter set
+
 ## v6.3.1 (2024-04-12)
 
 - Fix `CarrierFields` serialization bug causing carrier account operations to fail

--- a/EasyPost/Parameters/Order/Create.cs
+++ b/EasyPost/Parameters/Order/Create.cs
@@ -13,11 +13,24 @@ namespace EasyPost.Parameters.Order
         #region Request Parameters
 
         /// <summary>
+        ///     The <see cref="Address"/> (or <see cref="Address.Create"/> parameters) of the buyer for the new <see cref="Models.API.Order"/>.
+        ///     Defaults to <see cref="ToAddress"/> if not provided.
+        /// </summary>
+        [TopLevelRequestParameter(Necessity.Optional, "order", "buyer_address")]
+        public IAddressParameter? BuyerAddress { get; set; }
+
+        /// <summary>
         ///     List of <see cref="Models.API.CarrierAccount"/>s to use to create the new <see cref="Models.API.Order"/>.
         ///     The provided <see cref="Models.API.CarrierAccount"/>s must exist prior to making the API call.
         /// </summary>
         [TopLevelRequestParameter(Necessity.Optional, "order", "carrier_accounts")]
         public List<Models.API.CarrierAccount>? CarrierAccounts { get; set; }
+
+        /// <summary>
+        ///     <see cref="Models.API.CustomsInfo"/> (or a <see cref="Parameters.CustomsInfo.Create"/> parameter set) for the new <see cref="Models.API.Order"/>.
+        /// </summary>
+        [TopLevelRequestParameter(Necessity.Optional, "order", "customs_info")]
+        public ICustomsInfoParameter? CustomsInfo { get; set; }
 
         /// <summary>
         ///     The origin <see cref="Models.API.Address"/> (or <see cref="Address.Create"/> parameters) for the new <see cref="Models.API.Order"/>.
@@ -26,10 +39,29 @@ namespace EasyPost.Parameters.Order
         public IAddressParameter? FromAddress { get; set; }
 
         /// <summary>
+        ///     Whether the new <see cref="Models.API.Order"/> is a return.
+        /// </summary>
+        [TopLevelRequestParameter(Necessity.Optional, "order", "is_return")]
+        public bool? IsReturn { get; set; }
+
+        /// <summary>
+        ///     Additional <see cref="Models.API.Options"/> for the new <see cref="Models.API.Order"/>.
+        /// </summary>
+        [TopLevelRequestParameter(Necessity.Optional, "order", "options")]
+        public Models.API.Options? Options { get; set; }
+
+        /// <summary>
         ///     Reference name for the new <see cref="Models.API.Order"/>.
         /// </summary>
         [TopLevelRequestParameter(Necessity.Optional, "order", "reference")]
         public string? Reference { get; set; }
+
+        /// <summary>
+        ///     The return <see cref="Models.API.Address"/> (or <see cref="Address.Create"/> parameters) for the new <see cref="Models.API.Order"/>.
+        ///     Defaults to <see cref="FromAddress"/> if not provided.
+        /// </summary>
+        [TopLevelRequestParameter(Necessity.Optional, "order", "return_address")]
+        public IAddressParameter? ReturnAddress { get; set; }
 
         /// <summary>
         ///     List of <see cref="Models.API.Shipment"/>s (or <see cref="Shipment.Create"/> parameter sets) for the new <see cref="Models.API.Order"/>.

--- a/EasyPost/Parameters/Order/Create.cs
+++ b/EasyPost/Parameters/Order/Create.cs
@@ -27,28 +27,10 @@ namespace EasyPost.Parameters.Order
         public List<Models.API.CarrierAccount>? CarrierAccounts { get; set; }
 
         /// <summary>
-        ///     <see cref="Models.API.CustomsInfo"/> (or a <see cref="Parameters.CustomsInfo.Create"/> parameter set) for the new <see cref="Models.API.Order"/>.
-        /// </summary>
-        [TopLevelRequestParameter(Necessity.Optional, "order", "customs_info")]
-        public ICustomsInfoParameter? CustomsInfo { get; set; }
-
-        /// <summary>
         ///     The origin <see cref="Models.API.Address"/> (or <see cref="Address.Create"/> parameters) for the new <see cref="Models.API.Order"/>.
         /// </summary>
         [TopLevelRequestParameter(Necessity.Optional, "order", "from_address")]
         public IAddressParameter? FromAddress { get; set; }
-
-        /// <summary>
-        ///     Whether the new <see cref="Models.API.Order"/> is a return.
-        /// </summary>
-        [TopLevelRequestParameter(Necessity.Optional, "order", "is_return")]
-        public bool? IsReturn { get; set; }
-
-        /// <summary>
-        ///     Additional <see cref="Models.API.Options"/> for the new <see cref="Models.API.Order"/>.
-        /// </summary>
-        [TopLevelRequestParameter(Necessity.Optional, "order", "options")]
-        public Models.API.Options? Options { get; set; }
 
         /// <summary>
         ///     Reference name for the new <see cref="Models.API.Order"/>.


### PR DESCRIPTION
# Description

- Add missing `BuyerAddress` and `ReturnAddress` parameters for `Order.Create` parameter set
# Testing

- N/A

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
