### PR TITLE
[chore] Clean up dependency groups in nuspec

### DIFF
--- a/EasyPost.nuspec
+++ b/EasyPost.nuspec
@@ -18,9 +18,6 @@
             <group targetFramework="netstandard2.0">
                 <dependency id="Newtonsoft.Json" version="[13.0.1, 14.0.0)" />
             </group>
-            <group targetFramework="netcoreapp3.1">
-                <dependency id="Newtonsoft.Json" version="[13.0.1, 14.0.0)" />
-            </group>
             <group targetFramework="net5.0">
                 <dependency id="Newtonsoft.Json" version="[13.0.1, 14.0.0)" />
             </group>
@@ -28,6 +25,9 @@
                 <dependency id="Newtonsoft.Json" version="[13.0.1, 14.0.0)" />
             </group>
             <group targetFramework="net7.0">
+                <dependency id="Newtonsoft.Json" version="[13.0.1, 14.0.0)" />
+            </group>
+            <group targetFramework="net8.0">
                 <dependency id="Newtonsoft.Json" version="[13.0.1, 14.0.0)" />
             </group>
         </dependencies>


### PR DESCRIPTION
# Description

Following recommended best practices, as warned by our CI:

> WARNING: NU5128: Some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder do not have exact matches in the other location. Consult the list of actions below:
> - Add lib or ref assemblies for the netcoreapp3.1 target framework

> WARNING: NU5130: Some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder have compatible matches, but not exact matches in the other location. Unless intentional, consult the list of actions below:
> - Add a dependency group for net8.0 to the nuspec


Removed unused 3.1 dependency group, added explicit 8.0 group

This does not impact users' ability to install and use our library, but does clear up inconsistencies and follows best practices

# Testing

- No warning during build process now

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
