### PR TITLE
[chore] Demonstrate how users can provide their own proxy in custom HttpClient

### DIFF
--- a/EasyPost.Tests/ClientTest.cs
+++ b/EasyPost.Tests/ClientTest.cs
@@ -149,8 +149,8 @@ namespace EasyPost.Tests
 #if NET5_0_OR_GREATER
                     Assert.Equal($"Connection refused ({proxyAddress})", e.Message);
 #else
-                // Message is inconsistent in .NET Framework, so just assert that the exception was thrown
-                Assert.True(true);
+                    // Message is inconsistent in .NET Framework, so just assert that the exception was thrown
+                    Assert.True(true);
 #endif
                 }
             }

--- a/EasyPost.Tests/ClientTest.cs
+++ b/EasyPost.Tests/ClientTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -138,7 +139,20 @@ namespace EasyPost.Tests
             }
             catch (HttpRequestException e)
             {
-                Assert.Equal($"Connection refused ({proxyAddress})", e.Message);
+                // GitHub runner will reject the connection attempt, this is considered a pass
+                if (e.Message.Contains("No connection could be made because the target machine actively refused it"))
+                {
+                    Assert.True(true);
+                }
+                else // Evaluate the error message
+                {
+#if NET5_0_OR_GREATER
+                    Assert.Equal($"Connection refused ({proxyAddress})", e.Message);
+#else
+                // Message is inconsistent in .NET Framework, so just assert that the exception was thrown
+                Assert.True(true);
+#endif
+                }
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,28 @@ client.Hooks.OnRequestExecuting += (sender, args) => { /* ... */ };
 client.Hooks.OnRequestExecuting -= OnRequestExecutingHandler;
 ```
 
+### Proxies
+
+If you need to use a proxy to make requests to the EasyPost API, you can define a custom `HttpClientHandler` on a custom `HttpClient` passed to the `ClientConfiguration` constructor.
+
+```csharp
+// Define a custom HttpClientHandler with details about the proxy
+HttpClientHandler handler = new()
+{
+        UseProxy = true,
+        Proxy = new WebProxy($"http://localhost:8888"),
+};
+
+// Define a custom HttpClient with the custom handler
+HttpClient httpClient = new(handler: handler);
+
+// Pass the custom HttpClient to the ClientConfiguration constructor when creating a new EasyPost Client
+Client client = new(new ClientConfiguration(FakeApikey)
+{
+    CustomHttpClient = httpClient,
+});
+```
+
 ## Documentation
 
 API documentation can be found at: <https://easypost.com/docs/api>.

--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ If you need to use a proxy to make requests to the EasyPost API, you can define 
 // Define a custom HttpClientHandler with details about the proxy
 HttpClientHandler handler = new()
 {
-        UseProxy = true,
-        Proxy = new WebProxy($"http://localhost:8888"),
+    UseProxy = true,
+    Proxy = new WebProxy($"http://localhost:8888"),
 };
 
 // Define a custom HttpClient with the custom handler


### PR DESCRIPTION
# Description

Added unit test showing that/how users can use a proxy by utilizing the custom `HttpClient` capabilities in this library. No changes to the source code are required for proxy support.

# Testing

- Added unit tests for proxy configuration

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
