### PR TITLE
[fix] Missing inheritance preventing `Batch` object use in parameter sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v6.5.1 (2024-06-11)
+
+- Fix `Batch` object not allowed to be used in parameter sets due to missing `IBatchParameter` inheritance
+
 ## v6.5.0 (2024-06-05)
 
 - Add missing parameters for `CustomsItem.Create` parameter set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v6.5.1 (2024-06-11)
+## v6.5.1 (2024-06-10)
 
 - Fix `Batch` object not allowed to be used in parameter sets due to missing `IBatchParameter` inheritance
 

--- a/EasyPost.nuspec
+++ b/EasyPost.nuspec
@@ -3,7 +3,7 @@
     <metadata>
         <id>EasyPost-Official</id>
         <title>EasyPost (Official)</title>
-        <version>6.5.0</version>
+        <version>6.5.1</version>
         <authors>EasyPost</authors>
         <owners>EasyPost</owners>
         <projectUrl>https://www.easypost.com</projectUrl>

--- a/EasyPost/Models/API/Batch.cs
+++ b/EasyPost/Models/API/Batch.cs
@@ -10,7 +10,7 @@ namespace EasyPost.Models.API
     /// <summary>
     ///     Class representing an <a href="https://www.easypost.com/docs/api#batch-object">EasyPost batch</a>.
     /// </summary>
-    public class Batch : EasyPostObject
+    public class Batch : EasyPostObject, Parameters.IBatchParameter
     {
         #region JSON Properties
 

--- a/EasyPost/Properties/VersionInfo.cs
+++ b/EasyPost/Properties/VersionInfo.cs
@@ -2,6 +2,6 @@
 
 // Version information for an assembly must follow semantic versioning
 // When releasing a release candidate, append a 4th digit being the number of the release candidate
-[assembly: AssemblyVersion("6.5.0")]
-[assembly: AssemblyFileVersion("6.5.0")]
-[assembly: AssemblyInformationalVersion("6.5.0")]
+[assembly: AssemblyVersion("6.5.1")]
+[assembly: AssemblyFileVersion("6.5.1")]
+[assembly: AssemblyInformationalVersion("6.5.1")]


### PR DESCRIPTION
# Description

- Fix `Batch` class not inheriting `IBatchParameter`, preventing a `Batch` object from being used in a parameter set. Ex:
```csharp
Batch batch = await client.Batch.Retrieve("batch_123");
EasyPost.Parameters.Pickup.Create parameters = new()
{
    Batch = batch, // compile error due to mismatch type
    Instructions = "Special pickup instructions",
};
```
- Prep for v6.5.1 release

# Testing

- Test snippet above now compiles

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
