### PR TITLE
[fix] Remove "required" validation for `Shipment` parameter of `Pickup.Create` set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v6.5.2 (2024-06-12)
+
+- Fix `Shipment` parameter requirement for `Pickup.Create` parameter set
+
 ## v6.5.1 (2024-06-10)
 
 - Fix `Batch` object not allowed to be used in parameter sets due to missing `IBatchParameter` inheritance

--- a/EasyPost.nuspec
+++ b/EasyPost.nuspec
@@ -3,7 +3,7 @@
     <metadata>
         <id>EasyPost-Official</id>
         <title>EasyPost (Official)</title>
-        <version>6.5.1</version>
+        <version>6.5.2</version>
         <authors>EasyPost</authors>
         <owners>EasyPost</owners>
         <projectUrl>https://www.easypost.com</projectUrl>

--- a/EasyPost/Parameters/Pickup/Create.cs
+++ b/EasyPost/Parameters/Pickup/Create.cs
@@ -19,7 +19,7 @@ namespace EasyPost.Parameters.Pickup
         public IAddressParameter? Address { get; set; }
 
         /// <summary>
-        ///     <see cref="Models.API.Batch"/> being set for pickup (if <see cref="Shipment"/> not provided).
+        ///     <see cref="Models.API.Batch"/> being set for pickup (required if <see cref="Shipment"/> not provided).
         /// </summary>
         [TopLevelRequestParameter(Necessity.Optional, "pickup", "batch")]
         public IBatchParameter? Batch { get; set; }
@@ -62,9 +62,9 @@ namespace EasyPost.Parameters.Pickup
         public string? Reference { get; set; }
 
         /// <summary>
-        ///     <see cref="Models.API.Shipment"/> being set for pickup (if <see cref="Batch"/> not provided).
+        ///     <see cref="Models.API.Shipment"/> being set for pickup (required if <see cref="Batch"/> not provided).
         /// </summary>
-        [TopLevelRequestParameter(Necessity.Required, "pickup", "shipment")]
+        [TopLevelRequestParameter(Necessity.Optional, "pickup", "shipment")]
         public IShipmentParameter? Shipment { get; set; }
 
         #endregion

--- a/EasyPost/Properties/VersionInfo.cs
+++ b/EasyPost/Properties/VersionInfo.cs
@@ -2,6 +2,6 @@
 
 // Version information for an assembly must follow semantic versioning
 // When releasing a release candidate, append a 4th digit being the number of the release candidate
-[assembly: AssemblyVersion("6.5.1")]
-[assembly: AssemblyFileVersion("6.5.1")]
-[assembly: AssemblyInformationalVersion("6.5.1")]
+[assembly: AssemblyVersion("6.5.2")]
+[assembly: AssemblyFileVersion("6.5.2")]
+[assembly: AssemblyInformationalVersion("6.5.2")]


### PR DESCRIPTION
# Description

Either `Shipment` or `Batch` can be used when creating a Pickup, meaning the `Shipment` parameter should be optional, not required.

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
