### PR TITLE
[bug] Fix pagination parameters for child user lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Fix pagination parameters for `GetNextPageOfChildren` function
+
 ## v6.7.0 (2024-07-24)
 
 - Add new `Claim` service for filing claims on EasyPost shipments and insurances

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next Release
 
-- Fix pagination parameters for `GetNextPageOfChildren` function
+- Fix pagination parameters for `GetNextPageOfChildren` function for User service
 
 ## v6.7.0 (2024-07-24)
 

--- a/EasyPost.Tests/cassettes/net/user_service/get_next_page_of_children.json
+++ b/EasyPost.Tests/cassettes/net/user_service/get_next_page_of_children.json
@@ -1,7 +1,7 @@
 [
   {
-    "Duration": 336,
-    "RecordedAt": "2024-04-05T13:24:59.404002-06:00",
+    "Duration": 115,
+    "RecordedAt": "2024-08-01T15:18:21.047164-06:00",
     "Request": {
       "Body": "",
       "BodyContentType": "Text",
@@ -29,14 +29,14 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "Referrer-Policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "1f0ae7a56610500bf4304a55000fa80f",
+        "x-ep-request-uuid": "3567503d66abfb9cf43df2a800270008",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "x-runtime": "0.173213",
-        "x-node": "bigweb42nuq",
-        "x-version-label": "easypost-202404051854-b9502cad97-master",
+        "x-runtime": "0.142828",
+        "x-node": "bigweb35nuq",
+        "x-version-label": "easypost-202408012013-135f8f9b76-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb4nuq 39c21b8207,extlb2nuq 60566a9ec2",
+        "x-proxied": "intlb4nuq c0f5e722d1,extlb1nuq fa152d4755",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost.Tests/cassettes/netstandard/user_service/get_next_page_of_children.json
+++ b/EasyPost.Tests/cassettes/netstandard/user_service/get_next_page_of_children.json
@@ -1,7 +1,7 @@
 [
   {
-    "Duration": 195,
-    "RecordedAt": "2024-04-05T13:23:55.120429-06:00",
+    "Duration": 846,
+    "RecordedAt": "2024-08-01T15:18:59.396992-06:00",
     "Request": {
       "Body": "",
       "BodyContentType": "Text",
@@ -29,14 +29,14 @@
         "x-download-options": "noopen",
         "x-permitted-cross-domain-policies": "none",
         "referrer-policy": "strict-origin-when-cross-origin",
-        "x-ep-request-uuid": "f5042d7766104fcbf408d34a00100e43",
+        "x-ep-request-uuid": "0af7a3d066abfbc2f43e9d140026d996",
         "Cache-Control": "no-store, no-cache, private",
         "Pragma": "no-cache",
-        "x-runtime": "0.027218",
-        "x-node": "bigweb39nuq",
-        "x-version-label": "easypost-202404051854-b9502cad97-master",
+        "x-runtime": "0.028712",
+        "x-node": "bigweb34nuq",
+        "x-version-label": "easypost-202408012013-135f8f9b76-master",
         "x-backend": "easypost",
-        "x-proxied": "intlb4nuq 39c21b8207,extlb1nuq 60566a9ec2",
+        "x-proxied": "intlb3nuq c0f5e722d1,extlb2nuq fa152d4755",
         "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload"
       },
       "Status": {

--- a/EasyPost/Models/API/ChildUserCollection.cs
+++ b/EasyPost/Models/API/ChildUserCollection.cs
@@ -32,7 +32,7 @@ public class ChildUserCollection : PaginatedCollection<User>
     {
         AllChildren parameters = Filters != null ? (AllChildren)Filters : new AllChildren();
 
-        parameters.BeforeId = entries.Last().Id;
+        parameters.AfterId = entries.Last().Id;
 
         if (pageSize != null)
         {


### PR DESCRIPTION
# Description

Pagination for listing child users needs to use "after_id", not "before_id"

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
