### PR TITLE
[fix] Include "verify" and "verify_strict" parameters for Address creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Fix inclusion of `Verify` and `VerifyStrict` parameters when creating an Address as part of a larger object creation (e.g. Shipment, Order, etc.)
+
 ## v6.7.1 (2024-08-09)
 
 - Fix pagination parameters for `GetNextPageOfChildren` function for User service

--- a/EasyPost/Parameters/Address/Create.cs
+++ b/EasyPost/Parameters/Address/Create.cs
@@ -170,14 +170,22 @@ namespace EasyPost.Parameters.Address
         ///     Whether to enforce strict verification for the new <see cref="Models.API.Address"/>.
         /// </summary>
         [TopLevelRequestParameter(Necessity.Optional, "verify_strict")]
-        // "verify_strict" is not included when address creation parameters are used in a non-address creation request.
+        [NestedRequestParameter(typeof(Shipment.Create), Necessity.Optional, "verify_strict")]
+        [NestedRequestParameter(typeof(Insurance.Create), Necessity.Optional, "verify_strict")]
+        [NestedRequestParameter(typeof(Order.Create), Necessity.Optional, "verify_strict")]
+        [NestedRequestParameter(typeof(Pickup.Create), Necessity.Optional, "verify_strict")]
+        [NestedRequestParameter(typeof(Beta.Rate.Retrieve), Necessity.Optional, "verify_strict")]
         public bool? VerifyStrict { get; set; }
 
         /// <summary>
         ///     Whether to enforce verification for the new <see cref="Models.API.Address"/>.
         /// </summary>
         [TopLevelRequestParameter(Necessity.Optional, "verify")]
-        // "verify" is not included when address creation parameters are used in a non-address creation request.
+        [NestedRequestParameter(typeof(Shipment.Create), Necessity.Optional, "verify")]
+        [NestedRequestParameter(typeof(Insurance.Create), Necessity.Optional, "verify")]
+        [NestedRequestParameter(typeof(Order.Create), Necessity.Optional, "verify")]
+        [NestedRequestParameter(typeof(Pickup.Create), Necessity.Optional, "verify")]
+        [NestedRequestParameter(typeof(Beta.Rate.Retrieve), Necessity.Optional, "verify")]
         public bool? Verify { get; set; }
 
         /// <summary>


### PR DESCRIPTION
# Description

Include `Verify` and `VerifyStrict` parameters for Address when creating as part of Shipment et. al creation request.

These were previously purposefully excluded when Address creation was being performed as part of a larger creation request, such as Shipment or Order, due to uncertainty about their placement in the payload schema. Consequently, this made for end-user confusion as to why address verification was not being performed as part of a Shipment or Order creation, and was causing Shipments and Orders to be successfully created with invalid Addresses.

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
