### PR TITLE
[fix] Recursion causing stack overflow when disposing client/service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 
 - Corrects all API documentation link references to point to their new locations
+- Fix recursion during disposal causing stack overflow
 
 ## v6.7.2 (2024-08-16)
 

--- a/EasyPost.Tests/ClientTest.cs
+++ b/EasyPost.Tests/ClientTest.cs
@@ -71,6 +71,15 @@ namespace EasyPost.Tests
         private const string FakeApikey = "fake_api_key";
 
         [Fact]
+        public void TestClientDisposal()
+        {
+            Client client = new(new ClientConfiguration(FakeApikey));
+            client.Dispose();
+
+            // As long as this test doesn't throw an exception, it passes
+        }
+
+        [Fact]
         public void TestBaseUrlOverride()
         {
             Client normalClient = new(new ClientConfiguration(FakeApikey));

--- a/EasyPost.Tests/ClientTest.cs
+++ b/EasyPost.Tests/ClientTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -9,6 +8,7 @@ using EasyPost.Exceptions.API;
 using EasyPost.Tests._Utilities;
 using EasyPost.Tests._Utilities.Attributes;
 using Xunit;
+using CustomAssertions = EasyPost.Tests._Utilities.Assertions.Assert;
 
 namespace EasyPost.Tests
 {
@@ -74,9 +74,7 @@ namespace EasyPost.Tests
         public void TestClientDisposal()
         {
             Client client = new(new ClientConfiguration(FakeApikey));
-            client.Dispose();
-
-            // As long as this test doesn't throw an exception, it passes
+            CustomAssertions.DoesNotThrow(() => client.Dispose());
         }
 
         [Fact]

--- a/EasyPost.Tests/HttpTests/ClientConfigurationTest.cs
+++ b/EasyPost.Tests/HttpTests/ClientConfigurationTest.cs
@@ -9,6 +9,16 @@ namespace EasyPost.Tests.HttpTests
         #region Tests
 
         [Fact]
+        public void TestClientConfigurationDisposal()
+        {
+            ClientConfiguration configuration = new("not_a_real_api_key");
+
+            configuration.Dispose();
+
+            // As long as this test doesn't throw an exception, it passes
+        }
+
+        [Fact]
         [Testing.Function]
         public void TestClientConfiguration()
         {

--- a/EasyPost.Tests/HttpTests/ClientConfigurationTest.cs
+++ b/EasyPost.Tests/HttpTests/ClientConfigurationTest.cs
@@ -1,6 +1,7 @@
 using System;
 using EasyPost.Tests._Utilities.Attributes;
 using Xunit;
+using CustomAssertions = EasyPost.Tests._Utilities.Assertions.Assert;
 
 namespace EasyPost.Tests.HttpTests
 {
@@ -12,10 +13,7 @@ namespace EasyPost.Tests.HttpTests
         public void TestClientConfigurationDisposal()
         {
             ClientConfiguration configuration = new("not_a_real_api_key");
-
-            configuration.Dispose();
-
-            // As long as this test doesn't throw an exception, it passes
+            CustomAssertions.DoesNotThrow(() => configuration.Dispose());
         }
 
         [Fact]

--- a/EasyPost.Tests/HttpTests/RequestTest.cs
+++ b/EasyPost.Tests/HttpTests/RequestTest.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using EasyPost._base;
 using EasyPost.Http;
 using Xunit;
+using CustomAssertions = EasyPost.Tests._Utilities.Assertions.Assert;
 
 namespace EasyPost.Tests.HttpTests;
 
@@ -13,10 +14,7 @@ public class RequestTest
     public void TestRequestDisposal()
     {
         Request request = new("https://google.com", "not_a_real_endpoint", Method.Get, ApiVersion.V2, new Dictionary<string, object> { { "key", "value" } }, new Dictionary<string, string> { { "header_key", "header_value" } });
-
-        request.Dispose();
-
-        // As long as this test doesn't throw an exception, it passes
+        CustomAssertions.DoesNotThrow(() => request.Dispose());
     }
 
     #endregion

--- a/EasyPost.Tests/HttpTests/RequestTest.cs
+++ b/EasyPost.Tests/HttpTests/RequestTest.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using EasyPost._base;
+using EasyPost.Http;
+using Xunit;
+
+namespace EasyPost.Tests.HttpTests;
+
+public class RequestTest
+{
+    #region Tests
+
+    [Fact]
+    public void TestRequestDisposal()
+    {
+        Request request = new("https://google.com", "not_a_real_endpoint", Method.Get, ApiVersion.V2, new Dictionary<string, object> { { "key", "value" } }, new Dictionary<string, string>{ { "header_key", "header_value" } });
+
+        request.Dispose();
+
+        // As long as this test doesn't throw an exception, it passes
+    }
+
+    #endregion
+}

--- a/EasyPost.Tests/HttpTests/RequestTest.cs
+++ b/EasyPost.Tests/HttpTests/RequestTest.cs
@@ -12,7 +12,7 @@ public class RequestTest
     [Fact]
     public void TestRequestDisposal()
     {
-        Request request = new("https://google.com", "not_a_real_endpoint", Method.Get, ApiVersion.V2, new Dictionary<string, object> { { "key", "value" } }, new Dictionary<string, string>{ { "header_key", "header_value" } });
+        Request request = new("https://google.com", "not_a_real_endpoint", Method.Get, ApiVersion.V2, new Dictionary<string, object> { { "key", "value" } }, new Dictionary<string, string> { { "header_key", "header_value" } });
 
         request.Dispose();
 

--- a/EasyPost.Tests/ServicesTests/ServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/ServiceTest.cs
@@ -28,7 +28,7 @@ namespace EasyPost.Tests.ServicesTests
             Client client = new(new ClientConfiguration("not_a_real_api_key"));
 
             AddressService addressService = client.Address;
-            addressService.Dispose(); // Will also dispose the underlying client
+            addressService.Dispose();
 
             // As long as this test doesn't throw an exception, it passes
         }

--- a/EasyPost.Tests/ServicesTests/ServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/ServiceTest.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using EasyPost.Exceptions.General;
 using EasyPost.Http;
 using EasyPost.Models.API;
+using EasyPost.Services;
 using EasyPost.Tests._Utilities;
 using EasyPost.Tests._Utilities.Attributes;
 using EasyPost.Utilities.Internal.Attributes;
@@ -19,6 +20,17 @@ namespace EasyPost.Tests.ServicesTests
     {
         public ServiceTests() : base("base_service")
         {
+        }
+
+        [Fact]
+        public void TestServiceDisposal()
+        {
+            Client client = new(new ClientConfiguration("not_a_real_api_key"));
+
+            AddressService addressService = client.Address;
+            addressService.Dispose(); // Will also dispose the underlying client
+
+            // As long as this test doesn't throw an exception, it passes
         }
 
         /// <summary>

--- a/EasyPost.Tests/ServicesTests/ServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/ServiceTest.cs
@@ -10,6 +10,7 @@ using EasyPost.Tests._Utilities;
 using EasyPost.Tests._Utilities.Attributes;
 using EasyPost.Utilities.Internal.Attributes;
 using Xunit;
+using CustomAssertions = EasyPost.Tests._Utilities.Assertions.Assert;
 
 namespace EasyPost.Tests.ServicesTests
 {
@@ -28,9 +29,7 @@ namespace EasyPost.Tests.ServicesTests
             Client client = new(new ClientConfiguration("not_a_real_api_key"));
 
             AddressService addressService = client.Address;
-            addressService.Dispose();
-
-            // As long as this test doesn't throw an exception, it passes
+            CustomAssertions.DoesNotThrow(() => addressService.Dispose());
         }
 
         /// <summary>

--- a/EasyPost.Tests/_Utilities/Assertions/AnyException.cs
+++ b/EasyPost.Tests/_Utilities/Assertions/AnyException.cs
@@ -3,7 +3,7 @@ using Xunit.Sdk;
 namespace EasyPost.Tests._Utilities.Assertions
 {
     /// <summary>
-    /// Exception thrown when an Any assertion has one or more items fail an assertion.
+    ///     Exception thrown when an Any assertion has one or more items fail an assertion.
     /// </summary>
     public class AnyException : XunitException
     {

--- a/EasyPost.Tests/_Utilities/Assertions/CollectionAsserts.cs
+++ b/EasyPost.Tests/_Utilities/Assertions/CollectionAsserts.cs
@@ -6,12 +6,6 @@ namespace EasyPost.Tests._Utilities.Assertions
     // ReSharper disable once PartialTypeWithSinglePart
     public abstract partial class Assert
     {
-        private static void GuardArgumentNotNull(string argName, object argValue)
-        {
-            if (argValue == null)
-                throw new ArgumentNullException(argName);
-        }
-
         /// <summary>
         /// Verifies that any items in the collection pass when executed against
         /// action.

--- a/EasyPost.Tests/_Utilities/Assertions/DoesNotThrowAssert.cs
+++ b/EasyPost.Tests/_Utilities/Assertions/DoesNotThrowAssert.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace EasyPost.Tests._Utilities.Assertions
+{
+    // ReSharper disable once PartialTypeWithSinglePart
+    public abstract partial class Assert
+    {
+        /// <summary>
+        ///     Verifies that an action does not throw an exception.
+        /// </summary>
+        /// <param name="action">The action to test</param>
+        /// <exception cref="DoesNotThrowException">Thrown when the action throws an exception</exception>
+        public static void DoesNotThrow(Action action)
+        {
+            GuardArgumentNotNull(nameof(action), action);
+
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                throw new DoesNotThrowException(ex);
+            }
+        }
+
+        /// <summary>
+        ///     Verifies that an action does not throw a specific exception.
+        /// </summary>
+        /// <param name="action">The action to test</param>
+        /// <typeparam name="T">The type of the exception to not throw</typeparam>
+        /// <exception cref="DoesNotThrowException">Thrown when the action throws an exception of type T</exception>
+        public static void DoesNotThrow<T>(Action action) where T : Exception
+        {
+            GuardArgumentNotNull(nameof(action), action);
+
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                if (ex.GetType() == typeof(T))
+                {
+                    throw new DoesNotThrowException(ex);
+                }
+            }
+        }
+    }
+}

--- a/EasyPost.Tests/_Utilities/Assertions/DoesNotThrowException.cs
+++ b/EasyPost.Tests/_Utilities/Assertions/DoesNotThrowException.cs
@@ -1,0 +1,19 @@
+using System;
+using Xunit.Sdk;
+
+namespace EasyPost.Tests._Utilities.Assertions
+{
+    /// <summary>
+    ///     Exception thrown when a DoesNotThrow assertion fails.
+    /// </summary>
+    public class DoesNotThrowException : XunitException
+    {
+        /// <summary>
+        ///     Creates a new instance of the <see cref="DoesNotThrowException"/> class.
+        /// </summary>
+        public DoesNotThrowException(Exception ex)
+            : base("Assert.DoesNotThrow() Failure", ex)
+        {
+        }
+    }
+}

--- a/EasyPost.Tests/_Utilities/Assertions/GuardArgumentNotNull.cs
+++ b/EasyPost.Tests/_Utilities/Assertions/GuardArgumentNotNull.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace EasyPost.Tests._Utilities.Assertions
+{
+    // ReSharper disable once PartialTypeWithSinglePart
+    public abstract partial class Assert
+    {
+        private static void GuardArgumentNotNull(string argName, object argValue)
+        {
+            if (argValue == null)
+                throw new ArgumentNullException(argName);
+        }
+    }
+}

--- a/EasyPost/Client.cs
+++ b/EasyPost/Client.cs
@@ -190,46 +190,42 @@ namespace EasyPost
         /// <inheritdoc cref="EasyPostClient.Dispose(bool)"/>
         protected override void Dispose(bool disposing)
         {
-            // ref: https://dzone.com/articles/when-and-how-to-use-dispose-and-finalize-in-c
-            // ref: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1063#pseudo-code-example
-            if (disposing)
-            {
-                // Dispose managed state (managed objects).
-                // "disposing" inherently true when called from Dispose(), so don't need to pass it in.
+            if (!disposing) return;
 
-                // Dispose of the services
-                Address.Dispose();
-                ApiKey.Dispose();
-                Batch.Dispose();
-                Billing.Dispose();
-                CarrierAccount.Dispose();
-                CarrierMetadata.Dispose();
-                CarrierType.Dispose();
-                Claim.Dispose();
-                CustomsInfo.Dispose();
-                CustomsItem.Dispose();
-                EndShipper.Dispose();
-                Event.Dispose();
-                Insurance.Dispose();
-                Order.Dispose();
-                Parcel.Dispose();
-                Pickup.Dispose();
-                Rate.Dispose();
-                ReferralCustomer.Dispose();
-                Refund.Dispose();
-                Report.Dispose();
-                ScanForm.Dispose();
-                Shipment.Dispose();
-                SmartRate.Dispose();
-                Tracker.Dispose();
-                User.Dispose();
-                Webhook.Dispose();
+            // Dispose managed state (managed objects)
 
-                // Dispose of the Beta client
-                Beta.Dispose();
-            }
+            // "disposing" inherently true when called from Dispose(), so don't need to pass it in.
 
-            // Free native resources (unmanaged objects) and override a finalizer below.
+            // Attempt to dispose of the services (some may already be disposed)
+            Address.Dispose();
+            ApiKey.Dispose();
+            Batch.Dispose();
+            Billing.Dispose();
+            CarrierAccount.Dispose();
+            CarrierMetadata.Dispose();
+            CarrierType.Dispose();
+            Claim.Dispose();
+            CustomsInfo.Dispose();
+            CustomsItem.Dispose();
+            EndShipper.Dispose();
+            Event.Dispose();
+            Insurance.Dispose();
+            Order.Dispose();
+            Parcel.Dispose();
+            Pickup.Dispose();
+            Rate.Dispose();
+            ReferralCustomer.Dispose();
+            Refund.Dispose();
+            Report.Dispose();
+            ScanForm.Dispose();
+            Shipment.Dispose();
+            SmartRate.Dispose();
+            Tracker.Dispose();
+            User.Dispose();
+            Webhook.Dispose();
+
+            // Attempt to dispose of the Beta client (may already be disposed)
+            Beta.Dispose();
 
             // Dispose of the base client
             base.Dispose(disposing);

--- a/EasyPost/ClientConfiguration.cs
+++ b/EasyPost/ClientConfiguration.cs
@@ -147,21 +147,18 @@ public class ClientConfiguration : IDisposable
     /// <inheritdoc cref="EasyPostClient.Dispose(bool)"/>
     protected virtual void Dispose(bool disposing)
     {
-        if (_isDisposed) return;
+        if (!disposing || _isDisposed) return;
 
-        if (disposing)
-        {
-            // Dispose managed state (managed objects).
-
-            // dispose of the prepared HTTP client
-            PreparedHttpClient?.Dispose();
-
-            // dispose of the user-provided HTTP client
-            CustomHttpClient?.Dispose();
-        }
-
-        // Free native resources (unmanaged objects) and override a finalizer below.
+        // Set the disposed flag to true before disposing of the object to avoid infinite loops
         _isDisposed = true;
+
+        // Dispose managed state (managed objects)
+
+        // Attempt to dispose of the prepared HTTP client (may already be disposed)
+        PreparedHttpClient?.Dispose();
+
+        // Attempt to dispose of the user-provided HTTP client (may already be disposed)
+        CustomHttpClient?.Dispose();
     }
 
     /// <summary>

--- a/EasyPost/Http/Request.cs
+++ b/EasyPost/Http/Request.cs
@@ -159,17 +159,15 @@ namespace EasyPost.Http
         /// <inheritdoc cref="EasyPostClient.Dispose(bool)"/>
         protected virtual void Dispose(bool disposing)
         {
-            if (_isDisposed) return;
-            if (disposing)
-            {
-                // Dispose managed state (managed objects).
+            if (!disposing || _isDisposed) return;
 
-                // Dispose the request message
-                _requestMessage.Dispose();
-            }
-
-            // Free native resources (unmanaged objects) and override a finalizer below.
+            // Set the disposed flag to true before disposing of the object to avoid infinite loops
             _isDisposed = true;
+
+            // Dispose managed state (managed objects)
+
+            // Dispose the request message
+            _requestMessage.Dispose();
         }
 
         /// <summary>

--- a/EasyPost/_base/EasyPostClient.cs
+++ b/EasyPost/_base/EasyPostClient.cs
@@ -222,17 +222,15 @@ namespace EasyPost._base
         /// <param name="disposing">Whether this object is being disposed.</param>
         protected virtual void Dispose(bool disposing)
         {
-            if (_isDisposed) return;
-            if (disposing)
-            {
-                // Dispose managed state (managed objects).
+            if (!disposing || _isDisposed) return;
 
-                // Dispose the configuration
-                _configuration.Dispose();
-            }
-
-            // Free native resources (unmanaged objects) and override a finalizer below.
+            // Set the disposed flag to true before disposing of the object to avoid infinite loops
             _isDisposed = true;
+
+            // Dispose managed state (managed objects)
+
+            // Dispose of the configuration
+            _configuration.Dispose();
         }
 
         /// <summary>

--- a/EasyPost/_base/EasyPostService.cs
+++ b/EasyPost/_base/EasyPostService.cs
@@ -73,8 +73,8 @@ namespace EasyPost._base
 
             // Dispose managed state (managed objects)
 
-            // Attempt to dispose the client (may already be disposed)
-            Client.Dispose();
+            // Don't dispose of the associated client here, as it may be shared among multiple services
+            // Client.Dispose();
         }
 
         /// <summary>

--- a/EasyPost/_base/EasyPostService.cs
+++ b/EasyPost/_base/EasyPostService.cs
@@ -66,17 +66,15 @@ namespace EasyPost._base
         /// <inheritdoc cref="EasyPostClient.Dispose(bool)"/>
         protected virtual void Dispose(bool disposing)
         {
-            if (_isDisposed) return;
-            if (disposing)
-            {
-                // Dispose managed state (managed objects).
+            if (!disposing || _isDisposed) return;
 
-                // Dispose the client
-                Client.Dispose();
-            }
-
-            // Free native resources (unmanaged objects) and override a finalizer below.
+            // Set the disposed flag to true before disposing of the object to avoid infinite loops
             _isDisposed = true;
+
+            // Dispose managed state (managed objects)
+
+            // Attempt to dispose the client (may already be disposed)
+            Client.Dispose();
         }
 
         /// <summary>

--- a/EasyPost/_base/EasyPostService.cs
+++ b/EasyPost/_base/EasyPostService.cs
@@ -74,7 +74,6 @@ namespace EasyPost._base
             // Dispose managed state (managed objects)
 
             // Don't dispose of the associated client here, as it may be shared among multiple services
-            // Client.Dispose();
         }
 
         /// <summary>


### PR DESCRIPTION
# Description

Unhandled recursion during disposal of a `Client` or service would cause a stack overflow.

Closes #587

# Testing

- Add unit tests to verify disposal does not cause stack overflow

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
