### PR TITLE
[fix] ]Handle serializing array/list parameters in GET/DELETE query strings

### DIFF
--- a/EasyPost.Tests/HttpTests/RequestTest.cs
+++ b/EasyPost.Tests/HttpTests/RequestTest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Net.Http;
 using EasyPost._base;
 using EasyPost.Http;
 using Xunit;
@@ -15,6 +16,38 @@ public class RequestTest
     {
         Request request = new("https://google.com", "not_a_real_endpoint", Method.Get, ApiVersion.V2, new Dictionary<string, object> { { "key", "value" } }, new Dictionary<string, string> { { "header_key", "header_value" } });
         CustomAssertions.DoesNotThrow(() => request.Dispose());
+    }
+
+    [Fact]
+    public void TestQueryParameterList()
+    {
+        const string key = "key";
+        var value = new List<string>
+        {
+            "value1",
+            "value2"
+        };
+        const string key2 = "key2";
+        const string value2 = "value3";
+        var parameters = new Dictionary<string, object>
+        {
+            { key, value },
+            { key2, value2 }
+        };
+
+        Request request = new("https://google.com", "not_a_real_endpoint", Method.Get, ApiVersion.V2, parameters, new Dictionary<string, string> { { "header_key", "header_value" } });
+
+        HttpRequestMessage httpRequestMessage = request.AsHttpRequestMessage();
+
+        string queryString = httpRequestMessage.RequestUri?.Query;
+
+        string keyWithArray = $"{key}[]";
+
+        foreach (string item in value)
+        {
+            Assert.Contains($"{keyWithArray}={item}", queryString); // Does not account for URL encoding
+        }
+        Assert.Contains($"{key2}={value2}", queryString); // Does not account for URL encoding
     }
 
     #endregion

--- a/EasyPost.Tests/HttpTests/RequestTest.cs
+++ b/EasyPost.Tests/HttpTests/RequestTest.cs
@@ -14,40 +14,28 @@ public class RequestTest
     [Fact]
     public void TestRequestDisposal()
     {
-        Request request = new("https://google.com", "not_a_real_endpoint", Method.Get, ApiVersion.V2, new Dictionary<string, object> { { "key", "value" } }, new Dictionary<string, string> { { "header_key", "header_value" } });
+        Request request = new("https://example.com", "not_a_real_endpoint", Method.Get, ApiVersion.V2, new Dictionary<string, object> { { "key", "value" } }, new Dictionary<string, string> { { "header_key", "header_value" } });
         CustomAssertions.DoesNotThrow(() => request.Dispose());
     }
 
     [Fact]
     public void TestQueryParameterList()
     {
-        const string key = "key";
-        var value = new List<string>
-        {
-            "value1",
-            "value2"
-        };
-        const string key2 = "key2";
-        const string value2 = "value3";
         var parameters = new Dictionary<string, object>
         {
-            { key, value },
-            { key2, value2 }
+            { "key1", new List<string> { "value1", "value2" } },
+            { "key2", "value3" }
         };
 
-        Request request = new("https://google.com", "not_a_real_endpoint", Method.Get, ApiVersion.V2, parameters, new Dictionary<string, string> { { "header_key", "header_value" } });
+        Request request = new("https://example.com", "not_a_real_endpoint", Method.Get, ApiVersion.V2, parameters, new Dictionary<string, string> { { "header_key", "header_value" } });
 
         HttpRequestMessage httpRequestMessage = request.AsHttpRequestMessage();
 
         string queryString = httpRequestMessage.RequestUri?.Query;
 
-        string keyWithArray = $"{key}[]";
-
-        foreach (string item in value)
-        {
-            Assert.Contains($"{keyWithArray}={item}", queryString); // Does not account for URL encoding
-        }
-        Assert.Contains($"{key2}={value2}", queryString); // Does not account for URL encoding
+        Assert.Contains("key1[]=value1", queryString); // Does not account for URL encoding
+        Assert.Contains("key1[]=value2", queryString); // Does not account for URL encoding
+        Assert.Contains("key2=value3", queryString); // Does not account for URL encoding
     }
 
     #endregion

--- a/EasyPost/Http/Request.cs
+++ b/EasyPost/Http/Request.cs
@@ -131,7 +131,7 @@ namespace EasyPost.Http
                 var @switch = new SwitchCase
                 {
                     { param.Value is IList, () => listParameters = AddListQueryParameter(listParameters, param.Key, (IList)param.Value) },
-                    { SwitchCaseScenario.Default, () => query[param.Key] = param.Value.ToString() }
+                    { SwitchCaseScenario.Default, () => query[param.Key] = param.Value.ToString() },
                 };
                 @switch.MatchFirstTrue();
             }
@@ -168,6 +168,7 @@ namespace EasyPost.Http
                 {
                     continue;
                 }
+
                 string pair = $"{keyPrefix}={HttpUtility.UrlEncode(itemString)}";
                 pairs.Add(pair);
             }

--- a/EasyPost/Http/Request.cs
+++ b/EasyPost/Http/Request.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Net.Http;
@@ -115,6 +116,9 @@ namespace EasyPost.Http
             // add query parameters
             NameValueCollection query = HttpUtility.ParseQueryString(string.Empty);
 
+            // Separately store the list parameters to add them last
+            List<string> listParameters = new();
+
             // build query string from parameters
             foreach (KeyValuePair<string, object> param in _parameters)
             {
@@ -124,26 +128,51 @@ namespace EasyPost.Http
                     continue;
                 }
 
-                query[param.Key] = param.Value switch
+                var @switch = new SwitchCase
                 {
-                    // TODO: Handle special conversions for other types
-                    // DateTime dateTime => dateTime.ToString("o", CultureInfo.InvariantCulture),
-                    var _ => param.Value.ToString(),
+                    { param.Value is IList, () => listParameters = AddListQueryParameter(listParameters, param.Key, (IList)param.Value) },
+                    { SwitchCaseScenario.Default, () => query[param.Key] = param.Value.ToString() }
                 };
+                @switch.MatchFirstTrue();
             }
 
-            // short circuit if no query parameters
-            if (query.Count == 0)
+            // Finalize the query string
+            string queryString = query.ToString() ?? string.Empty;
+
+            // Add list parameters to the query string
+            string parameterCharacter = queryString.Length == 0 ? "?" : "&";
+            foreach (string pair in listParameters)
             {
-                return;
+                queryString += $"{parameterCharacter}{pair}";
+                parameterCharacter = "&";
             }
 
             // rebuild the request URL with the query string appended
             var uriBuilder = new UriBuilder(_requestMessage.RequestUri!)
             {
-                Query = query.ToString(),
+                Query = queryString,
             };
-            _requestMessage.RequestUri = new Uri(uriBuilder.ToString());
+
+            // _requestMessage.RequestUri = new Uri(uriBuilder.ToString());
+            _requestMessage.RequestUri = uriBuilder.Uri;
+        }
+
+        private static List<string> AddListQueryParameter(List<string> pairs, string key, IList value)
+        {
+            string keyPrefix = $"{HttpUtility.UrlEncode(key)}[]";
+            // ReSharper disable once LoopCanBeConvertedToQuery
+            foreach (object? item in value)
+            {
+                string? itemString = item?.ToString();
+                if (itemString == null)
+                {
+                    continue;
+                }
+                string pair = $"{keyPrefix}={HttpUtility.UrlEncode(itemString)}";
+                pairs.Add(pair);
+            }
+
+            return pairs;
         }
 
         /// <inheritdoc cref="EasyPostClient._isDisposed"/>

--- a/EasyPost/Parameters/Tracker/All.cs
+++ b/EasyPost/Parameters/Tracker/All.cs
@@ -84,7 +84,7 @@ namespace EasyPost.Parameters.Tracker
                 EndDatetime = dictionary.GetOrNull<string>("end_datetime"),
                 Carrier = dictionary.GetOrNull<string>("carrier"),
                 TrackingCode = dictionary.GetOrNull<string>("tracking_code"),
-                TrackingCodes = dictionary.GetOrNull<List<string>>("tracking_codes")
+                TrackingCodes = dictionary.GetOrNull<List<string>>("tracking_codes"),
             };
         }
     }

--- a/EasyPost/Parameters/Tracker/All.cs
+++ b/EasyPost/Parameters/Tracker/All.cs
@@ -84,6 +84,7 @@ namespace EasyPost.Parameters.Tracker
                 EndDatetime = dictionary.GetOrNull<string>("end_datetime"),
                 Carrier = dictionary.GetOrNull<string>("carrier"),
                 TrackingCode = dictionary.GetOrNull<string>("tracking_code"),
+                TrackingCodes = dictionary.GetOrNull<List<string>>("tracking_codes")
             };
         }
     }


### PR DESCRIPTION
# Description

Using the new `tracking_codes` parameter for the `Tracker.All`parameter set was not serializing parameters properly, resulting in the value (a list of tracking codes) being lost in transit.

This PR introduces a fix in the query parameter construction process that will account for arrays. Specifically, the following list of tracking codes "001", "002", "003" will result in the following URL + query string being sent to the API: `https://api.easypost.com/v2/trackers?tracking_codes[]=001&tracking_codes[]=002&tracking_codes[]=003`. This is [the format expected by our backend](https://til.hashrocket.com/posts/syzssfozay-pass-array-of-values-as-query-string-in-rails-) for proper parsing.

Accomplishing this requires some string manipulation in the query building process, as this is not the typical way the built-in `System.Uri` in  .NET handles query arrays (typically would use comma-separated lists instead, producing `https://api.easypost.com/v2/trackers?tracking_codes=001,002,003`, which is incompatible with the API server).

`tracking_codes` is currently the only query-based parameter (GET/DELETE request) that is an array, so this issue did not arise until it was recently introduced.

# Testing

- New unit test to confirm serialization
- No existing cassettes needed to be re-recorded, suggesting change does not impact other serialization flows

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
