### PR TITLE
[bug] Add missing claims parameters, fix interdependency parameter enforcement

### DIFF
--- a/EasyPost.Tests/Fixture.cs
+++ b/EasyPost.Tests/Fixture.cs
@@ -298,6 +298,7 @@ namespace EasyPost.Tests._Utilities
                         ContactEmail = fixture.GetOrNull<string>("contact_email"),
                         PaymentMethod = fixture.GetOrNullEnum<ClaimPaymentMethod>("payment_method"),
                         RecipientName = fixture.GetOrNull<string>("recipient_name"),
+                        CheckDeliveryAddress = fixture.GetOrNull<string>("check_delivery_address"),
                     };
                 }
 

--- a/EasyPost.Tests/ParametersTests/ParametersTest.cs
+++ b/EasyPost.Tests/ParametersTests/ParametersTest.cs
@@ -592,7 +592,8 @@ namespace EasyPost.Tests.ParametersTests
             try
             {
                 parameters.ToDictionary();
-            } catch (Exceptions.General.InvalidParameterPairError)
+            }
+            catch (Exceptions.General.InvalidParameterPairError)
             {
                 Assert.Fail("Should not throw exception if both Param1 and Param2 are set correctly.");
             }
@@ -616,7 +617,8 @@ namespace EasyPost.Tests.ParametersTests
             try
             {
                 parameters.ToDictionary();
-            } catch (Exceptions.General.InvalidParameterPairError)
+            }
+            catch (Exceptions.General.InvalidParameterPairError)
             {
                 Assert.Fail("Should not throw exception if Param1 is not set to a value that enforces a restriction on Param2.");
             }

--- a/EasyPost/Models/API/ClaimPaymentMethod.cs
+++ b/EasyPost/Models/API/ClaimPaymentMethod.cs
@@ -18,6 +18,12 @@ public class ClaimPaymentMethod : ValueEnum
     public static readonly ClaimPaymentMethod EasyPostWallet = new(2, "easypost_wallet");
 
     /// <summary>
+    ///     An enum representing paying a claim reimbursement via a bank transfer.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public static readonly ClaimPaymentMethod ACH = new(3, "ach");
+
+    /// <summary>
     ///     Initializes a new instance of the <see cref="ClaimPaymentMethod"/> class.
     /// </summary>
     /// <param name="id">The internal ID of this enum.</param>

--- a/EasyPost/Parameters/Claim/Create.cs
+++ b/EasyPost/Parameters/Claim/Create.cs
@@ -71,10 +71,17 @@ namespace EasyPost.Parameters.Claim
         public string? ContactEmail { get; set; }
 
         /// <summary>
-        ///     The <see cref="ClaimPaymentMethod"/> for the claim reimbursement.
+        ///     The <see cref="ClaimPaymentMethod"/> for the claim reimbursement. If set to <see cref="ClaimPaymentMethod.MailedCheck"/>, the <see cref="CheckDeliveryAddress"/> must be provided.
         /// </summary>
         [TopLevelRequestParameter(Necessity.Optional, "payment_method")]
+        [TopLevelRequestParameterDependents(IndependentStatus.IfValue, "mailed_check", DependentStatus.MustBeSet, "CheckDeliveryAddress")]
         public ClaimPaymentMethod? PaymentMethod { get; set; }
+
+        /// <summary>
+        ///     The destination address for a reimbursement check. Required if the <see cref="PaymentMethod"/> is <see cref="ClaimPaymentMethod.MailedCheck"/>.
+        /// </summary>
+        [TopLevelRequestParameter(Necessity.Optional, "check_delivery_address")]
+        public string? CheckDeliveryAddress { get; set; }
 
         #endregion
     }

--- a/EasyPost/Utilities/Cryptography.cs
+++ b/EasyPost/Utilities/Cryptography.cs
@@ -46,6 +46,7 @@ namespace EasyPost.Utilities
         /// </summary>
         /// <param name="bytes">Byte array to convert to hex string.</param>
         /// <returns>Hex string equivalent of input byte array.</returns>
+#pragma warning disable CA1859 // Use byte[] instead of IReadOnlyList<byte>
         private static string AsHexString(this IReadOnlyList<byte> bytes)
         {
             // Fastest safe way to convert a byte array to hex string,
@@ -61,6 +62,7 @@ namespace EasyPost.Utilities
 
             return new string(result).ToLowerInvariant();
         }
+#pragma warning restore CA1859 // Use byte[] instead of IReadOnlyList<byte>
 
         /// <summary>
         ///     Convert a string to a hex string using a specific encoding.

--- a/EasyPost/Utilities/Internal/Attributes/RequestParameterAttribute.cs
+++ b/EasyPost/Utilities/Internal/Attributes/RequestParameterAttribute.cs
@@ -150,9 +150,9 @@ namespace EasyPost.Utilities.Internal.Attributes
         ///     Initializes a new instance of the <see cref="RequestParameterDependentsAttribute"/> class.
         /// </summary>
         /// <param name="independentStatus">The set status of the independent property.</param>
-        /// <param name="independentValue">The value of the independent property.</param>
+        /// <param name="independentValue">The value of the independent property. If enforcing a custom <see cref="ValueEnum"/>, provide the underlying value.</param>
         /// <param name="dependentStatus">The set status of the dependent properties.</param>
-        /// <param name="dependentValue">The value of the dependent properties.</param>
+        /// <param name="dependentValue">The value of the dependent properties. If enforcing a custom <see cref="ValueEnum"/>, provide the underlying value.</param>
         /// <param name="dependentProperties">The names of the dependent properties.</param>
         protected RequestParameterDependentsAttribute(IndependentStatus independentStatus, object independentValue, DependentStatus dependentStatus, object dependentValue, params string[] dependentProperties)
         {
@@ -168,7 +168,7 @@ namespace EasyPost.Utilities.Internal.Attributes
         /// </summary>
         /// <param name="independentStatus">The set status of the independent property.</param>
         /// <param name="dependentStatus">The set status of the dependent properties.</param>
-        /// <param name="dependentValue">The value of the dependent properties.</param>
+        /// <param name="dependentValue">The value of the dependent properties. If enforcing a custom <see cref="ValueEnum"/>, provide the underlying value.</param>
         /// <param name="dependentProperties">The names of the dependent properties.</param>
         protected RequestParameterDependentsAttribute(IndependentStatus independentStatus, DependentStatus dependentStatus, object dependentValue, params string[] dependentProperties)
         {
@@ -182,7 +182,7 @@ namespace EasyPost.Utilities.Internal.Attributes
         ///     Initializes a new instance of the <see cref="RequestParameterDependentsAttribute"/> class.
         /// </summary>
         /// <param name="independentStatus">The set status of the independent property.</param>
-        /// <param name="independentValue">The value of the independent property.</param>
+        /// <param name="independentValue">The value of the independent property. If enforcing a custom <see cref="ValueEnum"/>, provide the underlying value.</param>
         /// <param name="dependentStatus">The set status of the dependent properties.</param>
         /// <param name="dependentProperties">The names of the dependent properties.</param>
         protected RequestParameterDependentsAttribute(IndependentStatus independentStatus, object independentValue, DependentStatus dependentStatus, params string[] dependentProperties)
@@ -197,7 +197,7 @@ namespace EasyPost.Utilities.Internal.Attributes
         ///     Check that the expected value state of the property is met.
         /// </summary>
         /// <param name="propertyValue">Optional, the value of the independent property.</param>
-        /// <param name="dependentPropertyValue">The value of the dependent property.</param>
+        /// <param name="dependentPropertyValue">The value of the dependent property. Do not pass in <see cref="ValueEnum"/>; instead, pass in the underlying value.</param>
         /// <returns>True if the dependent property meets the dependency condition, false otherwise.</returns>
         private bool DependencyConditionPasses(object? propertyValue, object? dependentPropertyValue)
         {
@@ -228,10 +228,17 @@ namespace EasyPost.Utilities.Internal.Attributes
         ///     Check that all dependent properties are compliant with the dependency conditions.
         /// </summary>
         /// <param name="obj">The object containing the dependent properties.</param>
-        /// <param name="propertyValue">The value of the independent property.</param>
+        /// <param name="propertyValue">The value of the independent property. A <see cref="ValueEnum"/> will be converted to its underlying value.</param>
         /// <returns>A tuple containing a boolean indicating whether the dependency is met, and a string containing the name of the first dependent property that does not meet the dependency conditions.</returns>
         public Tuple<bool, string> DependentsAreCompliant(object obj, object? propertyValue)
         {
+            // Convert any value enums to their underlying values (this cannot work with non-value Enums, but those can't be passed to attributes, so it is safe to ignore)
+            if (propertyValue != null && Objects.IsValueEnum(propertyValue))
+            {
+                ValueEnum enumValue = (ValueEnum)propertyValue;
+                propertyValue = enumValue.Value;
+            }
+
             // No need to check dependent IfSet properties if the property is not set
             if (propertyValue == null && IndependentStatus == IndependentStatus.IfSet)
             {
@@ -304,9 +311,9 @@ namespace EasyPost.Utilities.Internal.Attributes
         ///     Initializes a new instance of the <see cref="TopLevelRequestParameterDependentsAttribute"/> class.
         /// </summary>
         /// <param name="independentStatus">The set status of the independent property.</param>
-        /// <param name="independentValue">The value of the independent property.</param>
+        /// <param name="independentValue">The value of the independent property. If enforcing a custom <see cref="ValueEnum"/>, provide the underlying value.</param>
         /// <param name="dependentStatus">The set status of the dependent properties.</param>
-        /// <param name="dependentValue">The value of the dependent properties.</param>
+        /// <param name="dependentValue">The value of the dependent properties. If enforcing a custom <see cref="ValueEnum"/>, provide the underlying value.</param>
         /// <param name="dependentProperties">The names of the dependent properties.</param>
         public TopLevelRequestParameterDependentsAttribute(IndependentStatus independentStatus, object independentValue, DependentStatus dependentStatus, object dependentValue, params string[] dependentProperties)
             : base(independentStatus, independentValue, dependentStatus, dependentValue, dependentProperties)
@@ -318,7 +325,7 @@ namespace EasyPost.Utilities.Internal.Attributes
         /// </summary>
         /// <param name="independentStatus">The set status of the independent property.</param>
         /// <param name="dependentStatus">The set status of the dependent properties.</param>
-        /// <param name="dependentValue">The value of the dependent properties.</param>
+        /// <param name="dependentValue">The value of the dependent properties. If enforcing a custom <see cref="ValueEnum"/>, provide the underlying value.</param>
         /// <param name="dependentProperties">The names of the dependent properties.</param>
         public TopLevelRequestParameterDependentsAttribute(IndependentStatus independentStatus, DependentStatus dependentStatus, object dependentValue, params string[] dependentProperties)
             : base(independentStatus, dependentStatus, dependentValue, dependentProperties)
@@ -329,7 +336,7 @@ namespace EasyPost.Utilities.Internal.Attributes
         ///     Initializes a new instance of the <see cref="TopLevelRequestParameterDependentsAttribute"/> class.
         /// </summary>
         /// <param name="independentStatus">The set status of the independent property.</param>
-        /// <param name="independentValue">The value of the independent property.</param>
+        /// <param name="independentValue">The value of the independent property. If enforcing a custom <see cref="ValueEnum"/>, provide the underlying value.</param>
         /// <param name="dependentStatus">The set status of the dependent properties.</param>
         /// <param name="dependentProperties">The names of the dependent properties.</param>
         public TopLevelRequestParameterDependentsAttribute(IndependentStatus independentStatus, object independentValue, DependentStatus dependentStatus, params string[] dependentProperties)
@@ -392,9 +399,9 @@ namespace EasyPost.Utilities.Internal.Attributes
         ///     Initializes a new instance of the <see cref="NestedRequestParameterDependentsAttribute"/> class.
         /// </summary>
         /// <param name="independentStatus">The set status of the independent property.</param>
-        /// <param name="independentValue">The value of the independent property.</param>
+        /// <param name="independentValue">The value of the independent property. If enforcing a custom <see cref="ValueEnum"/>, provide the underlying value.</param>
         /// <param name="dependentStatus">The set status of the dependent properties.</param>
-        /// <param name="dependentValue">The value of the dependent properties.</param>
+        /// <param name="dependentValue">The value of the dependent properties. If enforcing a custom <see cref="ValueEnum"/>, provide the underlying value.</param>
         /// <param name="dependentProperties">The names of the dependent properties.</param>
         public NestedRequestParameterDependentsAttribute(IndependentStatus independentStatus, object independentValue, DependentStatus dependentStatus, object dependentValue, params string[] dependentProperties)
             : base(independentStatus, independentValue, dependentStatus, dependentValue, dependentProperties)
@@ -406,7 +413,7 @@ namespace EasyPost.Utilities.Internal.Attributes
         /// </summary>
         /// <param name="independentStatus">The set status of the independent property.</param>
         /// <param name="dependentStatus">The set status of the dependent properties.</param>
-        /// <param name="dependentValue">The value of the dependent properties.</param>
+        /// <param name="dependentValue">The value of the dependent properties. If enforcing a custom <see cref="ValueEnum"/>, provide the underlying value.</param>
         /// <param name="dependentProperties">The names of the dependent properties.</param>
         public NestedRequestParameterDependentsAttribute(IndependentStatus independentStatus, DependentStatus dependentStatus, object dependentValue, params string[] dependentProperties)
             : base(independentStatus, dependentStatus, dependentValue, dependentProperties)
@@ -417,7 +424,7 @@ namespace EasyPost.Utilities.Internal.Attributes
         ///     Initializes a new instance of the <see cref="NestedRequestParameterDependentsAttribute"/> class.
         /// </summary>
         /// <param name="independentStatus">The set status of the independent property.</param>
-        /// <param name="independentValue">The value of the independent property.</param>
+        /// <param name="independentValue">The value of the independent property. If enforcing a custom <see cref="ValueEnum"/>, provide the underlying value.</param>
         /// <param name="dependentStatus">The set status of the dependent properties.</param>
         /// <param name="dependentProperties">The names of the dependent properties.</param>
         public NestedRequestParameterDependentsAttribute(IndependentStatus independentStatus, object independentValue, DependentStatus dependentStatus, params string[] dependentProperties)

--- a/EasyPost/Utilities/Internal/Enum.cs
+++ b/EasyPost/Utilities/Internal/Enum.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/EasyPost/Utilities/Internal/Enum.cs
+++ b/EasyPost/Utilities/Internal/Enum.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -109,11 +110,11 @@ namespace EasyPost.Utilities.Internal
         public static IEnumerable<T> GetAll<T>()
             where T : IEnum
             =>
-            typeof(T).GetFields(BindingFlags.Public |
-                                BindingFlags.Static |
-                                BindingFlags.DeclaredOnly)
-                .Select(f => f.GetValue(null))
-                .Cast<T>();
+                typeof(T).GetFields(BindingFlags.Public |
+                                    BindingFlags.Static |
+                                    BindingFlags.DeclaredOnly)
+                    .Select(f => f.GetValue(null))
+                    .Cast<T>();
 
         /// <summary>
         ///     Compare two objects.

--- a/EasyPost/Utilities/Internal/Objects.cs
+++ b/EasyPost/Utilities/Internal/Objects.cs
@@ -32,5 +32,25 @@ namespace EasyPost.Utilities.Internal
         {
             return obj is string or ValueType or null;
         }
+
+        /// <summary>
+        ///    Check if an object is an <see cref="Enum"/> or derived from <see cref="Enum"/>.
+        /// </summary>
+        /// <param name="obj">The object to evaluate.</param>
+        /// <returns><c>true</c> if the object is an <see cref="Enum"/> or derived from <see cref="Enum"/>, <c>false</c> otherwise.</returns>
+        public static bool IsEnum(object? obj)
+        {
+            return obj is Enum;
+        }
+
+        /// <summary>
+        ///     Check if an object is a <see cref="ValueEnum"/> or derived from <see cref="ValueEnum"/>.
+        /// </summary>
+        /// <param name="obj">The object to evaluate.</param>
+        /// <returns><c>true</c> if the object is a <see cref="ValueEnum"/> or derived from <see cref="ValueEnum"/>, <c>false</c> otherwise.</returns>
+        public static bool IsValueEnum(object? obj)
+        {
+            return obj is ValueEnum;
+        }
     }
 }


### PR DESCRIPTION
# Description

- Add missing `ACH` payment method type for claims
- Add missing `CheckDeliveryAddress` parameter for creating a claim
  - Require `CheckDeliveryAddress` if `PaymentMethod` is `MailedCheck`
  - Account for enums when enforcing interdependence of parameters*

*An unfortunate side effect of the custom enum classes used throughout the project, these cannot be passed into an attribute because they are not available at compile-time (unlike traditional enums). Instead, the attribute is provided the underlying primitive (string, float, int, etc.) value that is expected, and a pre-comparison check will convert any custom enum to its own underlying value, ensuring that the underlying primitive values are what is being compared in the interdependency check.

# Testing

- Added unit test to confirm interdependency enforcement works as expected with enum parameters

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
