### PR TITLE
feat: add additional webhook params

### DIFF
--- a/EasyPost.Integration/TestUtils.cs
+++ b/EasyPost.Integration/TestUtils.cs
@@ -116,7 +116,7 @@ namespace EasyPost.Integration.Utilities
                     Censors = censors,
                     SimulateDelay = false,
                     ManualDelay = 0,
-                    ValidTimeFrame = TimeFrame.Months6,
+                    ValidTimeFrame = TimeFrame.Months12,
                     WhenExpired = ExpirationActions.Warn
                 };
                 _vcr = new EasyVCR.VCR(advancedSettings);
@@ -151,7 +151,7 @@ namespace EasyPost.Integration.Utilities
                 // set up cassette
                 Cassette cassette = new(_testCassettesFolder, cassetteName, new CassetteOrder.Alphabetical());
 
-                // add cassette to vcr  
+                // add cassette to vcr
                 _vcr.Insert(cassette);
 
                 string filePath = Path.Combine(_testCassettesFolder, cassetteName + ".json");

--- a/EasyPost.Tests/Fixture.cs
+++ b/EasyPost.Tests/Fixture.cs
@@ -42,6 +42,9 @@ namespace EasyPost.Tests._Utilities
 
         internal static string WebhookUrl => GetFixtureStructure().WebhookUrl;
 
+        // TODO: Add WebhookCustomHeaders
+        // TODO: Pull in updated examples submodule, update all above references to webhook fixture data
+
         internal static Dictionary<string, object> BasicCarrierAccount => GetFixtureStructure().CarrierAccounts.Basic;
 
         internal static Dictionary<string, object> BasicCustomsInfo => GetFixtureStructure().CustomsInfos.Basic;

--- a/EasyPost.Tests/ServicesTests/WebhookServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/WebhookServiceTest.cs
@@ -42,6 +42,7 @@ namespace EasyPost.Tests.ServicesTests
 
             string url = $"https://example.com/create/{TestUtils.NetVersion}";
 
+            // TODO: Add webhook_secret and custom_headers params
             Webhook webhook = await Client.Webhook.Create(new Dictionary<string, object> { { "url", url } });
             CleanUpAfterTest(webhook.Id);
 
@@ -162,6 +163,7 @@ namespace EasyPost.Tests.ServicesTests
                 Thread.Sleep(10000); // Wait enough time to process
             }
 
+            // TODO: Add webhook_secret and custom_headers params
             webhook = await Client.Webhook.Update(webhook.Id, new Dictionary<string, object>());
 
             Assert.IsType<Webhook>(webhook);

--- a/EasyPost.Tests/TestUtils.cs
+++ b/EasyPost.Tests/TestUtils.cs
@@ -127,7 +127,7 @@ namespace EasyPost.Tests._Utilities
                     Censors = censors,
                     SimulateDelay = false,
                     ManualDelay = 0,
-                    ValidTimeFrame = TimeFrame.Months6,
+                    ValidTimeFrame = TimeFrame.Months12,
                     WhenExpired = ExpirationActions.Warn
                 };
                 _vcr = new EasyVCR.VCR(advancedSettings);
@@ -191,81 +191,81 @@ namespace EasyPost.Tests._Utilities
         {
             internal Method Method { get; set; } = method;
 
-        internal string ResourceRegex { get; set; } = resourceRegex;
-    }
+            internal string ResourceRegex { get; set; } = resourceRegex;
+        }
 
-    public class MockRequestResponseInfo(HttpStatusCode statusCode, string? content = null, object? data = null)
+        public class MockRequestResponseInfo(HttpStatusCode statusCode, string? content = null, object? data = null)
         {
             internal HttpStatusCode StatusCode { get; set; } = statusCode;
 
-    internal string? Content { get; set; } = content ?? JsonSerialization.ConvertObjectToJson(data);
-}
+            internal string? Content { get; set; } = content ?? JsonSerialization.ConvertObjectToJson(data);
+        }
 
-public class MockRequest
-{
-    public MockRequestMatchRules MatchRules { get; }
+        public class MockRequest
+        {
+            public MockRequestMatchRules MatchRules { get; }
 
-    public MockRequestResponseInfo ResponseInfo { get; }
+            public MockRequestResponseInfo ResponseInfo { get; }
 
-    internal MockRequest(MockRequestMatchRules matchRules, MockRequestResponseInfo responseInfo)
-    {
-        MatchRules = matchRules;
-        ResponseInfo = responseInfo;
-    }
-}
+            internal MockRequest(MockRequestMatchRules matchRules, MockRequestResponseInfo responseInfo)
+            {
+                MatchRules = matchRules;
+                ResponseInfo = responseInfo;
+            }
+        }
 
-internal sealed class MockClient : Client
-{
-    private readonly List<MockRequest> _mockRequests = new();
+        internal sealed class MockClient : Client
+        {
+            private readonly List<MockRequest> _mockRequests = new();
 
 #pragma warning disable CS1998
-    public override async Task<HttpResponseMessage> ExecuteRequest(HttpRequestMessage request, CancellationToken cancellationToken)
+            public override async Task<HttpResponseMessage> ExecuteRequest(HttpRequestMessage request, CancellationToken cancellationToken)
 #pragma warning restore CS1998
-    {
-        MockRequest? mockRequest = FindMatchingMockRequest(request);
+            {
+                MockRequest? mockRequest = FindMatchingMockRequest(request);
 
-        if (mockRequest == null)
-        {
+                if (mockRequest == null)
+                {
 #pragma warning disable CA2201
-            throw new Exception("No matching mock request found");
+                    throw new Exception("No matching mock request found");
 #pragma warning restore CA2201
+                }
+
+                return new HttpResponseMessage
+                {
+                    Content = new StringContent(mockRequest.ResponseInfo.Content),
+                    StatusCode = mockRequest.ResponseInfo.StatusCode,
+                };
+            }
+
+            internal MockClient(EasyPostClient client) : base(new ClientConfiguration(client.ApiKeyInUse)
+            {
+                ApiBase = client.ApiBaseInUse,
+                CustomHttpClient = client.CustomHttpClient,
+            })
+            {
+            }
+
+            internal void AddMockRequest(MockRequest mockRequest) => _mockRequests.Add(mockRequest);
+
+            internal void AddMockRequests(IEnumerable<MockRequest> mockRequests) => _mockRequests.AddRange(mockRequests);
+
+            private MockRequest? FindMatchingMockRequest(HttpRequestMessage request) => _mockRequests.FirstOrDefault(mock => mock.MatchRules.Method.HttpMethod == request.Method && EndpointMatches(request.RequestUri.AbsoluteUri, mock.MatchRules.ResourceRegex));
+
+            private static bool EndpointMatches(string endpoint, string pattern)
+            {
+                try
+                {
+                    return Regex.IsMatch(endpoint,
+                        pattern,
+                        RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase | RegexOptions.Singleline,
+                        TimeSpan.FromMilliseconds(250));
+                }
+                catch (RegexMatchTimeoutException)
+                {
+                    return false;
+                }
+            }
         }
-
-        return new HttpResponseMessage
-        {
-            Content = new StringContent(mockRequest.ResponseInfo.Content),
-            StatusCode = mockRequest.ResponseInfo.StatusCode,
-        };
-    }
-
-    internal MockClient(EasyPostClient client) : base(new ClientConfiguration(client.ApiKeyInUse)
-    {
-        ApiBase = client.ApiBaseInUse,
-        CustomHttpClient = client.CustomHttpClient,
-    })
-    {
-    }
-
-    internal void AddMockRequest(MockRequest mockRequest) => _mockRequests.Add(mockRequest);
-
-    internal void AddMockRequests(IEnumerable<MockRequest> mockRequests) => _mockRequests.AddRange(mockRequests);
-
-    private MockRequest? FindMatchingMockRequest(HttpRequestMessage request) => _mockRequests.FirstOrDefault(mock => mock.MatchRules.Method.HttpMethod == request.Method && EndpointMatches(request.RequestUri.AbsoluteUri, mock.MatchRules.ResourceRegex));
-
-    private static bool EndpointMatches(string endpoint, string pattern)
-    {
-        try
-        {
-            return Regex.IsMatch(endpoint,
-                pattern,
-                RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase | RegexOptions.Singleline,
-                TimeSpan.FromMilliseconds(250));
-        }
-        catch (RegexMatchTimeoutException)
-        {
-            return false;
-        }
-    }
-}
     }
 }

--- a/EasyPost/Parameters/Webhook/Create.cs
+++ b/EasyPost/Parameters/Webhook/Create.cs
@@ -25,6 +25,8 @@ namespace EasyPost.Parameters.Webhook
         [TopLevelRequestParameter(Necessity.Required, "url")]
         public string? Url { get; set; }
 
+        // TODO: Add custom_headers
+
         #endregion
     }
 }

--- a/EasyPost/Parameters/Webhook/Update.cs
+++ b/EasyPost/Parameters/Webhook/Update.cs
@@ -19,6 +19,8 @@ namespace EasyPost.Parameters.Webhook
         [TopLevelRequestParameter(Necessity.Optional, "webhook_secret")]
         public string? Secret { get; set; }
 
+        // TODO: Add custom_headers
+
         #endregion
     }
 }

--- a/EasyPost/Services/WebhookService.cs
+++ b/EasyPost/Services/WebhookService.cs
@@ -99,6 +99,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Webhook> Update(string id, Dictionary<string, object>? parameters = null, CancellationToken cancellationToken = default)
         {
+            parameters = parameters?.Wrap("webhook");
             return await RequestAsync<Webhook>(Method.Put, $"webhooks/{id}", cancellationToken, parameters);
         }
 
@@ -113,6 +114,7 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Webhook> Update(string id, Parameters.Webhook.Update? parameters = null, CancellationToken cancellationToken = default)
         {
+            // TODO: Validate, do we need to wrap the params here too or is it implicitly done somehow?
             return await RequestAsync<Webhook>(Method.Put, $"webhooks/{id}", cancellationToken, parameters?.ToDictionary());
         }
 

--- a/EasyPost/Services/WebhookService.cs
+++ b/EasyPost/Services/WebhookService.cs
@@ -99,7 +99,6 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Webhook> Update(string id, Dictionary<string, object>? parameters = null, CancellationToken cancellationToken = default)
         {
-            parameters = parameters?.Wrap("webhook");
             return await RequestAsync<Webhook>(Method.Put, $"webhooks/{id}", cancellationToken, parameters);
         }
 
@@ -114,7 +113,6 @@ namespace EasyPost.Services
         [CrudOperations.Update]
         public async Task<Webhook> Update(string id, Parameters.Webhook.Update? parameters = null, CancellationToken cancellationToken = default)
         {
-            // TODO: Validate, do we need to wrap the params here too or is it implicitly done somehow?
             return await RequestAsync<Webhook>(Method.Put, $"webhooks/{id}", cancellationToken, parameters?.ToDictionary());
         }
 


### PR DESCRIPTION
# Description

To the next dev that picks this up, we need to:

1. Add the `custom_headers` to the create and update parameter sets
2. Ensure that the update webhook overload function that uses the param sets doesn't need to have the params wrapped for it to work as expected
3. Update create/update webhook tests to pass in the `webhook_secret` and `custom_headers` to ensure we pass them correctly

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
