### PR TITLE
fix: install proper dotnet version on CI for coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.x.x
+
       - name: Set up dotnet tools and dependencies
         run: make install
 


### PR DESCRIPTION
# Description

We were using the default dotnet 8 for coverage uploading; however, we needed dotnet 9 for the tool to work. This should correct uploading coverage on CI.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Won't know till we land and check master CI output.

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
