### PR TITLE
feat: add params to requestPin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v7.8.0 (2025-06-25)
+
+- Adds `params` to `requestPin` ensuring users can pass `easypost_details` to the call
+
 ## v7.7.3 (2026-04-28)
 
 - Corrects nesting of `report` create parameters in request allowing params like `columns` and `additional_columns` to take effect correctly (closes #658)

--- a/EasyPost.Tests/ServicesTests/WithParameters/FedExRegistrationServiceTest.cs
+++ b/EasyPost.Tests/ServicesTests/WithParameters/FedExRegistrationServiceTest.cs
@@ -102,7 +102,12 @@ namespace EasyPost.Tests.ServicesTests.WithParameters
         {
             UseMockClient();
 
-            FedExRequestPinResponse response = await Client.FedExRegistration.RequestPin("123456789", "SMS");
+            Parameters.FedExRegistration.RequestPin parameters = new Parameters.FedExRegistration.RequestPin
+            {
+                CarrierAccountId = "ca_123",
+            };
+
+            FedExRequestPinResponse response = await Client.FedExRegistration.RequestPin("123456789", "SMS", parameters);
 
             Assert.NotNull(response);
             Assert.NotNull(response.Message);

--- a/EasyPost.nuspec
+++ b/EasyPost.nuspec
@@ -3,7 +3,7 @@
     <metadata>
         <id>EasyPost-Official</id>
         <title>EasyPost (Official)</title>
-        <version>7.7.3</version>
+        <version>7.8.0</version>
         <authors>EasyPost</authors>
         <owners>EasyPost</owners>
         <projectUrl>https://www.easypost.com</projectUrl>

--- a/EasyPost/Parameters/FedExRegistration/RequestPin.cs
+++ b/EasyPost/Parameters/FedExRegistration/RequestPin.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics.CodeAnalysis;
+using EasyPost.Utilities.Internal.Attributes;
+
+namespace EasyPost.Parameters.FedExRegistration
+{
+    /// <summary>
+    ///     Parameters for <see cref="EasyPost.Services.FedExRegistrationService.RequestPin(string, string, RequestPin, System.Threading.CancellationToken)"/> API calls.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class RequestPin : BaseParameters<Models.API.FedExRequestPinResponse>, IFedExRegistrationParameter
+    {
+        #region Request Parameters
+
+        /// <summary>
+        ///     Action for the FedEx registration (create/update).
+        /// </summary>
+        [TopLevelRequestParameter(Necessity.Optional, "easypost_details", "action")]
+        public string? Action { get; set; }
+
+        /// <summary>
+        ///     Type of carrier account for the FedEx registration.
+        /// </summary>
+        [TopLevelRequestParameter(Necessity.Optional, "easypost_details", "type")]
+        public string? Type { get; set; }
+
+        /// <summary>
+        ///     Carrier account ID for the FedEx registration.
+        /// </summary>
+        [TopLevelRequestParameter(Necessity.Optional, "easypost_details", "carrier_account_id")]
+        public string? CarrierAccountId { get; set; }
+
+        #endregion
+    }
+}

--- a/EasyPost/Properties/VersionInfo.cs
+++ b/EasyPost/Properties/VersionInfo.cs
@@ -2,6 +2,6 @@
 
 // Version information for an assembly must follow semantic versioning
 // When releasing a release candidate, append a 4th digit being the number of the release candidate
-[assembly: AssemblyVersion("7.7.3")]
-[assembly: AssemblyFileVersion("7.7.3")]
-[assembly: AssemblyInformationalVersion("7.7.3")]
+[assembly: AssemblyVersion("7.8.0")]
+[assembly: AssemblyFileVersion("7.8.0")]
+[assembly: AssemblyInformationalVersion("7.8.0")]

--- a/EasyPost/Services/FedExRegistrationService.cs
+++ b/EasyPost/Services/FedExRegistrationService.cs
@@ -42,18 +42,15 @@ namespace EasyPost.Services
         /// </summary>
         /// <param name="fedexAccountNumber">The FedEx account number.</param>
         /// <param name="pinMethodOption">The PIN delivery method: "SMS", "CALL", or "EMAIL".</param>
+        /// <param name="parameters"><see cref="Parameters.FedExRegistration.RequestPin"/> parameter set.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> to use for the HTTP request.</param>
         /// <returns><see cref="FedExRequestPinResponse"/> object confirming PIN was sent.</returns>
-        public async Task<FedExRequestPinResponse> RequestPin(string fedexAccountNumber, string pinMethodOption, CancellationToken cancellationToken = default)
+        public async Task<FedExRequestPinResponse> RequestPin(string fedexAccountNumber, string pinMethodOption, Parameters.FedExRegistration.RequestPin parameters, CancellationToken cancellationToken = default)
         {
-            Dictionary<string, object> wrappedParams = new Dictionary<string, object>
+            Dictionary<string, object> wrappedParams = parameters.ToDictionary();
+            wrappedParams["pin_method"] = new Dictionary<string, object>
             {
-                {
-                    "pin_method", new Dictionary<string, object>
-                    {
-                        { "option", pinMethodOption },
-                    }
-                },
+                { "option", pinMethodOption },
             };
             string endpoint = $"fedex_registrations/{fedexAccountNumber}/pin";
 


### PR DESCRIPTION
# Description

Adds `params` to `requestPin` ensuring users can pass `easypost_details` to the call.

<!-- Please provide a general summary of your PR changes and link any related issues or other pull requests. -->

# Testing

Updated test to accept new param.

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
